### PR TITLE
Remove unused require

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -1,7 +1,6 @@
 require 'jsonapi/configuration'
 require 'jsonapi/resource_for'
 require 'jsonapi/association'
-require 'action_dispatch/routing/mapper'
 
 module JSONAPI
   class Resource


### PR DESCRIPTION
Removes unused `require 'action_dispatch/routing/mapper'`

We are trying to use jsonapi-resources in a non-rails environment and found this along the way. Seems to work just as before.
