### PR TITLE
Format ids as strings to conform to specification.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 platforms :ruby do
   # sqlite3 1.3.9 does not work with rubinius 2.2.5:
   # https://github.com/sparklemotion/sqlite3-ruby/issues/122
-  gem 'sqlite3', '1.3.8'
+  gem 'sqlite3', '1.3.10'
 end
 
 platforms :jruby do

--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,6 @@ source 'https://rubygems.org'
 gemspec
 
 platforms :ruby do
-  # sqlite3 1.3.9 does not work with rubinius 2.2.5:
-  # https://github.com/sparklemotion/sqlite3-ruby/issues/122
   gem 'sqlite3', '1.3.10'
 end
 

--- a/lib/jsonapi/formatter.rb
+++ b/lib/jsonapi/formatter.rb
@@ -102,6 +102,14 @@ class DefaultValueFormatter < JSONAPI::ValueFormatter
   end
 end
 
+class IdValueFormatter < JSONAPI::ValueFormatter
+  class << self
+    def format(raw_value, context)
+      raw_value.to_s
+    end
+  end
+end
+
 class UnderscoredRouteFormatter < JSONAPI::RouteFormatter
 end
 

--- a/lib/jsonapi/formatter.rb
+++ b/lib/jsonapi/formatter.rb
@@ -105,6 +105,7 @@ end
 class IdValueFormatter < JSONAPI::ValueFormatter
   class << self
     def format(raw_value, context)
+      return if raw_value.nil?
       raw_value.to_s
     end
   end

--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -127,8 +127,9 @@ module JSONAPI
       end
 
       fields.each_with_object({}) do |name, hash|
+        format = name == :id ? 'id' : source.class._attribute_options(name)[:format]
         hash[format_key(name)] = format_value(source.send(name),
-                                              source.class._attribute_options(name)[:format],
+                                              format,
                                               source)
       end
     end

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -182,7 +182,7 @@ class PostsControllerTest < ActionController::TestCase
     get :index, {sort: 'title,body'}
 
     assert_response :success
-    assert_equal 8, json_response['posts'][0]['id']
+    assert_equal '8', json_response['posts'][0]['id']
   end
 
   def test_invalid_sort_param
@@ -211,8 +211,8 @@ class PostsControllerTest < ActionController::TestCase
     assert json_response['posts'].is_a?(Hash)
     assert_equal 'New post', json_response['posts']['title']
     assert_equal 'A body!!!', json_response['posts']['body']
-    assert_equal [1, 2, 3], json_response['posts']['links']['tags']
-    assert_equal [1, 2], json_response['posts']['links']['comments']
+    assert_equal ['1', '2', '3'], json_response['posts']['links']['tags']
+    assert_equal ['1', '2'], json_response['posts']['links']['comments']
     assert_nil json_response['linked']
   end
 
@@ -222,8 +222,8 @@ class PostsControllerTest < ActionController::TestCase
     assert json_response['posts'].is_a?(Hash)
     assert_equal 'New post', json_response['posts']['title']
     assert_equal 'A body!!!', json_response['posts']['body']
-    assert_equal [1, 2, 3], json_response['posts']['links']['tags']
-    assert_equal [1, 2], json_response['posts']['links']['comments']
+    assert_equal ['1', '2', '3'], json_response['posts']['links']['tags']
+    assert_equal ['1', '2'], json_response['posts']['links']['comments']
     assert_equal 2, json_response['linked']['comments'].size
     assert_nil json_response['linked']['tags']
   end
@@ -234,7 +234,7 @@ class PostsControllerTest < ActionController::TestCase
     assert json_response['posts'].is_a?(Hash)
     assert_nil json_response['posts']['title']
     assert_nil json_response['posts']['body']
-    assert_equal 1, json_response['posts']['links']['author']
+    assert_equal '1', json_response['posts']['links']['author']
   end
 
   def test_show_single_invalid_id_format
@@ -275,7 +275,7 @@ class PostsControllerTest < ActionController::TestCase
 
     assert_response :created
     assert json_response['posts'].is_a?(Hash)
-    assert_equal 3, json_response['posts']['links']['author']
+    assert_equal '3', json_response['posts']['links']['author']
     assert_equal 'JR is Great', json_response['posts']['title']
     assert_equal 'JSONAPIResources is the greatest thing since unsliced bread.', json_response['posts']['body']
   end
@@ -361,7 +361,7 @@ class PostsControllerTest < ActionController::TestCase
     assert_response :created
     assert json_response['posts'].is_a?(Array)
     assert_equal json_response['posts'].size, 2
