### PR TITLE
fix: change exception rescued in _save to match Rails API

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -117,7 +117,7 @@ module JSONAPI
     def _save
       @model.save!
       @save_needed = false
-    rescue ActiveRecord::RecordInvalid => e
+    rescue ActiveRecord::RecordNotSaved => e
       raise JSONAPI::Exceptions::ValidationErrors.new(e.record.errors.messages)
     end
 


### PR DESCRIPTION
from rails source, we see that save! method raises a different exception than is being rescued by the _save method:

``` ruby
def save!(*)
  create_or_update || raise(RecordNotSaved.new(nil, self))
end
```

I think that we should rescue this exception, as it complies with the rails API more. In particular, code I am using is dependent on that.
https://github.com/rails/rails/blob/5142d5411481c893f817c1431b0869be3745060f/activerecord/lib/active_record/persistence.rb#L141
