### PR TITLE
Route and field formatting

### DIFF
--- a/lib/jsonapi/configuration.rb
+++ b/lib/jsonapi/configuration.rb
@@ -2,17 +2,26 @@ require 'jsonapi/formatter'
 
 module JSONAPI
   class Configuration
-    attr_reader :json_key_format, :key_formatter, :allowed_request_params
+    attr_reader :json_key_format, :key_formatter, :allowed_request_params, :route_format, :route_formatter
 
     def initialize
       #:underscored_key, :camelized_key, :dasherized_key, or custom
       self.json_key_format = :underscored_key
+
+      #:underscored_route, :camelized_route, :dasherized_route, or custom
+      self.route_format = :underscored_route
+
       self.allowed_request_params = [:include, :fields, :format, :controller, :action, :sort]
     end
 
     def json_key_format=(format)
       @json_key_format = format
       @key_formatter = JSONAPI::Formatter.formatter_for(format)
+    end
+
+    def route_format=(format)
+      @route_format = format
+      @route_formatter = JSONAPI::Formatter.formatter_for(format)
     end
 
     def allowed_request_params=(allowed_request_params)

--- a/lib/jsonapi/configuration.rb
+++ b/lib/jsonapi/configuration.rb
@@ -2,16 +2,21 @@ require 'jsonapi/formatter'
 
 module JSONAPI
   class Configuration
-    attr_reader :json_key_format, :key_formatter
+    attr_reader :json_key_format, :key_formatter, :allowed_request_params
 
     def initialize
       #:underscored_key, :camelized_key, :dasherized_key, or custom
       self.json_key_format = :underscored_key
+      self.allowed_request_params = [:include, :fields, :format, :controller, :action, :sort]
     end
 
     def json_key_format=(format)
       @json_key_format = format
       @key_formatter = JSONAPI::Formatter.formatter_for(format)
+    end
+
+    def allowed_request_params=(allowed_request_params)
+      @allowed_request_params = allowed_request_params
     end
   end
 

--- a/lib/jsonapi/formatter.rb
+++ b/lib/jsonapi/formatter.rb
@@ -37,6 +37,18 @@ module JSONAPI
     end
   end
 
+  class RouteFormatter < Formatter
+    class << self
+      def format(route)
+        super
+      end
+
+      def unformat(formatted_route)
+        super.to_sym
+      end
+    end
+  end
+
   class ValueFormatter < Formatter
     class << self
       def format(raw_value, context)
@@ -91,6 +103,33 @@ class DefaultValueFormatter < JSONAPI::ValueFormatter
         else
           return raw_value.to_s
       end
+    end
+  end
+end
+
+class UnderscoredRouteFormatter < JSONAPI::RouteFormatter
+end
+
+class CamelizedRouteFormatter < JSONAPI::RouteFormatter
+  class << self
+    def format(route)
+      super.camelize(:lower)
+    end
+
+    def unformat(formatted_route)
+      formatted_route.to_s.underscore.to_sym
+    end
+  end
+end
+
+class DasherizedRouteFormatter < JSONAPI::RouteFormatter
+  class << self
+    def format(route)
+      super.dasherize
+    end
+
+    def unformat(formatted_route)
+      formatted_route.to_s.underscore.to_sym
     end
   end
 end

--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -134,9 +134,11 @@ module JSONAPI
       params.each do |key, value|
         filter = key.to_sym
 
-        if JSONAPI.configuration.allowed_request_params.include?(filter)
-          # Ignore non-filter parameters
-        elsif @resource_klass._allowed_filter?(filter)
+        # Ignore non-filter parameters
+        next if JSONAPI.configuration.allowed_request_params.include?(filter)
+
+        filter = unformat_key(key).to_sym
+        if @resource_klass._allowed_filter?(filter)
           filters[filter] = value
         else
           @errors.concat(JSONAPI::Exceptions::FilterNotAllowed.new(filter).errors)

--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -147,8 +147,18 @@ module JSONAPI
 
     def parse_sort_params(params)
       @sort_params = if params[:sort].present?
-        CSV.parse_line(params[:sort]).each do |sort_param|
-          check_sort_param(@resource_klass, sort_param)
+        CSV.parse_line(params[:sort]).collect do |sort_param|
+          # A parameter name may not start with a dash
+          # We need to preserve the dash as the sort direction before we unformat the string
+          if sort_param.start_with?('-')
+            unformatted_sort_param = unformat_key(sort_param[1..-1]).to_s
+            unformatted_sort_param.prepend('-')
+          else
+            unformatted_sort_param = unformat_key(sort_param).to_s
+          end
+
+          check_sort_param(@resource_klass, unformatted_sort_param)
+          unformatted_sort_param
         end
       else
         []