-    assert_equal json_response['posts'][0]['links']['author'], 3
+    assert_equal json_response['posts'][0]['links']['author'], '3'
     assert_match /JR is Great/, response.body
     assert_match /Ember is Great/, response.body
   end
@@ -438,10 +438,10 @@ class PostsControllerTest < ActionController::TestCase
 
     assert_response :created
     assert json_response['posts'].is_a?(Hash)
-    assert_equal 3, json_response['posts']['links']['author']
+    assert_equal '3', json_response['posts']['links']['author']
     assert_equal 'JR is Great', json_response['posts']['title']
     assert_equal 'JSONAPIResources is the greatest thing since unsliced bread.', json_response['posts']['body']
-    assert_equal [3, 4], json_response['posts']['links']['tags']
+    assert_equal ['3', '4'], json_response['posts']['links']['tags']
   end
 
   def test_create_with_links_include_and_fields
@@ -461,7 +461,7 @@ class PostsControllerTest < ActionController::TestCase
 
     assert_response :created
     assert json_response['posts'].is_a?(Hash)
-    assert_equal 3, json_response['posts']['links']['author']
+    assert_equal '3', json_response['posts']['links']['author']
     assert_equal 'JR is Great!', json_response['posts']['title']
     assert_equal nil, json_response['posts']['body']
     assert_equal nil, json_response['posts']['links']['tags']
@@ -487,11 +487,11 @@ class PostsControllerTest < ActionController::TestCase
 
     assert_response :success
     assert json_response['posts'].is_a?(Hash)
-    assert_equal 3, json_response['posts']['links']['author']
-    assert_equal javascript.id, json_response['posts']['links']['section']
+    assert_equal '3', json_response['posts']['links']['author']
+    assert_equal javascript.id.to_s, json_response['posts']['links']['section']
     assert_equal 'A great new Post', json_response['posts']['title']
     assert_equal 'AAAA', json_response['posts']['body']
-    assert matches_array?([3, 4], json_response['posts']['links']['tags'])
+    assert matches_array?(['3', '4'], json_response['posts']['links']['tags'])
   end
 
   def test_update_remove_links
@@ -509,7 +509,7 @@ class PostsControllerTest < ActionController::TestCase
 
     assert_response :success
     assert json_response['posts'].is_a?(Hash)
-    assert_equal 3, json_response['posts']['links']['author']
+    assert_equal '3', json_response['posts']['links']['author']
     assert_equal nil, json_response['posts']['links']['section']
     assert_equal 'A great new Post', json_response['posts']['title']
     assert_equal 'AAAA', json_response['posts']['body']
@@ -806,17 +806,17 @@ class PostsControllerTest < ActionController::TestCase
 
     assert_response :success
     assert_equal json_response['posts'].size, 2
-    assert_equal json_response['posts'][0]['links']['author'], 3
-    assert_equal json_response['posts'][0]['links']['section'], javascript.id
+    assert_equal json_response['posts'][0]['links']['author'], '3'
+    assert_equal json_response['posts'][0]['links']['section'], javascript.id.to_s
     assert_equal json_response['posts'][0]['title'], 'A great new Post QWERTY'
     assert_equal json_response['posts'][0]['body'], 'AAAA'
-    assert_equal json_response['posts'][0]['links']['tags'], [3, 4]
+    assert_equal json_response['posts'][0]['links']['tags'], ['3', '4']
 
-    assert_equal json_response['posts'][1]['links']['author'], 3
-    assert_equal json_response['posts'][1]['links']['section'], javascript.id
+    assert_equal json_response['posts'][1]['links']['author'], '3'
+    assert_equal json_response['posts'][1]['links']['section'], javascript.id.to_s
     assert_equal json_response['posts'][1]['title'], 'A great new Post ASDFG'
     assert_equal json_response['posts'][1]['body'], 'AAAA'
-    assert_equal json_response['posts'][1]['links']['tags'], [3, 4]
+    assert_equal json_response['posts'][1]['links']['tags'], ['3', '4']
   end
 
   def test_update_multiple_missing_keys
@@ -1104,7 +1104,7 @@ class ExpenseEntriesControllerTest < ActionController::TestCase
 
     assert_response :created
     assert json_response['expense_entries'].is_a?(Hash)
-    assert_equal 3, json_response['expense_entries']['links']['employee']
+    assert_equal '3', json_response['expense_entries']['links']['employee']
     assert_equal 'USD', json_response['expense_entries']['links']['iso_currency']
     assert_equal 50.58, json_response['expense_entries']['cost']
 
