### PR TITLE
Add before_save callback to resource and fix test order dependency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,22 @@ end
 
 The `context` is not by default used by the `ResourceController`, but may be used if you override the controller methods. By using the context you have the option to determine the createable and updateable fields based on the user.
 
+##### Before Save Callback
+
+The `before_save` method is called (with the `context`) before a resource is saved. This provides a hook into the create/update/destroy process to perform actions like authorization. If you would like to prevent the save, you should raise an exception and rescue in your controller.
+
+This example prevents a save if the user is not authorized:
+
+```ruby
+class JSONAPI::Resource
+
+  def before_save(context)
+    raise NotAuthorizedError unless authorized?(context[:current_user])
+  end
+end
+
+```
+
 ##### Sortable Attributes
 
 JR supports [sorting primary resources by multiple sort criteria](http://jsonapi.org/format/#fetching-sorting).

--- a/lib/jsonapi/operation.rb
+++ b/lib/jsonapi/operation.rb
@@ -40,7 +40,7 @@ module JSONAPI
 
     def apply(context)
       resource = @resource_klass.find_by_key(@resource_id, context: context)
-      resource.remove
+      resource.remove(context)
 
       return JSONAPI::OperationResult.new(:no_content)
 

--- a/lib/jsonapi/operation.rb
+++ b/lib/jsonapi/operation.rb
@@ -22,7 +22,7 @@ module JSONAPI
     def apply(context)
       resource = @resource_klass.create(context)
       resource.replace_fields(@values)
-      resource.save
+      resource.save(context)
 
       return JSONAPI::OperationResult.new(:created, resource)
 
@@ -64,7 +64,7 @@ module JSONAPI
     def apply(context)
       resource = @resource_klass.find_by_key(@resource_id, context: context)
       resource.replace_fields(values)
-      resource.save
+      resource.save(context)
 
       return JSONAPI::OperationResult.new(:ok, resource)
     end
@@ -83,7 +83,7 @@ module JSONAPI
     def apply(context)
       resource = @resource_klass.find_by_key(@resource_id, context: context)
       resource.create_has_one_link(@association_type, @key_value)
-      resource.save
+      resource.save(context)
 
       return JSONAPI::OperationResult.new(:no_content)
     end
@@ -102,7 +102,7 @@ module JSONAPI
     def apply(context)
       resource = @resource_klass.find_by_key(@resource_id, context: context)
       resource.replace_has_one_link(@association_type, @key_value)
-      resource.save
+      resource.save(context)
 
       return JSONAPI::OperationResult.new(:no_content)
     end
@@ -141,7 +141,7 @@ module JSONAPI
     def apply(context)
       resource = @resource_klass.find_by_key(@resource_id, context: context)
       resource.replace_has_many_links(@association_type, @key_values)
-      resource.save
+      resource.save(context)
 
       return JSONAPI::OperationResult.new(:no_content)
     end
@@ -180,7 +180,7 @@ module JSONAPI
     def apply(context)
       resource = @resource_klass.find_by_key(@resource_id, context: context)
       resource.remove_has_one_link(@association_type)
-      resource.save
+      resource.save(context)
 
       return JSONAPI::OperationResult.new(:no_content)
     end

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -16,7 +16,8 @@ module JSONAPI
       @context = context
     end
 
-    def remove
+    def remove(context = nil)
+      before_save(context)
       @model.destroy
     end
 

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -97,10 +97,15 @@ module JSONAPI
       end if field_data[:has_many]
     end
 
-    def save
+    def save(context = nil)
+      before_save(context)
       @model.save!
     rescue ActiveRecord::RecordInvalid => e
       raise JSONAPI::Exceptions::ValidationErrors.new(e.record.errors.messages)
+    end
+
+    def before_save(context)
+      # noop
     end
 
     # Override this on a resource instance to override the fetchable keys

--- a/lib/jsonapi/resource_controller.rb
+++ b/lib/jsonapi/resource_controller.rb
@@ -16,13 +16,19 @@ module JSONAPI
     before_filter :setup_request
 
     def index
-      render json: JSONAPI::ResourceSerializer.new(resource_klass).serialize_to_hash(
-          resource_klass.find(resource_klass.verify_filters(@request.filters, context),
-            context: context, sort_params: @request.sort_params),
-          include: @request.include,
-          fields: @request.fields,
-          attribute_formatters: attribute_formatters,
-          key_formatter: key_formatter)
+      serializer = JSONAPI::ResourceSerializer.new(resource_klass)
+      resources = resource_klass.find(
+        resource_klass.verify_filters(@request.filters, context),
+        context: context, sort_params: @request.sort_params
+      )
+      serialized = serializer.serialize_to_hash(
+        resources,
+        include: @request.include,
+        fields: @request.fields,
+        attribute_formatters: attribute_formatters,
+        key_formatter: key_formatter
+      )
+      render json: serialized
     rescue => e
       handle_exceptions(e)
     end

--- a/test/unit/operation/operations_processor_test.rb
+++ b/test/unit/operation/operations_processor_test.rb
@@ -42,7 +42,7 @@ class OperationsProcessorTest < MiniTest::Unit::TestCase
 
     operation = JSONAPI::CreateResourceOperation.new(PlanetResource, {attributes: {'name' => 'earth', 'description' => 'The best planet ever.'}})
 
-    PlanetResource.send(:define_method, :before_save, -> (context) { raise JSONAPI::Operation::AuthorizeError })
+    PlanetResource.send(:define_method, :before_save, lambda { |context| raise JSONAPI::Operation::AuthorizeError })
 
     request = JSONAPI::Request.new
     request.operations = [operation]

--- a/test/unit/operation/operations_processor_test.rb
+++ b/test/unit/operation/operations_processor_test.rb
@@ -5,6 +5,8 @@ require 'jsonapi/operation'
 require 'jsonapi/operation_result'
 require 'jsonapi/operations_processor'
 
+class JSONAPI::Operation::AuthorizeError < StandardError; end
+
 class OperationsProcessorTest < MiniTest::Unit::TestCase
   def setup
     betax = Planet.find(5)
@@ -32,6 +34,24 @@ class OperationsProcessorTest < MiniTest::Unit::TestCase
     assert_equal(:created, results[0].code)
     assert_equal(results.size, 1)
     assert_equal(Planet.count, count + 1)
+  end
+
+  def test_create_single_resource_with_before_save_exception
+    op = JSONAPI::OperationsProcessor.new()
+    count = Planet.count
+
+    operation = JSONAPI::CreateResourceOperation.new(PlanetResource, {attributes: {'name' => 'earth', 'description' => 'The best planet ever.'}})
+
+    PlanetResource.send(:define_method, :before_save, -> (context) { raise JSONAPI::Operation::AuthorizeError })
+
+    request = JSONAPI::Request.new
+    request.operations = [operation]
+    begin
+      results = op.process(request)
+    rescue JSONAPI::Operation::AuthorizeError
+    end
+    assert_equal(Planet.count, count)
+    PlanetResource.send(:define_method, :before_save, -> (context) { true })
   end
 
   def test_create_multiple_resources
@@ -63,7 +83,6 @@ class OperationsProcessorTest < MiniTest::Unit::TestCase
     planetoid = PlanetType.find(2)
     assert_equal(saturn.planet_type_id, planetoid.id)
 
-
     operations = [
       JSONAPI::ReplaceHasOneAssociationOperation.new(PlanetResource, saturn.id, :planet_type, gas_giant.id)
     ]
@@ -71,14 +90,19 @@ class OperationsProcessorTest < MiniTest::Unit::TestCase
     request = JSONAPI::Request.new
     request.operations = operations
 
-    results = op.process(request)
+    Planet.transaction do
+      results = op.process(request)
 
-    assert_kind_of(Array, results)
-    assert_kind_of(JSONAPI::OperationResult, results[0])
-    assert_equal(:no_content, results[0].code)
+      assert_kind_of(Array, results)
+      assert_kind_of(JSONAPI::OperationResult, results[0])
+      assert_equal(:no_content, results[0].code)
 
+      saturn.reload
+      assert_equal(saturn.planet_type_id, gas_giant.id)
+      raise ActiveRecord::Rollback
+    end
     saturn.reload
-    assert_equal(saturn.planet_type_id, gas_giant.id)
+    assert_equal(saturn.planet_type_id, planetoid.id)
   end
 
   def test_create_has_many_association
@@ -92,26 +116,29 @@ class OperationsProcessorTest < MiniTest::Unit::TestCase
     betax.planet_type_id = unknown.id
     betay.planet_type_id = unknown.id
     betaz.planet_type_id = unknown.id
-    betax.save!
-    betay.save!
-    betaz.save!
+    Planet.transaction do
+      betax.save!
+      betay.save!
+      betaz.save!
 
-    operations = [
-      JSONAPI::CreateHasManyAssociationOperation.new(PlanetTypeResource, gas_giant.id, :planets, [betax.id, betay.id, betaz.id])
-    ]
+      operations = [
+        JSONAPI::CreateHasManyAssociationOperation.new(PlanetTypeResource, gas_giant.id, :planets, [betax.id, betay.id, betaz.id])
+      ]
 
-    request = JSONAPI::Request.new
-    request.operations = operations
+      request = JSONAPI::Request.new
+      request.operations = operations
 
-    results = op.process(request)
+      results = op.process(request)
 
-    betax.reload
-    betay.reload
-    betaz.reload
+      betax.reload
+      betay.reload
+      betaz.reload
 
-    assert_equal(betax.planet_type_id, gas_giant.id)
-    assert_equal(betay.planet_type_id, gas_giant.id)
-    assert_equal(betaz.planet_type_id, gas_giant.id)
+      assert_equal(betax.planet_type_id, gas_giant.id)
+      assert_equal(betay.planet_type_id, gas_giant.id)
+      assert_equal(betaz.planet_type_id, gas_giant.id)
+      raise ActiveRecord::Rollback
+    end
   end
 
   def test_replace_has_many_association
@@ -125,26 +152,29 @@ class OperationsProcessorTest < MiniTest::Unit::TestCase
     betax.planet_type_id = unknown.id
     betay.planet_type_id = unknown.id
     betaz.planet_type_id = unknown.id
-    betax.save!
-    betay.save!
-    betaz.save!
+    Planet.transaction do
+      betax.save!
+      betay.save!
+      betaz.save!
 
-    operations = [
-      JSONAPI::ReplaceHasManyAssociationOperation.new(PlanetTypeResource, gas_giant.id, :planets, [betax.id, betay.id, betaz.id])
-    ]
+      operations = [
+        JSONAPI::ReplaceHasManyAssociationOperation.new(PlanetTypeResource, gas_giant.id, :planets, [betax.id, betay.id, betaz.id])
+      ]
 
-    request = JSONAPI::Request.new
-    request.operations = operations
+      request = JSONAPI::Request.new
+      request.operations = operations
 
-    results = op.process(request)
+      results = op.process(request)
 
-    betax.reload
-    betay.reload
-    betaz.reload
+      betax.reload
+      betay.reload
+      betaz.reload
 
-    assert_equal(betax.planet_type_id, gas_giant.id)
-    assert_equal(betay.planet_type_id, gas_giant.id)
-    assert_equal(betaz.planet_type_id, gas_giant.id)
+      assert_equal(betax.planet_type_id, gas_giant.id)
+      assert_equal(betay.planet_type_id, gas_giant.id)
+      assert_equal(betaz.planet_type_id, gas_giant.id)
+      raise ActiveRecord::Rollback
+    end
   end
 
   def test_replace_attributes
@@ -161,19 +191,22 @@ class OperationsProcessorTest < MiniTest::Unit::TestCase
     request = JSONAPI::Request.new
     request.operations = operations
 
-    results = op.process(request)
+    Planet.transaction do
+      results = op.process(request)
 
-    assert_kind_of(Array, results)
-    assert_equal(results.size, 1)
+      assert_kind_of(Array, results)
+      assert_equal(results.size, 1)
 
-    assert_kind_of(JSONAPI::OperationResult, results[0])
-    assert_equal(:ok, results[0].code)
+      assert_kind_of(JSONAPI::OperationResult, results[0])
+      assert_equal(:ok, results[0].code)
 
-    saturn = Planet.find(1)
+      saturn = Planet.find(1)
 
-    assert_equal(saturn.name, 'saturn')
+      assert_equal(saturn.name, 'saturn')
 
-    assert_equal(Planet.count, count)
+      assert_equal(Planet.count, count)
+      raise ActiveRecord::Rollback
+    end
   end
 
   def test_remove_resource
@@ -189,15 +222,17 @@ class OperationsProcessorTest < MiniTest::Unit::TestCase
 
     request = JSONAPI::Request.new
     request.operations = operations
+    Planet.transaction do
+      results = op.process(request)
 
-    results = op.process(request)
+      assert_kind_of(Array, results)
+      assert_equal(results.size, 1)
 
-    assert_kind_of(Array, results)
-    assert_equal(results.size, 1)
-
-    assert_kind_of(JSONAPI::OperationResult, results[0])
-    assert_equal(:no_content, results[0].code)
-    assert_equal(Planet.count, count - 1)
+      assert_kind_of(JSONAPI::OperationResult, results[0])
+      assert_equal(:no_content, results[0].code)
+      assert_equal(Planet.count, count - 1)
+      raise ActiveRecord::Rollback
+    end
   end
 
   def test_rollback_from_error

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -79,7 +79,7 @@ class ResourceTest < MiniTest::Unit::TestCase
     end
   end
 
-  def test_save_with_before_save_returning_false
+  def test_save_with_before_save_exception
     author = Person.new
     resource = PersonResource.new(author)
     resource.define_singleton_method :before_save do |context|
@@ -87,6 +87,17 @@ class ResourceTest < MiniTest::Unit::TestCase
     end
     assert_raises JSONAPI::Resource::BeforeSaveError do
       resource.save
+    end
+  end
+
+  def test_remove_with_before_save_exception
+    author = Person.new
+    resource = PersonResource.new(author)
+    resource.define_singleton_method :before_save do |context|
+      raise JSONAPI::Resource::BeforeSaveError
+    end
+    assert_raises JSONAPI::Resource::BeforeSaveError do
+      resource.remove
     end
   end
 

--- a/test/unit/serializer/serializer_test.rb
+++ b/test/unit/serializer/serializer_test.rb
@@ -595,7 +595,7 @@ class SerializerTest < MiniTest::Unit::TestCase
                     name: 'Beta X',
                     description: 'Newly discovered Planet Z',
                     links: {
-                      planetType: '1',
+                      planetType: '5',
                       tags: [],
                       moons: []
                     }
@@ -612,7 +612,7 @@ class SerializerTest < MiniTest::Unit::TestCase
                   }],
         linked: {
           planetTypes: [
-            { id: '1', name: "Gas Giant" }
+            { id: '5', name: "unknown" }
           ]
         }
       }, planet_hash)


### PR DESCRIPTION
To address https://github.com/cerebris/jsonapi-resources/issues/62 I implemented a `before_save` callback on the `JSONAPI::Resource` class. I could imagine other implementation approaches, but this seemed pretty good.

The rest of the changes deal with test suite brittleness that I encountered along the way.
