### PR TITLE
Fix include associations which might be nil.

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -398,7 +398,7 @@ module JSONAPI
               resource_class = self.class.resource_for(type_name)
               if resource_class
                 associated_model = @model.send attr
-                return resource_class.new(associated_model, @context)
+                return associated_model ? resource_class.new(associated_model, @context) : nil
               end
             end unless method_defined?(attr)
           elsif @_associations[attr].is_a?(JSONAPI::Association::HasMany)

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -135,7 +135,7 @@ end
 
 class Planet < ActiveRecord::Base
   has_many :moons
-  has_one :planet_type
+  belongs_to :planet_type
 
   has_and_belongs_to_many :tags, join_table: :planets_tags
 end
@@ -452,7 +452,7 @@ class PropertyResource < JSONAPI::Resource
 end
 
 class PlanetTypeResource < JSONAPI::Resource
-  attribute :name
+  attributes :id, :name
   has_many :planets
 end
 

--- a/test/unit/serializer/serializer_test.rb
+++ b/test/unit/serializer/serializer_test.rb
@@ -549,4 +549,50 @@ class SerializerTest < MiniTest::Unit::TestCase
     assert_match /\"planetType\":null/, json
     assert_match /\"moons\":\[\]/, json
   end
+
+  def test_serializer_include_with_empty_links_null_and_array
+    planets = []
+    Planet.find(7, 8).each do |planet|
+      planets.push PlanetResource.new(planet)
+    end
+
+    planet_hash = JSONAPI::ResourceSerializer.new.serialize_to_hash(
+      planets,
+      include: ['planet_type'],
+      fields: { planet_types: [:id, :name] }
+    )
+
+    assert_hash_equals(
+      {
+        planets: [{
+                    id: 7,
+                    name: 'Beta X',
+                    description: 'Newly discovered Planet Z',
+                    links: {
+                      planetType: 1,
+                      tags: [],
+                      moons: []
+                    }
+                  },
+                  {
+                    id: 8,
+                    name: 'Beta W',
+                    description: 'Newly discovered Planet W',
+                    links: {
+                      planetType: nil,
+                      tags: [],
+                      moons: []
+                    }
+                  }],
+        linked: {
+          planetTypes: [
+            { id: 1, name: "Gas Giant" }
+          ]
+        }
+      }, planet_hash)
+
+    json = planet_hash.to_json
+    assert_match /\"planetType\":null/, json
+    assert_match /\"moons\":\[\]/, json
+  end
 end


### PR DESCRIPTION
Fixes the issue #36
has_one association should return nil is source model's one is nil. Or I think so.
You can try the test without other changes to reproduce the exact issue I had encountered to find better solutions if possible.
