### PR TITLE
Context rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ end
 
 This resource has 5 attributes: `:id`, `:name_first`, `:name_last`, `:email`, `:twitter`. By default these attributes must exist on the model that is handled by the resource.
 
-A resource object wraps a Ruby model, usually an ActiveModel record, which is available as the `@model` variable. This allows a resource's methods to access the underlying model.
+A resource object wraps a Ruby object, usually an ActiveModel record, which is available as the `@model` variable. This allows a resource's methods to access the underlying model.
 
 For example, a computed attribute for `full_name` could be defined as such:
 

--- a/README.md
+++ b/README.md
@@ -458,7 +458,7 @@ JR by default uses some simple rules to format an attribute for serialization. S
 
 If you want to change the way an attribute is serialized you have a couple of ways. The simplest method is to create a getter method on the resource which overrides the attribute and apply the formatting there. For example:
 
-```
+```ruby
 class PersonResource < JSONAPI::Resource
   attributes :id, :name, :email
   attribute :last_login_time
@@ -475,7 +475,7 @@ This is simple to implement for a one off situation, but not for example if you 
 
 To overcome the above limitations JR uses Value Formatters. Value Formatters allow you to control the way values are handled for an attribute. The `format` can be set per attribute as it is declared in the resource. For example:
 
-```
+```ruby
 class PersonResource < JSONAPI::Resource
   attributes :id, :name, :email
   attribute :last_login_time, format: :date_with_timezone
@@ -484,7 +484,7 @@ end
 
 A Value formatter has a `format` and an `unformat` method. Here's the base ValueFormatter and DefaultValueFormatter for reference:
 
-```
+```ruby
 module JSONAPI
   class ValueFormatter < Formatter
     class << self
@@ -524,7 +524,7 @@ The `unformat` method is called when processing the request. Each incoming attri
 
 Another way to handle formatting is to set a different default value formatter. This will affect all attributes that do notw have a `format` set. You can do this by overriding the `default_attribute_options` method for a resource (or a base resource for a system wide change).
 
-```
+```ruby
   def default_attribute_options
     {format: :my_default}
   end
@@ -532,7 +532,7 @@ Another way to handle formatting is to set a different default value formatter. 
 
 and
 
-```
+```ruby
 class MyDefaultValueFormatter < JSONAPI::ValueFormatter
   class << self
     def format(raw_value, context)
@@ -566,7 +566,7 @@ end
 
 This will cause the serializer to use the CamelizedKeyFormatter. Besides UnderscoredKeyFormatter and CamelizedKeyFormatter JR defines the DasherizedKeyFormatter. You can also create your own KeyFormatter, for example:
 
-```
+```ruby
 class UpperCamelizedKeyFormatter < JSONAPI::KeyFormatter
   class << self
     def format(key)

--- a/lib/jsonapi/formatter.rb
+++ b/lib/jsonapi/formatter.rb
@@ -37,11 +37,11 @@ module JSONAPI
 
   class ValueFormatter < Formatter
     class << self
-      def format(raw_value, source, context)
+      def format(raw_value, context)
         super(raw_value)
       end
 
-      def unformat(value, resource_klass, context)
+      def unformat(value, context)
         super(value)
       end
 
@@ -82,7 +82,7 @@ end
 
 class DefaultValueFormatter < JSONAPI::ValueFormatter
   class << self
-    def format(raw_value, source, context)
+    def format(raw_value, context)
       case raw_value
         when String, Integer
           return raw_value

--- a/lib/jsonapi/operation.rb
+++ b/lib/jsonapi/operation.rb
@@ -20,9 +20,9 @@ module JSONAPI
     end
 
     def apply(context)
-      resource = @resource_klass.new
-      resource.replace_fields(@values, context)
-      resource.save(context)
+      resource = @resource_klass.create(context)
+      resource.replace_fields(@values)
+      resource.save
 
       return JSONAPI::OperationResult.new(:created, resource)
 
@@ -40,7 +40,7 @@ module JSONAPI
 
     def apply(context)
       resource = @resource_klass.find_by_key(@resource_id, context)
-      resource.remove(context)
+      resource.remove
 
       return JSONAPI::OperationResult.new(:no_content)
 
@@ -63,8 +63,8 @@ module JSONAPI
 
     def apply(context)
       resource = @resource_klass.find_by_key(@resource_id, context)
-      resource.replace_fields(values, context)
-      resource.save(context)
+      resource.replace_fields(values)
+      resource.save
 
       return JSONAPI::OperationResult.new(:ok, resource)
     end
@@ -82,8 +82,8 @@ module JSONAPI
 
     def apply(context)
       resource = @resource_klass.find_by_key(@resource_id, context)
-      resource.create_has_one_link(@association_type, @key_value, context)
-      resource.save(context)
+      resource.create_has_one_link(@association_type, @key_value)
+      resource.save
 
       return JSONAPI::OperationResult.new(:no_content)
     end
@@ -101,8 +101,8 @@ module JSONAPI
 
     def apply(context)
       resource = @resource_klass.find_by_key(@resource_id, context)
