### PR TITLE
Add a hook to access the underlying Active Record relation

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ end
 
 ##### Finders
 
-Basic finding by filters is supported by resources. However if you have more complex requirements for finding you can override the `find` and `find_by_key` methods on the resource.
+Basic finding by filters is supported by resources. However if you have more complex requirements for finding you can override the `find`, `find_by_key` and `find_by_keys` methods on the resource class.
 
 Here's an example that defers the `find` operation to a `current_user` set on the `context` option:
 
@@ -279,6 +279,23 @@ class AuthorResource < JSONAPI::Resource
     return authors.map do |author|
       self.new(author)
     end
+  end
+end
+```
+
+##### Customizing base records for finder methods
+
+If you need to change the base records on which `find`, `find_by_key` and `find_by_keys` operate, you can override the `records` method on the resource class.
+
+For example to allow a user to only retrieve his own posts you can do the following:
+
+```ruby
+class PostResource < JSONAPI::Resource
+  attribute :id, :title, :body
+
+  def self.records(options = {})
+    context = options[:context]
+    context.current_user.posts
   end
 end
 ```

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -239,7 +239,7 @@ module JSONAPI
 
         resources = []
         order_options = construct_order_options(sort_params)
-        _model_class.where(where_filters).order(order_options).includes(includes).each do |model|
+        records(options).where(where_filters).order(order_options).includes(includes).each do |model|
           resources.push self.new(model, context)
         end
 
@@ -248,7 +248,7 @@ module JSONAPI
 
       def find_by_key(key, options = {})
         context = options[:context]
-        model = _model_class.where({_primary_key => key}).first
+        model = records(options).where({_primary_key => key}).first
         if model.nil?
           raise JSONAPI::Exceptions::RecordNotFound.new(key)
         end
@@ -257,7 +257,7 @@ module JSONAPI
 
       def find_by_keys(keys, options = {})
         context = options[:context]
-        _models = _model_class.where({_primary_key => keys})
+        _models = records(options).where({_primary_key => keys})
 
         unless _models.length == keys.length
           key = (keys - _models.pluck(:id).map(&:to_s)).first
@@ -265,6 +265,12 @@ module JSONAPI
         end
 
         _models.map { |model| self.new(model, context) }
+      end
+
+      # Override this method if you want to customize the relation for
+      # finder methods (find, find_by_key, find_by_keys)
+      def records(options = {})
+        _model_class
       end
 
       def verify_filters(filters, context = nil)


### PR DESCRIPTION
[One of the examples](https://github.com/cerebris/jsonapi-resources#finders) in the readme shows overriding the `find` method to achieve scoping resources to current user:

``` ruby
def self.find(attrs, options = {})
  ...
  authors = context.current_user.find_authors(attrs)
  ...
end
```

I believe this a very common use case in API's. The problem is that for this to really work one must also override `find_by_key` and `find_by_keys`.

One way to make this easier is to provide a hook to override the Active Record relation:

``` ruby
class PostResource < JSONAPI::Resource
  attribute :id, :title, :body

  # instead of overriding find, find_by_key and find_by_keys
  def self.relation(options = {})
    context = options[:context]
    context.current_user.posts
  end
end
```

This could also be used for something like pagination:

``` ruby
class PostResource < JSONAPI::Resource
  attribute :id, :title, :body

  def self.relation(options = {})
    context = options[:context]
    _model_class.paginate(page: context.params[:page])
  end
end
```

_p.s.:_ The implementation is just a quick example and would need tests and documentation (and maybe a better name for the hook) if you think this is a viable approach.