--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -134,7 +134,7 @@ module JSONAPI
       params.each do |key, value|
         filter = key.to_sym
 
-        if [:include, :fields, :format, :controller, :action, :sort].include?(filter)
+        if JSONAPI.configuration.allowed_request_params.include?(filter)
           # Ignore non-filter parameters
         elsif @resource_klass._allowed_filter?(filter)
           filters[filter] = value

--- a/lib/jsonapi/resource_controller.rb
+++ b/lib/jsonapi/resource_controller.rb
@@ -54,7 +54,7 @@ module JSONAPI
       parent_resource = resource_klass.find_by_key(parent_key, context: context)
 
       association = resource_klass._association(association_type)
-      render json: { association_type => parent_resource.send(association.foreign_key)}
+      render json: { key_formatter.format(association_type) => parent_resource.send(association.foreign_key)}
     rescue => e
       # :nocov:
       handle_exceptions(e)

--- a/lib/jsonapi/routing_ext.rb
+++ b/lib/jsonapi/routing_ext.rb
@@ -1,14 +1,31 @@
 module ActionDispatch
   module Routing
     class Mapper
+
+      Resource.class_eval do
+        def unformat_route(route)
+          JSONAPI.configuration.route_formatter.unformat(route.to_s)
+        end
+
+        def nested_param
+          :"#{unformat_route(singular)}_#{param}"
+        end
+      end
+
       Resources.class_eval do
+        def format_route(route)
+          JSONAPI.configuration.route_formatter.format(route.to_s)
+        end
+
         def jsonapi_resource(*resources, &block)
           resource_type = resources.first
-          options = resources.extract_options!.dup
-
           res = JSONAPI::Resource.resource_for(resource_type)
 
-          resource resource_type, options.merge(res.routing_resource_options) do
+          options = resources.extract_options!.dup
+          options[:controller] ||= resource_type
+          options.merge!(res.routing_resource_options)
+
+          resource format_route(resource_type), options do
             @scope[:jsonapi_resource] = resource_type
 
             if block_given?
@@ -27,15 +44,18 @@ module ActionDispatch
 
         def jsonapi_resources(*resources, &block)
           resource_type = resources.first
-          options = resources.extract_options!.dup
-
           res = JSONAPI::Resource.resource_for(resource_type)
 
-          # Route using the primary_key. Can be overridden using routing_resource_options
-          options.merge!(param: res._primary_key)
+          options = resources.extract_options!.dup
+          options[:controller] ||= resource_type
+          options.merge!(res.routing_resource_options)
 
-          resources resource_type, options.merge(res.routing_resource_options) do
+          # Route using the primary_key. Can be overridden using routing_resource_options
+          options[:param] ||= res._primary_key
+
+          resources format_route(resource_type), options do
             @scope[:jsonapi_resource] = resource_type
+            @scope[:nested_param] = "#{format_route(resource_type.to_s.singularize)}_#{res._primary_key}"
 
             if block_given?
               yield
@@ -64,6 +84,7 @@ module ActionDispatch
 
         def jsonapi_link(*links)
           link_type = links.first
+          formatted_association_name = format_route(link_type)
           options = links.extract_options!.dup
 
           res = JSONAPI::Resource.resource_for(@scope[:jsonapi_resource])
@@ -71,24 +92,29 @@ module ActionDispatch
           methods = links_methods(options)
 
           if methods.include?(:show)
-            match "links/#{link_type}", controller: res._type.to_s, action: 'show_association', association: link_type.to_s, via: [:get]
+            match "links/#{formatted_association_name}", controller: res._type.to_s,
+                  action: 'show_association', association: link_type.to_s, via: [:get]
           end
 
           if methods.include?(:create)
-            match "links/#{link_type}", controller: res._type.to_s, action: 'create_association', association: link_type.to_s, via: [:post]
+            match "links/#{formatted_association_name}", controller: res._type.to_s,
+                  action: 'create_association', association: link_type.to_s, via: [:post]
           end
 
           if methods.include?(:update)