@@ -1131,7 +1131,7 @@ class ExpenseEntriesControllerTest < ActionController::TestCase
 
     assert_response :created
     assert json_response['expenseEntries'].is_a?(Hash)
-    assert_equal 3, json_response['expenseEntries']['links']['employee']
+    assert_equal '3', json_response['expenseEntries']['links']['employee']
     assert_equal 'USD', json_response['expenseEntries']['links']['isoCurrency']
     assert_equal 50.58, json_response['expenseEntries']['cost']
 
@@ -1158,7 +1158,7 @@ class ExpenseEntriesControllerTest < ActionController::TestCase
 
     assert_response :created
     assert json_response['expense-entries'].is_a?(Hash)
-    assert_equal 3, json_response['expense-entries']['links']['employee']
+    assert_equal '3', json_response['expense-entries']['links']['employee']
     assert_equal 'USD', json_response['expense-entries']['links']['iso-currency']
     assert_equal 50.58, json_response['expense-entries']['cost']
 
@@ -1346,7 +1346,7 @@ class PeopleControllerTest < ActionController::TestCase
     get :index, {name: 'Joe Author'}
     assert_response :success
     assert_equal json_response['people'].size, 1
-    assert_equal json_response['people'][0]['id'], 1
+    assert_equal json_response['people'][0]['id'], '1'
     assert_equal json_response['people'][0]['name'], 'Joe Author'
   end
 end
@@ -1356,7 +1356,7 @@ class AuthorsControllerTest < ActionController::TestCase
     get :index, {id: '1'}
     assert_response :success
     assert_equal 1, json_response['authors'].size
-    assert_equal 1, json_response['authors'][0]['id']
+    assert_equal '1', json_response['authors'][0]['id']
     assert_equal 'Joe Author', json_response['authors'][0]['name']
     assert_equal nil, json_response['authors'][0]['email']
     assert_equal 1, json_response['authors'][0]['links'].size
@@ -1367,7 +1367,7 @@ class AuthorsControllerTest < ActionController::TestCase
     get :index, {id: '4'}
     assert_response :success
     assert_equal 1, json_response['authors'].size
-    assert_equal 4, json_response['authors'][0]['id']
+    assert_equal '4', json_response['authors'][0]['id']
     assert_equal 'Tag Crazy Author', json_response['authors'][0]['name']
     assert_equal 'taggy@xyz.fake', json_response['authors'][0]['email']
     assert_equal 1, json_response['authors'][0]['links'].size
@@ -1378,7 +1378,7 @@ class AuthorsControllerTest < ActionController::TestCase
     get :index, {name: 'thor'}
     assert_response :success
     assert_equal 3, json_response['authors'].size
-    assert_equal 1, json_response['authors'][0]['id']
+    assert_equal '1', json_response['authors'][0]['id']
     assert_equal 'Joe Author', json_response['authors'][0]['name']
     assert_equal 1, json_response['authors'][0]['links'].size
     assert_equal 3, json_response['authors'][0]['links']['posts'].size
@@ -1391,7 +1391,7 @@ class BreedsControllerTest < ActionController::TestCase
   def test_poro_index
     get :index
     assert_response :success
-    assert_equal 0, json_response['breeds'][0]['id']
+    assert_equal '0', json_response['breeds'][0]['id']
     assert_equal 'Persian', json_response['breeds'][0]['name']
   end
 
@@ -1399,7 +1399,7 @@ class BreedsControllerTest < ActionController::TestCase
     get :show, {id: '0'}
     assert_response :success
     assert json_response['breeds'].is_a?(Hash)
-    assert_equal 0, json_response['breeds']['id']
+    assert_equal '0', json_response['breeds']['id']
     assert_equal 'Persian', json_response['breeds']['name']
   end
 
@@ -1408,9 +1408,9 @@ class BreedsControllerTest < ActionController::TestCase
     assert_response :success
     assert json_response['breeds'].is_a?(Array)
     assert_equal 2, json_response['breeds'].size
-    assert_equal 0, json_response['breeds'][0]['id']
+    assert_equal '0', json_response['breeds'][0]['id']
     assert_equal 'Persian', json_response['breeds'][0]['name']
-    assert_equal 2, json_response['breeds'][1]['id']
+    assert_equal '2', json_response['breeds'][1]['id']
     assert_equal 'Sphinx', json_response['breeds'][1]['name']
   end
 
