### PR TITLE
Empty index results should return an empty array

### DIFF
--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -8,6 +8,12 @@ class PostsControllerTest < ActionController::TestCase
     assert json_response['posts'].is_a?(Array)
   end
 
+  def test_index_filter_with_empty_result
+    get :index, {title: 'post that does not exist'}
+    assert_response :success
+    assert json_response['posts'].is_a?(Array)
+  end
+
   def test_index_filter_by_id
     get :index, {id: '1'}
     assert_response :success


### PR DESCRIPTION
Given there are no posts in the database:

``` json
GET /posts

Currently:
{}

Expected result:
{
  "posts": []
}
```

JSON API does not specifically requires this, but an empty array seems much more reasonable (also existing clients like [ember-json-api](https://github.com/kurko/ember-json-api) expect an array response).

At the moment this is just a failing test, as I'm not sure how to fix the issue.
The problem is that [here](https://github.com/cerebris/jsonapi-resources/blob/master/lib/jsonapi/resource_serializer.rb#L14) there is no way for the serializer to know the current resource type.
One possible solution - passing some kind of ResourceCollection  to the serializer instead of just plain array..