-            match "links/#{link_type}", controller: res._type.to_s, action: 'update_association', association: link_type.to_s, via: [:put]
+            match "links/#{formatted_association_name}", controller: res._type.to_s,
+                  action: 'update_association', association: link_type.to_s, via: [:put]
           end
 
           if methods.include?(:destroy)
-            match "links/#{link_type}", controller: res._type.to_s, action: 'destroy_association', association: link_type.to_s, via: [:delete]
+            match "links/#{formatted_association_name}", controller: res._type.to_s,
+                  action: 'destroy_association', association: link_type.to_s, via: [:delete]
           end
         end
 
         def jsonapi_links(*links)
           link_type = links.first
+          formatted_association_name = format_route(link_type)
           options = links.extract_options!.dup
 
           res = JSONAPI::Resource.resource_for(@scope[:jsonapi_resource])
@@ -96,19 +122,23 @@ module ActionDispatch
           methods = links_methods(options)
 
           if methods.include?(:show)
-            match "links/#{link_type}", controller: res._type.to_s, action: 'show_association', association: link_type.to_s, via: [:get]
+            match "links/#{formatted_association_name}", controller: res._type.to_s,
+                  action: 'show_association', association: link_type.to_s, via: [:get]
           end
 
           if methods.include?(:create)
-            match "links/#{link_type}", controller: res._type.to_s, action: 'create_association', association: link_type.to_s, via: [:post]
+            match "links/#{formatted_association_name}", controller: res._type.to_s,
+                  action: 'create_association', association: link_type.to_s, via: [:post]
           end
 
           if methods.include?(:update) && res._association(link_type).acts_as_set
-            match "links/#{link_type}", controller: res._type.to_s, action: 'update_association', association: link_type.to_s, via: [:put]
+            match "links/#{formatted_association_name}", controller: res._type.to_s,
+                  action: 'update_association', association: link_type.to_s, via: [:put]
           end
 
           if methods.include?(:destroy)
-            match "links/#{link_type}/:keys", controller: res._type.to_s, action: 'destroy_association', association: link_type.to_s, via: [:delete]
+            match "links/#{formatted_association_name}/:keys", controller: res._type.to_s,
+                  action: 'destroy_association', association: link_type.to_s, via: [:delete]
           end
         end
       end

--- a/lib/jsonapi/routing_ext.rb
+++ b/lib/jsonapi/routing_ext.rb
@@ -24,8 +24,9 @@ module ActionDispatch
           options = resources.extract_options!.dup
           options[:controller] ||= resource_type
           options.merge!(res.routing_resource_options)
+          options[:path] = format_route(resource_type)
 
-          resource format_route(resource_type), options do
+          resource resource_type, options do
             @scope[:jsonapi_resource] = resource_type
 
             if block_given?
@@ -53,9 +54,10 @@ module ActionDispatch
           # Route using the primary_key. Can be overridden using routing_resource_options
           options[:param] ||= res._primary_key
 
-          resources format_route(resource_type), options do
+          options[:path] = format_route(resource_type)
+
+          resources resource_type, options do
             @scope[:jsonapi_resource] = resource_type
-            @scope[:nested_param] = "#{format_route(resource_type.to_s.singularize)}_#{res._primary_key}"
 
             if block_given?
               yield

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -1197,6 +1197,54 @@ class IsoCurrenciesControllerTest < ActionController::TestCase
     assert_response :success
     assert json_response['isoCurrencies'].is_a?(Hash)
   end
