### PR TITLE
Small readme fix for `fetchable_fields`

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ class AuthorResource < JSONAPI::Resource
   model_name 'Person'
   has_many :posts
 
-  def fetchable_fields(context)
+  def fetchable_fields
     if (context.current_user.guest)
       super(context) - [:email]
     else


### PR DESCRIPTION
Found a small issue in the readme, while working on #30:

`fetchable_fields` does not accept `context` as a parameter, `context` is resource's attribute.

https://github.com/cerebris/jsonapi-resources/blob/master/lib/jsonapi/resource.rb#L118
