### PR TITLE
dispaly error message if resource could not be found

### DIFF
--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -76,10 +76,14 @@ module JSONAPI
       fields.each do |type, values|
         underscored_type = unformat_key(type)
         fields[type] = []
-        type_resource = self.class.resource_for(underscored_type)
-        if type_resource.nil? || !(@resource_klass._type == underscored_type ||
-                                   @resource_klass._has_association?(underscored_type))
+        begin
+          type_resource = self.class.resource_for(underscored_type)
+        rescue NameError
           @errors.concat(JSONAPI::Exceptions::InvalidResource.new(type).errors)
+        end
+          if type_resource.nil? || !(@resource_klass._type == underscored_type ||
+                                     @resource_klass._has_association?(underscored_type))
+            @errors.concat(JSONAPI::Exceptions::InvalidResource.new(type).errors)
         else
           unless values.nil?
             valid_fields = type_resource.fields.collect {|key| format_key(key)}

--- a/lib/jsonapi/resource_for.rb
+++ b/lib/jsonapi/resource_for.rb
@@ -11,7 +11,7 @@ module JSONAPI
           resource_name = JSONAPI::Resource._resource_name_from_type(type)
           Object.const_get resource_name if resource_name
         rescue NameError
-          nil
+          raise NameError, "JSONAPI: Could not find resource '#{type}'. (Class #{resource_name} not found)"
         end
       else
         def resource_for(type)


### PR DESCRIPTION
I had a typo in one of the resource classes. This resulted in an error:

```
jsonapi/routing_ext.rb:53:in `jsonapi_resources': undefined method `routing_resource_options' for nil:NilClass (NoMethodError)
```

I've just started using JR, so this message wasn't very helpful to me. Hope this little patch will save someone some time.
