### PR TITLE
Fix resource class lookup for namespaced resources.

### DIFF
--- a/lib/jsonapi/routing_ext.rb
+++ b/lib/jsonapi/routing_ext.rb
@@ -45,7 +45,11 @@ module ActionDispatch
 
         def jsonapi_resources(*resources, &block)
           resource_type = resources.first
-          res = JSONAPI::Resource.resource_for(resource_type)
+          resource_type_with_module_prefix = [
+            @scope[:module],
+            resource_type
+          ].compact.collect(&:to_s).join("/")
+          res = JSONAPI::Resource.resource_for(resource_type_with_module_prefix)
 
           options = resources.extract_options!.dup
           options[:controller] ||= resource_type

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -177,6 +177,9 @@ end
 class Fact < ActiveRecord::Base
 end
 
+class Like < ActiveRecord::Base
+end
+
 class Breed
 
   def initialize(id = nil, name = nil)
@@ -287,6 +290,9 @@ module Api
     end
 
     class MoonsController < JSONAPI::ResourceController
+    end
+
+    class LikesController < JSONAPI::ResourceController
     end
   end
 
@@ -553,6 +559,9 @@ module Api
       filter :name
     end
 
+    class LikeResource < JSONAPI::Resource
+    end
+
     class PostResource < JSONAPI::Resource
       # V1 no longer supports tags and now calls author 'writer'
       attribute :id
@@ -570,23 +579,49 @@ module Api
 
       filters :writer
     end
+
+    AuthorResource = AuthorResource.dup
+    PersonResource = PersonResource.dup
+    CommentResource = CommentResource.dup
+    TagResource = TagResource.dup
+    SectionResource = SectionResource.dup
+    IsoCurrencyResource = IsoCurrencyResource.dup
+    ExpenseEntryResource = ExpenseEntryResource.dup
+    BreedResource = BreedResource.dup
+    PlanetResource = PlanetResource.dup
+    PlanetTypeResource = PlanetTypeResource.dup
+    MoonResource = MoonResource.dup
+    PreferencesResource = PreferencesResource.dup
   end
 end
 
 module Api
   module V2
-    class PreferencesResource < PreferencesResource
-    end
+    PreferencesResource = PreferencesResource.dup
+    AuthorResource = AuthorResource.dup
+    PostResource = PostResource.dup
+  end
+end
+
+module Api
+  module V3
+    PostResource = PostResource.dup
   end
 end
 
 module Api
   module V4
-    class IsoCurrencyResource < IsoCurrencyResource
-    end
+    PostResource = PostResource.dup
+    ExpenseEntryResource = ExpenseEntryResource.dup
+    IsoCurrencyResource = IsoCurrencyResource.dup
+  end
+end
 
-    class ExpenseEntryResource < ExpenseEntryResource
-    end
+module Api
+  module V5
+    PostResource = PostResource.dup
+    ExpenseEntryResource = ExpenseEntryResource.dup
+    IsoCurrencyResource = IsoCurrencyResource.dup
   end
 end
 

--- a/test/integration/routes/routes_test.rb
+++ b/test/integration/routes/routes_test.rb
@@ -84,9 +84,9 @@ class RoutesTest < ActionDispatch::IntegrationTest
                    {action: 'destroy', controller: 'api/v1/posts', id: '1'})
   end
 
-  def test_routing_v1_posts_links_author_show
-    assert_routing({path: '/api/v1/posts/1/links/author', method: :get},
-                   {controller: 'api/v1/posts', action: 'show_association', post_id: '1', association: 'author'})
+  def test_routing_v1_posts_links_writer_show
+    assert_routing({path: '/api/v1/posts/1/links/writer', method: :get},
+                   {controller: 'api/v1/posts', action: 'show_association', post_id: '1', association: 'writer'})
   end
 
   # V2
@@ -148,7 +148,7 @@ class RoutesTest < ActionDispatch::IntegrationTest
     assert_routing({path: '/api/v5/expense-entries/1/links/iso-currency', method: :get},
                    {controller: 'api/v5/expense_entries', action: 'show_association', expense_entry_id: '1', association: 'iso_currency'})
   end
-  
+
   #primary_key
   def test_routing_primary_key_jsonapi_resources
     assert_routing({path: '/iso_currencies/USD', method: :get},

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -72,6 +72,7 @@ TestApp.routes.draw do
       jsonapi_resources :planet_types
       jsonapi_resources :moons
       jsonapi_resources :preferences
+      jsonapi_resources :likes
     end
 
     namespace :v2 do


### PR DESCRIPTION
The `jsonapi_resources` method was not getting the namespaced resource. That wasn't showing as an error because there weren't any resources that were only exposed within a namespace (and so it was looking up the non-namespaced resource). This fixes that.