-      resource.replace_has_one_link(@association_type, @key_value, context)
-      resource.save(context)
+      resource.replace_has_one_link(@association_type, @key_value)
+      resource.save
 
       return JSONAPI::OperationResult.new(:no_content)
     end
@@ -121,7 +121,7 @@ module JSONAPI
     def apply(context)
       resource = @resource_klass.find_by_key(@resource_id, context)
       @key_values.each do |value|
-        resource.create_has_many_link(@association_type, value, context)
+        resource.create_has_many_link(@association_type, value)
       end
 
       return JSONAPI::OperationResult.new(:no_content)
@@ -140,8 +140,8 @@ module JSONAPI
 
     def apply(context)
       resource = @resource_klass.find_by_key(@resource_id, context)
-      resource.replace_has_many_links(@association_type, @key_values, context)
-      resource.save(context)
+      resource.replace_has_many_links(@association_type, @key_values)
+      resource.save
 
       return JSONAPI::OperationResult.new(:no_content)
     end
@@ -159,7 +159,7 @@ module JSONAPI
 
     def apply(context)
       resource = @resource_klass.find_by_key(@resource_id, context)
-      resource.remove_has_many_link(@association_type, @associated_key, context)
+      resource.remove_has_many_link(@association_type, @associated_key)
 
       return JSONAPI::OperationResult.new(:no_content)
 
@@ -179,8 +179,8 @@ module JSONAPI
 
     def apply(context)
       resource = @resource_klass.find_by_key(@resource_id, context)
-      resource.remove_has_one_link(@association_type, context)
-      resource.save(context)
+      resource.remove_has_one_link(@association_type)
+      resource.save
 
       return JSONAPI::OperationResult.new(:no_content)
     end

--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -182,15 +182,15 @@ module JSONAPI
         association = @resource_klass._association(param)
 
         if association.is_a?(JSONAPI::Association::HasOne)
-          checked_has_one_associations[param] = @resource_klass.resource_for(association.type).verify_key(value, context)
+          checked_has_one_associations[param] = @resource_klass.resource_for(association.type).verify_key(value, @context)
         elsif association.is_a?(JSONAPI::Association::HasMany)
           keys = []
           if value.is_a?(Array)
             value.each do |val|
-              keys.push(@resource_klass.resource_for(association.type).verify_key(val, context))
+              keys.push(@resource_klass.resource_for(association.type).verify_key(val, @context))
             end
           else
-            keys.push(@resource_klass.resource_for(association.type).verify_key(value, context))
+            keys.push(@resource_klass.resource_for(association.type).verify_key(value, @context))
           end
           checked_has_many_associations[param] = keys
         else
@@ -368,7 +368,7 @@ module JSONAPI
     def parse_key_array(raw)
       keys = []
       raw.split(/,/).collect do |key|
-        keys.push @resource_klass.verify_key(key, context)
+        keys.push @resource_klass.verify_key(key, @context)
       end
       return keys
     end

--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -207,7 +207,7 @@ module JSONAPI
 
     def unformat_value(attribute, value)
       value_formatter = JSONAPI::ValueFormatter.value_formatter_for(@resource_klass._attribute_options(attribute)[:format])
-      value_formatter.unformat(value, @resource_klass, context)
+      value_formatter.unformat(value, @context)
     end
 
     def verify_permitted_params(params, allowed_fields)

--- a/lib/jsonapi/resource_controller.rb
+++ b/lib/jsonapi/resource_controller.rb
@@ -13,24 +13,23 @@ module JSONAPI
   class ResourceController < ActionController::Base
     include ResourceFor
 
-    before_filter {
-      begin
-        @request = JSONAPI::Request.new(params, {
-          context: context,
-          key_formatter: key_formatter
-        })
-        render_errors(@request.errors) unless @request.errors.empty?
-      rescue => e
-        handle_exceptions(e)
-      end
-    }
+    before_filter :setup_request
+
+    def setup_request
+      @request = JSONAPI::Request.new(params, {
+        context: context,
+        key_formatter: key_formatter
+      })
+      render_errors(@request.errors) unless @request.errors.empty?
+    rescue => e
+      handle_exceptions(e)
+    end
 
     def index
       render json: JSONAPI::ResourceSerializer.new.serialize_to_hash(
           resource_klass.find(resource_klass.verify_filters(@request.filters, context), context),
           include: @request.include,
           fields: @request.fields,
-          context: context,
           attribute_formatters: attribute_formatters,
           key_formatter: key_formatter)
     rescue => e
@@ -53,7 +52,6 @@ module JSONAPI
           resources,
           include: @request.include,
           fields: @request.fields,
-          context: context,
           attribute_formatters: attribute_formatters,
           key_formatter: key_formatter)
     rescue => e
@@ -172,7 +170,6 @@ module JSONAPI
                  json: JSONAPI::ResourceSerializer.new.serialize_to_hash(resources.length > 1 ? resources : resources[0],
                                                                          include: @request.include,
                                                                          fields: @request.fields,
-                                                                         context: context,
                                                                          attribute_formatters: attribute_formatters,
                                                                          key_formatter: key_formatter)
         else