+
+  def test_currencies_json_key_underscored_sort
+    JSONAPI.configuration.json_key_format = :underscored_key
+    get :index, {sort: 'country_name'}
+    assert_response :success
+    assert_equal 2, json_response['iso_currencies'].size
+    assert_equal 'Euro Member Countries', json_response['iso_currencies'][0]['country_name']
+    assert_equal 'United States', json_response['iso_currencies'][1]['country_name']
+
+    # reverse sort
+    get :index, {sort: '-country_name'}
+    assert_response :success
+    assert_equal 2, json_response['iso_currencies'].size
+    assert_equal 'United States', json_response['iso_currencies'][0]['country_name']
+    assert_equal 'Euro Member Countries', json_response['iso_currencies'][1]['country_name']
+  end
+
+  def test_currencies_json_key_dasherized_sort
+    JSONAPI.configuration.json_key_format = :dasherized_key
+    get :index, {sort: 'country-name'}
+    assert_response :success
+    assert_equal 2, json_response['iso-currencies'].size
+    assert_equal 'Euro Member Countries', json_response['iso-currencies'][0]['country-name']
+    assert_equal 'United States', json_response['iso-currencies'][1]['country-name']
+
+    # reverse sort
+    get :index, {sort: '-country-name'}
+    assert_response :success
+    assert_equal 2, json_response['iso-currencies'].size
+    assert_equal 'United States', json_response['iso-currencies'][0]['country-name']
+    assert_equal 'Euro Member Countries', json_response['iso-currencies'][1]['country-name']
+  end
+
+  def test_currencies_json_key_custom_json_key_sort
+    JSONAPI.configuration.json_key_format = :upper_camelized_key
+    get :index, {sort: 'CountryName'}
+    assert_response :success
+    assert_equal 2, json_response['IsoCurrencies'].size
+    assert_equal 'Euro Member Countries', json_response['IsoCurrencies'][0]['CountryName']
+    assert_equal 'United States', json_response['IsoCurrencies'][1]['CountryName']
+
+    # reverse sort
+    get :index, {sort: '-CountryName'}
+    assert_response :success
+    assert_equal 2, json_response['IsoCurrencies'].size
+    assert_equal 'United States', json_response['IsoCurrencies'][0]['CountryName']
+    assert_equal 'Euro Member Countries', json_response['IsoCurrencies'][1]['CountryName']
+  end
 end
 
 class PeopleControllerTest < ActionController::TestCase

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -1252,6 +1252,30 @@ class IsoCurrenciesControllerTest < ActionController::TestCase
     assert_equal 'Euro Member Countries', json_response['IsoCurrencies'][1]['CountryName']
     assert_equal 'Canada', json_response['IsoCurrencies'][2]['CountryName']
   end
+
+  def test_currencies_json_key_underscored_filter
+    JSONAPI.configuration.json_key_format = :underscored_key
+    get :index, {country_name: 'Canada'}
+    assert_response :success
+    assert_equal 1, json_response['iso_currencies'].size
+    assert_equal 'Canada', json_response['iso_currencies'][0]['country_name']
+  end
+
+  def test_currencies_json_key_camelized_key_filter
+    JSONAPI.configuration.json_key_format = :camelized_key
+    get :index, {'countryName' => 'Canada'}
+    assert_response :success
+    assert_equal 1, json_response['isoCurrencies'].size
+    assert_equal 'Canada', json_response['isoCurrencies'][0]['countryName']
+  end
+
+  def test_currencies_json_key_custom_json_key_filter
+    JSONAPI.configuration.json_key_format = :upper_camelized_key
+    get :index, {'CountryName' => 'Canada'}
+    assert_response :success
+    assert_equal 1, json_response['IsoCurrencies'].size
+    assert_equal 'Canada', json_response['IsoCurrencies'][0]['CountryName']
+  end
 end
 
 class PeopleControllerTest < ActionController::TestCase

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -1166,30 +1166,31 @@ class IsoCurrenciesControllerTest < ActionController::TestCase
   end
 
   def test_currencies_index
+    JSONAPI.configuration.json_key_format = :camelized_key
     get :index
     assert_response :success
-    assert_equal 2, json_response['isoCurrencies'].size
+    assert_equal 3, json_response['isoCurrencies'].size
   end
 
   def test_currencies_json_key_underscored
     JSONAPI.configuration.json_key_format = :underscored_key
     get :index
     assert_response :success
-    assert_equal 2, json_response['iso_currencies'].size
+    assert_equal 3, json_response['iso_currencies'].size
   end
 
   def test_currencies_json_key_dasherized
     JSONAPI.configuration.json_key_format = :dasherized_key
     get :index
     assert_response :success
-    assert_equal 2, json_response['iso-currencies'].size
+    assert_equal 3, json_response['iso-currencies'].size
   end
 
   def test_currencies_custom_json_key
     JSONAPI.configuration.json_key_format = :upper_camelized_key
     get :index
     assert_response :success
-    assert_equal 2, json_response['IsoCurrencies'].size
+    assert_equal 3, json_response['IsoCurrencies'].size
   end
 
   def test_currencies_show
@@ -1202,48 +1203,54 @@ class IsoCurrenciesControllerTest < ActionController::TestCase
     JSONAPI.configuration.json_key_format = :underscored_key
     get :index, {sort: 'country_name'}
     assert_response :success