@@ -1483,4 +1483,3 @@ class FactsControllerTest < ActionController::TestCase
     assert_equal false, json_response['facts']['cool']
   end
 end
-

--- a/test/unit/serializer/serializer_test.rb
+++ b/test/unit/serializer/serializer_test.rb
@@ -22,15 +22,15 @@ class SerializerTest < MiniTest::Unit::TestCase
     assert_hash_equals(
       {
         posts: {
-          id: 1,
+          id: '1',
           title: 'New post',
           body: 'A body!!!',
           subject: 'New post',
           links: {
             section: nil,
-            author: 1,
-            tags: [1, 2, 3],
-            comments: [1, 2]
+            author: '1',
+            tags: ['1', '2', '3'],
+            comments: ['1', '2']
           }
         }
       },
@@ -43,10 +43,10 @@ class SerializerTest < MiniTest::Unit::TestCase
     assert_hash_equals(
       {
         posts: {
-          id: 1,
+          id: '1',
           title: 'New post',
           links: {
-            author: 1
+            author: '1'
           }
         }
       },
@@ -60,26 +60,26 @@ class SerializerTest < MiniTest::Unit::TestCase
     assert_hash_equals(
       {
         posts: {
-          id: 1,
+          id: '1',
           title: 'New post',
           body: 'A body!!!',
           subject: 'New post',
           links: {
-            author: 1,
-            tags: [1, 2, 3],
-            comments: [1, 2],
+            author: '1',
+            tags: ['1', '2', '3'],
+            comments: ['1', '2'],
             section: nil
           }
         },
         linked: {
           people: [{
-                     id: 1,
+                     id: '1',
                      name: 'Joe Author',
                      email: 'joe@xyz.fake',
                      dateJoined: '2013-08-07 16:25:00 -0400',
                      links: {
-                       comments: [1],
-                       posts: [1, 2, 11]
+                       comments: ['1'],
+                       posts: ['1', '2', '11']
                      }
                    }]
         }
@@ -93,26 +93,26 @@ class SerializerTest < MiniTest::Unit::TestCase
     assert_hash_equals(
       {
         posts: {
-          id: 1,
+          id: '1',
           title: 'New post',
           body: 'A body!!!',
           subject: 'New post',
           links: {
-            author: 1,
-            tags: [1, 2, 3],
-            comments: [1, 2],
+            author: '1',
+            tags: ['1', '2', '3'],
+            comments: ['1', '2'],
             section: nil
           }
         },
         linked: {
           people: [{
-                     id: 1,
+                     id: '1',
                      name: 'Joe Author',
                      email: 'joe@xyz.fake',
                      date_joined: '2013-08-07 16:25:00 -0400',
                      links: {
-                       comments: [1],
-                       posts: [1, 2, 11]
+                       comments: ['1'],
+                       posts: ['1', '2', '11']
                      }
                    }]
         }
@@ -128,35 +128,35 @@ class SerializerTest < MiniTest::Unit::TestCase
     assert_hash_equals(
       {
         posts: {
-          id: 1,
+          id: '1',
           title: 'New post',
           body: 'A body!!!',
           subject: 'New post',
           links: {
-            author: 1,
-            tags: [1, 2, 3],
-            comments: [1, 2],
+            author: '1',
+            tags: ['1', '2', '3'],
+            comments: ['1', '2'],
             section: nil
           }
         },
         linked: {
           tags: [
             {
-              id: 1,
+              id: '1',
               name: 'short',
               links: {
                 posts: :not_nil
               }
             },
             {
-              id: 2,
+              id: '2',
               name: 'whiny',
               links: {
                 posts: :not_nil
               }
             },
             {
-              id: 4,
+              id: '4',
               name: 'happy',
               links: {
                 posts: :not_nil
@@ -165,21 +165,21 @@ class SerializerTest < MiniTest::Unit::TestCase
           ],
           comments: [
             {
-              id: 1,
+              id: '1',
               body: 'what a dumb post',
               links: {
-                author: 1,
-                post: 1,
-                tags: [2, 1]
+                author: '1',
+                post: '1',
+                tags: ['2', '1']
               }
             },
             {
-              id: 2,
+              id: '2',
               body: 'i liked it',
               links: {
-                author: 2,
-                post: 1,
-                tags: [4, 1]
+                author: '2',
+                post: '1',
+                tags: ['4', '1']
               }
             }
           ]
@@ -194,35 +194,35 @@ class SerializerTest < MiniTest::Unit::TestCase
     assert_hash_equals(
       {
         posts: {
-          id: 1,
+          id: '1',
           title: 'New post',
           body: 'A body!!!',
           subject: 'New post',
           links: {
-            author: 1,
-            tags: [1, 2, 3],
-            comments: [1, 2],
+            author: '1',
+            tags: ['1', '2', '3'],
+            comments: ['1', '2'],
             section: nil
           }
         },
         linked: {
           tags: [
             {
-              id: 1,
+              id: '1',
               name: 'short',
               links: {
                 posts: :not_nil
               }
             },
             {
-              id: 2,
+              id: '2',
               name: 'whiny',
               links: {
                 posts: :not_nil
               }
             },
             {
-              id: 4,
+              id: '4',
               name: 'happy',
               links: {
                 posts: :not_nil
@@ -240,26 +240,26 @@ class SerializerTest < MiniTest::Unit::TestCase
     assert_hash_equals(
       {
         posts: {
-          id: 1,
+          id: '1',
           title: 'New post',
           body: 'A body!!!',
           subject: 'New post',
           links: {
-            author: 1,
-            tags: [1, 2, 3],
-            comments: [1, 2],
+            author: '1',
+            tags: ['1', '2', '3'],
+            comments: ['1', '2'],
             section: nil
           }
         },
         linked: {
           comments: [
             {
-              id: 1,
+              id: '1',
               body: 'what a dumb post',
               links: {
-                author: 1,
-                post: 1,
-                tags: [2, 1]
+                author: '1',
+                post: '1',
+                tags: ['2', '1']
               }
             }
           ]
@@ -274,32 +274,32 @@ class SerializerTest < MiniTest::Unit::TestCase
     assert_hash_equals(
       {
         people: {
-          id: 2,
+          id: '2',
           name: 'Fred Reader',
           email: 'fred@xyz.fake',
           dateJoined: '2013-10-31 16:25:00 -0400',
           links: {
             posts: [],
-            comments: [2, 3]
+            comments: ['2', '3']
           }
         },
         linked: {
           comments: [{
-                       id: 2,
+                       id: '2',
                        body: 'i liked it',
                        links: {
-                         author: 2,
-                         post: 1,
-                         tags: [4, 1]
+                         author: '2',
+                         post: '1',
+                         tags: ['4', '1']
                        }
                      },
                      {
-                       id: 3,
+                       id: '3',
                        body: 'Thanks man. Great post. But what is JR?',
                        links: {
-                         author: 2,
-                         post: 2,
-                         tags: [5]
+                         author: '2',
+                         post: '2',
+                         tags: ['5']
                        }
                      }
           ]
@@ -319,86 +319,86 @@ class SerializerTest < MiniTest::Unit::TestCase
     assert_hash_equals(
       {
         posts: [{
-                  id: 1,
+                  id: '1',
                   title: 'New post',
                   body: 'A body!!!',
                   subject: 'New post',
                   links: {
-                    author: 1,
-                    tags: [1, 2, 3],
-                    comments: [1, 2],
+                    author: '1',
+                    tags: ['1', '2', '3'],
+                    comments: ['1', '2'],
                     section: nil
                   }
                 },
                 {
-                  id: 2,
+                  id: '2',
                   title: 'JR Solves your serialization woes!',
                   body: 'Use JR',
                   subject: 'JR Solves your serialization woes!',
                   links: {
-                    author: 1,
-                    tags: [5],
-                    comments: [3],
-                    section: 3
+                    author: '1',
+                    tags: ['5'],
+                    comments: ['3'],
+                    section: '3'
                   }
                 }],
         linked: {
           tags: [
             {
-              id: 1,
+              id: '1',
               name: 'short',
               links: {
                 posts: :not_nil
               }
             },
             {
-              id: 2,
+              id: '2',
               name: 'whiny',
               links: {
                 posts: :not_nil
               }
             },
             {
-              id: 4,
+              id: '4',
               name: 'happy',
               links: {
                 posts: :not_nil
               }
             },
             {
-              id: 5,
+              id: '5',
               name: 'JR',
               links: {
-                posts: [2, 11]
+                posts: ['2', '11']
               }
             }
           ],
           comments: [
             {
-              id: 1,
+              id: '1',
               body: 'what a dumb post',
               links: {
-                author: 1,
-                post: 1,
-                tags: [2, 1]
+                author: '1',
+                post: '1',
+                tags: ['2', '1']
               }
             },
             {
-              id: 2,
+              id: '2',
               body: 'i liked it',
               links: {
-                author: 2,
-                post: 1,
-                tags: [4, 1]
+                author: '2',
+                post: '1',
+                tags: ['4', '1']
               }
             },
             {
-              id: 3,
+              id: '3',
               body: 'Thanks man. Great post. But what is JR?',
               links: {
-                author: 2,
-                post: 2,
-                tags: [5]
+                author: '2',
+                post: '2',
+                tags: ['5']
               }
             }
           ]
@@ -418,17 +418,17 @@ class SerializerTest < MiniTest::Unit::TestCase
     assert_hash_equals(
       {
         posts: [{
-                  id: 1,
+                  id: '1',
                   title: 'New post',
                   links: {
-                    author: 1
+                    author: '1'
                   }
                 },
                 {
-                  id: 2,
+                  id: '2',
                   title: 'JR Solves your serialization woes!',
                   links: {
-                    author: 1
+                    author: '1'
                   }
                 }],
         linked: {
@@ -448,42 +448,42 @@ class SerializerTest < MiniTest::Unit::TestCase
           ],
           comments: [
             {
-              id: 1,
+              id: '1',
               body: 'what a dumb post',
               links: {
-                post: 1
+                post: '1'
               }
             },
             {
-              id: 2,
+              id: '2',
               body: 'i liked it',
               links: {
-                post: 1
+                post: '1'
               }
             },
             {
-              id: 3,
+              id: '3',
               body: 'Thanks man. Great post. But what is JR?',
               links: {
-                post: 2
+                post: '2'
               }
             }
           ],
           posts: [
             {
-              id: 11,
+              id: '11',
               title: 'JR How To',
               links: {
-                author: 1
+                author: '1'
               }
             }
           ],
           people: [
             {
-              id: 1,
+              id: '1',
               email: 'joe@xyz.fake',
               links: {
-                comments: [1]
+                comments: ['1']
               }
             }]
         }
@@ -503,12 +503,12 @@ class SerializerTest < MiniTest::Unit::TestCase
     assert_hash_equals(
       {
         expenseEntries: {
-          id: 1,
+          id: '1',
           transactionDate: '04/15/2014',
           cost: 12.05,
           links: {
             isoCurrency: 'USD',
-            employee: 3
+            employee: '3'
           }
         },
         linked: {
@@ -519,7 +519,7 @@ class SerializerTest < MiniTest::Unit::TestCase
                             minorUnit: 'cent'
                           }],
           people: [{
-                     id: 3,
+                     id: '3',
                      name: 'Lazy Author',
                      email: 'lazy@xyz.fake',
                      dateJoined: '2013-10-31 17:25:00 -0400',
@@ -541,7 +541,7 @@ class SerializerTest < MiniTest::Unit::TestCase
     assert_hash_equals(
       {
         planets: {
-          id: 8,
+          id: '8',
           name: 'Beta W',
           description: 'Newly discovered Planet W',
           links: {
@@ -572,17 +572,17 @@ class SerializerTest < MiniTest::Unit::TestCase
     assert_hash_equals(
       {
         planets: [{
-                    id: 7,
+                    id: '7',
                     name: 'Beta X',
                     description: 'Newly discovered Planet Z',
                     links: {
-                      planetType: 1,
+                      planetType: '1',
                       tags: [],
                       moons: []
                     }
                   },
                   {
-                    id: 8,
+                    id: '8',
                     name: 'Beta W',
                     description: 'Newly discovered Planet W',
                     links: {
@@ -593,7 +593,7 @@ class SerializerTest < MiniTest::Unit::TestCase
                   }],
         linked: {
           planetTypes: [
-            { id: 1, name: "Gas Giant" }
+            { id: '1', name: "Gas Giant" }
           ]
         }
       }, planet_hash)
@@ -611,7 +611,7 @@ class SerializerTest < MiniTest::Unit::TestCase
     assert_hash_equals(
       {
         preferences: {
-                  id: 1,
+                  id: '1',
                   advanced_mode: false,
                   links: {
                     author: nil,
@@ -630,7 +630,7 @@ class SerializerTest < MiniTest::Unit::TestCase
     assert_hash_equals(
       {
         facts: {
-          id: 1,
+          id: '1',
           spouse_name: 'Jane Author',
           bio: 'First man to run across Antartica.',
           quality_rating: 23.89/45.6,


### PR DESCRIPTION
Addresses issue https://github.com/cerebris/jsonapi-resources/issues/55.

From the JSON API specification:

> An individual resource SHOULD be represented as a ... string value containing its ID...