--- a/lib/jsonapi/resource_controller.rb
+++ b/lib/jsonapi/resource_controller.rb
@@ -15,16 +15,6 @@ module JSONAPI
 
     before_filter :setup_request
 
-    def setup_request
-      @request = JSONAPI::Request.new(params, {
-        context: context,
-        key_formatter: key_formatter
-      })
-      render_errors(@request.errors) unless @request.errors.empty?
-    rescue => e
-      handle_exceptions(e)
-    end
-
     def index
       render json: JSONAPI::ResourceSerializer.new.serialize_to_hash(
           resource_klass.find(resource_klass.verify_filters(@request.filters, context), context),
@@ -113,6 +103,16 @@ module JSONAPI
 
     def resource_klass_name
       @resource_klass_name ||= "#{self.class.name.demodulize.sub(/Controller$/, '').singularize}Resource"
+    end
+
+    def setup_request
+      @request = JSONAPI::Request.new(params, {
+        context: context,
+        key_formatter: key_formatter
+      })
+      render_errors(@request.errors) unless @request.errors.empty?
+    rescue => e
+      handle_exceptions(e)
     end
 
     def parse_key_array(raw)

--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -229,9 +229,9 @@ module JSONAPI
       @key_formatter.format(key)
     end
 
-    def format_value(value, format, source, context)
+    def format_value(value, format, source)
       value_formatter = JSONAPI::ValueFormatter.value_formatter_for(format)
-      value_formatter.format(value, source, context)
+      value_formatter.format(value, source)
     end
   end
 end

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -288,7 +288,7 @@ class PersonResource < JSONAPI::Resource
 
   filter :name
 
-  def self.verify_custom_filter(filter, values, context = nil)
+  def self.verify_custom_filter(filter, values, context)
     case filter
       when :name
         values.each do |value|
@@ -308,22 +308,22 @@ class AuthorResource < JSONAPI::Resource
 
   filter :name
 
-  def self.find(filters, context = nil)
+  def self.find(filters, context)
     resources = []
 
     filters.each do |attr, filter|
-      _model_class.where("\"#{attr}\" LIKE \"%#{filter[0]}%\"").each do |object|
-        resources.push self.new(object)
+      _model_class.where("\"#{attr}\" LIKE \"%#{filter[0]}%\"").each do |model|
+        resources.push self.new(model, context)
       end
     end
     return resources
   end
 
-  def fetchable_fields(context)
-    if (@object.id % 2) == 1
-      super(context) - [:email]
+  def fetchable_fields
+    if (@model.id % 2) == 1
+      super - [:email]
     else
-      super(context)
+      super
     end
   end
 end
@@ -358,7 +358,7 @@ class PostResource < JSONAPI::Resource
   has_many :tags, acts_as_set: true
   has_many :comments, acts_as_set: false
   def subject
-    @object.title
+    @model.title
   end
 
   filters :title, :author, :tags, :comments
@@ -392,7 +392,7 @@ class PostResource < JSONAPI::Resource
 
   def self.verify_key(key, context = nil)
     raise JSONAPI::Exceptions::InvalidFieldValue.new(:id, key) unless is_num?(key)
-    raise JSONAPI::Exceptions::RecordNotFound.new(key) unless find_by_key(key)
+    raise JSONAPI::Exceptions::RecordNotFound.new(key) unless find_by_key(key, context)
     return key
   end
 end
@@ -419,13 +419,13 @@ class BreedResource < JSONAPI::Resource
   def self.find(attrs, context = nil)
     breeds = []
     $breed_data.breeds.values.each do |breed|
-      breeds.push(BreedResource.new(breed))
+      breeds.push(BreedResource.new(breed, context))
     end
     breeds
   end
 
   def self.find_by_key(id, context = nil)
-    BreedResource.new($breed_data.breeds[id.to_i])
+    BreedResource.new($breed_data.breeds[id.to_i], context)
   end
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -113,7 +113,7 @@ end
 
 class DateWithTimezoneValueFormatter < JSONAPI::ValueFormatter
   class << self
-    def format(raw_value, source, context)
+    def format(raw_value, context)
       raw_value.in_time_zone('Eastern Time (US & Canada)').to_s
     end
   end
@@ -121,7 +121,7 @@ end
 
 class DateValueFormatter < JSONAPI::ValueFormatter
   class << self
-    def format(raw_value, source, context)
+    def format(raw_value, context)
       raw_value.strftime('%m/%d/%Y')
     end
   end
@@ -129,11 +129,11 @@ end
 
 class TitleValueFormatter < JSONAPI::ValueFormatter
   class << self
-    def format(raw_value, source, context)
-      super(raw_value, source, context).titlecase
+    def format(raw_value, source)
+      super(raw_value, source).titlecase
     end
 
-    def unformat(value, resource_klass, context)
+    def unformat(value, context)
       value.to_s.downcase
     end
   end


### PR DESCRIPTION
Reworks the context to make it part of a resource instance.
Removes resource from ValueFormatters to clarify purpose.
Renames object in resource to model.