-    assert_equal 2, json_response['iso_currencies'].size
-    assert_equal 'Euro Member Countries', json_response['iso_currencies'][0]['country_name']
-    assert_equal 'United States', json_response['iso_currencies'][1]['country_name']
+    assert_equal 3, json_response['iso_currencies'].size
+    assert_equal 'Canada', json_response['iso_currencies'][0]['country_name']
+    assert_equal 'Euro Member Countries', json_response['iso_currencies'][1]['country_name']
+    assert_equal 'United States', json_response['iso_currencies'][2]['country_name']
 
     # reverse sort
     get :index, {sort: '-country_name'}
     assert_response :success
-    assert_equal 2, json_response['iso_currencies'].size
+    assert_equal 3, json_response['iso_currencies'].size
     assert_equal 'United States', json_response['iso_currencies'][0]['country_name']
     assert_equal 'Euro Member Countries', json_response['iso_currencies'][1]['country_name']
+    assert_equal 'Canada', json_response['iso_currencies'][2]['country_name']
   end
 
   def test_currencies_json_key_dasherized_sort
     JSONAPI.configuration.json_key_format = :dasherized_key
     get :index, {sort: 'country-name'}
     assert_response :success
-    assert_equal 2, json_response['iso-currencies'].size
-    assert_equal 'Euro Member Countries', json_response['iso-currencies'][0]['country-name']
-    assert_equal 'United States', json_response['iso-currencies'][1]['country-name']
+    assert_equal 3, json_response['iso-currencies'].size
+    assert_equal 'Canada', json_response['iso-currencies'][0]['country-name']
+    assert_equal 'Euro Member Countries', json_response['iso-currencies'][1]['country-name']
+    assert_equal 'United States', json_response['iso-currencies'][2]['country-name']
 
     # reverse sort
     get :index, {sort: '-country-name'}
     assert_response :success
-    assert_equal 2, json_response['iso-currencies'].size
+    assert_equal 3, json_response['iso-currencies'].size
     assert_equal 'United States', json_response['iso-currencies'][0]['country-name']
     assert_equal 'Euro Member Countries', json_response['iso-currencies'][1]['country-name']
+    assert_equal 'Canada', json_response['iso-currencies'][2]['country-name']
   end
 
   def test_currencies_json_key_custom_json_key_sort
     JSONAPI.configuration.json_key_format = :upper_camelized_key
     get :index, {sort: 'CountryName'}
     assert_response :success
-    assert_equal 2, json_response['IsoCurrencies'].size
-    assert_equal 'Euro Member Countries', json_response['IsoCurrencies'][0]['CountryName']
-    assert_equal 'United States', json_response['IsoCurrencies'][1]['CountryName']
+    assert_equal 3, json_response['IsoCurrencies'].size
+    assert_equal 'Canada', json_response['IsoCurrencies'][0]['CountryName']
+    assert_equal 'Euro Member Countries', json_response['IsoCurrencies'][1]['CountryName']
+    assert_equal 'United States', json_response['IsoCurrencies'][2]['CountryName']
 
     # reverse sort
     get :index, {sort: '-CountryName'}
     assert_response :success
-    assert_equal 2, json_response['IsoCurrencies'].size
+    assert_equal 3, json_response['IsoCurrencies'].size
     assert_equal 'United States', json_response['IsoCurrencies'][0]['CountryName']
     assert_equal 'Euro Member Countries', json_response['IsoCurrencies'][1]['CountryName']
+    assert_equal 'Canada', json_response['IsoCurrencies'][2]['CountryName']
   end
 end
 

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -616,6 +616,7 @@ end
 
 IsoCurrency.create(code: 'USD', name: 'United States Dollar', country_name: 'United States', minor_unit: 'cent')
 IsoCurrency.create(code: 'EUR', name: 'Euro Member Countries', country_name: 'Euro Member Countries', minor_unit: 'cent')
