### PR TITLE
Specify the correct Content-Type in the response headers

### DIFF
--- a/lib/jsonapi/resource_controller.rb
+++ b/lib/jsonapi/resource_controller.rb
@@ -15,7 +15,7 @@ module JSONAPI
 
     before_filter :ensure_correct_media_type, only: [:create, :update, :create_association, :update_association]
     before_filter :setup_request
-    before_filter :setup_response, only: [:index, :show, :create, :update, :create_association, :update_association]
+    after_filter :setup_response
 
     def index
       render json: JSONAPI::ResourceSerializer.new(resource_klass).serialize_to_hash(
@@ -132,7 +132,9 @@ module JSONAPI
     end
 
     def setup_response
-      response.headers['Content-Type'] = JSONAPI::MEDIA_TYPE
+      if response.body.size > 0
+        response.headers['Content-Type'] = JSONAPI::MEDIA_TYPE
+      end
     end
 
     def parse_key_array(raw)

--- a/lib/jsonapi/resource_controller.rb
+++ b/lib/jsonapi/resource_controller.rb
@@ -15,6 +15,7 @@ module JSONAPI
 
     before_filter :ensure_correct_media_type, only: [:create, :update, :create_association, :update_association]
     before_filter :setup_request
+    before_filter :setup_response, only: [:index, :show, :create, :update, :create_association, :update_association]
 
     def index
       render json: JSONAPI::ResourceSerializer.new(resource_klass).serialize_to_hash(
@@ -128,6 +129,10 @@ module JSONAPI
       # :nocov:
       handle_exceptions(e)
       # :nocov:
+    end
+
+    def setup_response
+      response.headers['Content-Type'] = JSONAPI::MEDIA_TYPE
     end
 
     def parse_key_array(raw)

--- a/test/integration/requests/request_test.rb
+++ b/test/integration/requests/request_test.rb
@@ -160,6 +160,7 @@ class RequestTest < ActionDispatch::IntegrationTest
   def test_destroy_single
     delete '/posts/7'
     assert_equal 204, status
+    assert_nil headers['Content-Type']
   end
 
   def test_destroy_multiple

--- a/test/integration/requests/request_test.rb
+++ b/test/integration/requests/request_test.rb
@@ -118,6 +118,45 @@ class RequestTest < ActionDispatch::IntegrationTest
     assert_equal 204, status
   end
 
+  def test_index_content_type
+    get '/posts'
+    assert_match JSONAPI::MEDIA_TYPE, headers['Content-Type']
+  end
+
+  def test_get_content_type
+    get '/posts/3'
+    assert_match JSONAPI::MEDIA_TYPE, headers['Content-Type']
+  end
+
+  def test_put_content_type
+    put '/posts/3',
+        {
+          'posts' => {
+            'id' => '3',
+            'title' => 'A great new Post',
+            'links' => {
+              'tags' => [3, 4]
+            }
+          }
+        }.to_json, "CONTENT_TYPE" => JSONAPI::MEDIA_TYPE
+
+    assert_match JSONAPI::MEDIA_TYPE, headers['Content-Type']
+  end
+
+  def test_post_correct_content_type
+    post '/posts',
+      {
+       'posts' => {
+         'title' => 'A great new Post',
+         'links' => {
+           'author' => '3'
+         }
+       }
+     }.to_json, "CONTENT_TYPE" => JSONAPI::MEDIA_TYPE
+
+    assert_match JSONAPI::MEDIA_TYPE, headers['Content-Type']
+  end
+
   def test_destroy_single
     delete '/posts/7'
     assert_equal 204, status


### PR DESCRIPTION
Currently, all response headers generated by `ResourceController` instances specify the `application/json` Content-Type header. While not explicitly declared in the spec, the examples imply that that all responses with payloads should specify the `application/vnd.api+json` Content-Type response header.

Expect result:

All `ResourceController` responses with data should include the `application/vnd.api+json` Content-Type header.