+IsoCurrency.create(code: 'CAD', name: 'Canadian dollar', country_name: 'Canada', minor_unit: 'cent')
 
 ExpenseEntry.create(currency_code: 'USD',
                employee_id: c.id,

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -299,6 +299,17 @@ module Api
     class IsoCurrenciesController < JSONAPI::ResourceController
     end
   end
+
+  module V5
+    class PostsController < JSONAPI::ResourceController
+    end
+
+    class ExpenseEntriesController < JSONAPI::ResourceController
+    end
+
+    class IsoCurrenciesController < JSONAPI::ResourceController
+    end
+  end
 end
 
 ### RESOURCES

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -288,6 +288,17 @@ module Api
     class PostsController < JSONAPI::ResourceController
     end
   end
+
+  module V4
+    class PostsController < JSONAPI::ResourceController
+    end
+
+    class ExpenseEntriesController < JSONAPI::ResourceController
+    end
+
+    class IsoCurrenciesController < JSONAPI::ResourceController
+    end
+  end
 end
 
 ### RESOURCES
@@ -414,6 +425,8 @@ end
 class IsoCurrencyResource < JSONAPI::Resource
   primary_key :code
   attributes :id, :name, :country_name, :minor_unit
+
+  filter :country_name
 end
 
 class ExpenseEntryResource < JSONAPI::Resource

--- a/test/integration/requests/request_test.rb
+++ b/test/integration/requests/request_test.rb
@@ -8,6 +8,35 @@ class RequestTest < ActionDispatch::IntegrationTest
     assert_equal 200, status
   end
 
+  def test_get_underscored_key
+    JSONAPI.configuration.json_key_format = :underscored_key
+    get '/iso_currencies'
+    assert_equal 200, status
+    assert_equal 3, json_response['iso_currencies'].size
+  end
+
+  def test_get_underscored_key_filtered
+    JSONAPI.configuration.json_key_format = :underscored_key
+    get '/iso_currencies?country_name=Canada'
+    assert_equal 200, status
+    assert_equal 1, json_response['iso_currencies'].size
+    assert_equal 'Canada', json_response['iso_currencies'][0]['country_name']
+  end
+
+  def test_get_camelized_key_filtered
+    JSONAPI.configuration.json_key_format = :camelized_key
+    get '/iso_currencies?countryName=Canada'
+    assert_equal 200, status
+    assert_equal 1, json_response['isoCurrencies'].size
+    assert_equal 'Canada', json_response['isoCurrencies'][0]['countryName']
+  end
+
+  def test_get_camelized_route_and_key_filtered
+    get '/api/v4/isoCurrencies?countryName=Canada'
+    assert_equal 200, status
+    assert_equal 1, json_response['isoCurrencies'].size
+    assert_equal 'Canada', json_response['isoCurrencies'][0]['countryName']
+  end
   def test_put_single
     put '/posts/3',
         {

--- a/test/integration/requests/request_test.rb
+++ b/test/integration/requests/request_test.rb
@@ -37,6 +37,14 @@ class RequestTest < ActionDispatch::IntegrationTest
     assert_equal 1, json_response['isoCurrencies'].size
     assert_equal 'Canada', json_response['isoCurrencies'][0]['countryName']
   end
+
+  def test_get_camelized_route_and_links
+    JSONAPI.configuration.json_key_format = :camelized_key
+    get '/api/v4/expenseEntries/1/links/isoCurrency'
+    assert_equal 200, status
+    assert_equal 'USD', json_response['isoCurrency']
+  end
+
   def test_put_single
     put '/posts/3',
         {

--- a/test/integration/routes/routes_test.rb
+++ b/test/integration/routes/routes_test.rb
@@ -111,6 +111,25 @@ class RoutesTest < ActionDispatch::IntegrationTest
                    {action: 'show', controller: 'api/v3/posts', id: '1'})
   end
 
+  # V4
+  def test_routing_v4_posts_show
+    assert_routing({path: '/api/v4/posts/1', method: :get},
+                   {action: 'show', controller: 'api/v4/posts', id: '1'})
+  end
+
+  def test_routing_v4_isoCurrencies_resources
+    assert_routing({path: '/api/v4/isoCurrencies/USD', method: :get},
+                   {action: 'show', controller: 'api/v4/iso_currencies', code: 'USD'})
+  end
+
+  def test_routing_v4_expenseEntries_resources
+    assert_routing({path: '/api/v4/expenseEntries/1', method: :get},
+                   {action: 'show', controller: 'api/v4/expense_entries', id: '1'})
+
+    assert_routing({path: '/api/v4/expenseEntries/1/links/isoCurrency', method: :get},
+                   {controller: 'api/v4/expense_entries', action: 'show_association', expense_entry_id: '1', association: 'iso_currency'})
+  end
+
   #primary_key
   def test_routing_primary_key_jsonapi_resources
     assert_routing({path: '/iso_currencies/USD', method: :get},
@@ -136,4 +155,3 @@ class RoutesTest < ActionDispatch::IntegrationTest
   # Test that non acts as set has_many association update route is not created
 
 end
-

--- a/test/integration/routes/routes_test.rb
+++ b/test/integration/routes/routes_test.rb
@@ -111,7 +111,7 @@ class RoutesTest < ActionDispatch::IntegrationTest
                    {action: 'show', controller: 'api/v3/posts', id: '1'})
   end
 
-  # V4
+  # V4 camelCase
   def test_routing_v4_posts_show
     assert_routing({path: '/api/v4/posts/1', method: :get},
                    {action: 'show', controller: 'api/v4/posts', id: '1'})
@@ -130,6 +130,25 @@ class RoutesTest < ActionDispatch::IntegrationTest
                    {controller: 'api/v4/expense_entries', action: 'show_association', expense_entry_id: '1', association: 'iso_currency'})
   end
 
+  # V5 dasherized
+  def test_routing_v5_posts_show
+    assert_routing({path: '/api/v5/posts/1', method: :get},
+                   {action: 'show', controller: 'api/v5/posts', id: '1'})
+  end
+
+  def test_routing_v5_isoCurrencies_resources
+    assert_routing({path: '/api/v5/iso-currencies/USD', method: :get},
+                   {action: 'show', controller: 'api/v5/iso_currencies', code: 'USD'})
+  end
+
+  def test_routing_v5_expenseEntries_resources
+    assert_routing({path: '/api/v5/expense-entries/1', method: :get},
+                   {action: 'show', controller: 'api/v5/expense_entries', id: '1'})
+
+    assert_routing({path: '/api/v5/expense-entries/1/links/iso-currency', method: :get},
+                   {controller: 'api/v5/expense_entries', action: 'show_association', expense_entry_id: '1', association: 'iso_currency'})
+  end
+  
   #primary_key
   def test_routing_primary_key_jsonapi_resources
     assert_routing({path: '/iso_currencies/USD', method: :get},

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -108,6 +108,10 @@ class UpperCamelizedKeyFormatter < JSONAPI::KeyFormatter
     def format(key)
       super.camelize(:upper)
     end
+
+    def unformat(formatted_key)
+      formatted_key.to_s.underscore.to_sym
+    end
   end
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -88,13 +88,19 @@ TestApp.routes.draw do
       end
     end
 
-    JSONAPI.configuration.route_format = :camelized_key
+    JSONAPI.configuration.route_format = :camelized_route
     namespace :v4 do
       jsonapi_resources :posts
       jsonapi_resources :expense_entries
       jsonapi_resources :iso_currencies
     end
-    JSONAPI.configuration.route_format = :underscored_key
+    JSONAPI.configuration.route_format = :dasherized_route
+    namespace :v5 do
+      jsonapi_resources :posts
+      jsonapi_resources :expense_entries
+      jsonapi_resources :iso_currencies
+    end
+    JSONAPI.configuration.route_format = :underscored_route
   end
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -54,7 +54,6 @@ TestApp.routes.draw do
   jsonapi_resources :moons
   jsonapi_resources :preferences
 
-
   namespace :api do
     namespace :v1 do
       jsonapi_resources :authors
@@ -88,6 +87,14 @@ TestApp.routes.draw do
         jsonapi_links :tags, only: [:show, :create]
       end
     end
+
+    JSONAPI.configuration.route_format = :camelized_key
+    namespace :v4 do
+      jsonapi_resources :posts
+      jsonapi_resources :expense_entries
+      jsonapi_resources :iso_currencies
+    end
+    JSONAPI.configuration.route_format = :underscored_key
   end
 end
 

--- a/test/unit/serializer/serializer_test.rb
+++ b/test/unit/serializer/serializer_test.rb
@@ -9,6 +9,12 @@ class SerializerTest < MiniTest::Unit::TestCase
     @fred = Person.find_by(name: 'Fred Reader')
 
     @expense_entry = ExpenseEntry.find(1)
+
+    JSONAPI.configuration.json_key_format = :camelized_key
+  end
+
+  def after_teardown
+    JSONAPI.configuration.json_key_format = :underscored_key
   end
 
   def test_serializer


### PR DESCRIPTION
Fixes an issue where the formatter was not being used for filters or sort parameters.
Adds a formatting option to apply to routes.
Adds the allowed_request_params configuration to allow additional parameters to be ignored by the request.
