### PR TITLE
Remove id from params unless in the createable_fields

### DIFF
--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -266,6 +266,7 @@ module JSONAPI
       #   end
       #   params.delete(:links)
       # end
+
       verify_permitted_params(params, allowed_fields)
 
       checked_attributes = {}
@@ -340,7 +341,6 @@ module JSONAPI
     def verify_permitted_params(params, allowed_fields)
       formatted_allowed_fields = allowed_fields.collect { |field| format_key(field).to_sym }
       params_not_allowed = []
-
       params.each do |key, value|
         if key == 'links' || key == :links
           value.each_key do |links_key|

--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -266,7 +266,7 @@ module JSONAPI
       #   end
       #   params.delete(:links)
       # end
-
+      params.delete(:id)
       verify_permitted_params(params, allowed_fields)
 
       checked_attributes = {}
@@ -341,6 +341,7 @@ module JSONAPI
     def verify_permitted_params(params, allowed_fields)
       formatted_allowed_fields = allowed_fields.collect { |field| format_key(field).to_sym }
       params_not_allowed = []
+
       params.each do |key, value|
         if key == 'links' || key == :links
           value.each_key do |links_key|

--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -266,7 +266,6 @@ module JSONAPI
       #   end
       #   params.delete(:links)
       # end
-      params.delete(:id)
       verify_permitted_params(params, allowed_fields)
 
       checked_attributes = {}
@@ -413,6 +412,10 @@ module JSONAPI
       key = data[@resource_klass._primary_key]
       if !keys.include?(key)
         raise JSONAPI::Exceptions::KeyNotIncludedInURL.new(key)
+      end
+
+      if !keys.include?(@resource_klass._primary_key)
+        data.delete(:id)
       end
 
       @operations.push(JSONAPI::ReplaceFieldsOperation.new(@resource_klass,

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -282,7 +282,7 @@ module JSONAPI
 
       # Override in your resource to filter the updateable keys
       def updateable_fields(context = nil)
-        _updateable_associations | _attributes.keys
+        _updateable_associations | _attributes.keys - [@_primary_key]
       end
 
       # Override in your resource to filter the createable keys

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -196,7 +196,7 @@ module JSONAPI
         type = base.name.demodulize.sub(/Resource$/, '').underscore
         base._type = type.pluralize.to_sym
 
-        attribute :id, format: :id
+        base.attribute :id, format: :id
 
         check_reserved_resource_name(base._type, base.name)
 

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -282,7 +282,7 @@ module JSONAPI
 
       # Override in your resource to filter the updateable keys
       def updateable_fields(context = nil)
-        _updateable_associations | _attributes.keys - [@_primary_key]
+        _updateable_associations | _attributes.keys - [_primary_key]
       end
 
       # Override in your resource to filter the createable keys

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -471,7 +471,7 @@ class PostResource < JSONAPI::Resource
   end
 
   def self.createable_fields(context)
-    super(context) - [:subject, :id]
+    super(context) - [:subject]
   end
 
   def self.sortable_fields(context)

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -467,11 +467,11 @@ class PostResource < JSONAPI::Resource
   filters :id, :ids
 
   def self.updateable_fields(context)
-    super(context) - [:author, :subject]
+    super(context) - [:author, :subject, :id]
   end
 
   def self.createable_fields(context)
-    super(context) - [:subject]
+    super(context) - [:subject, :id]
   end
 
   def self.sortable_fields(context)

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -467,7 +467,7 @@ class PostResource < JSONAPI::Resource
   filters :id, :ids
 
   def self.updateable_fields(context)
-    super(context) - [:author, :subject, :id]
+    super(context) - [:author, :subject]
   end
 
   def self.createable_fields(context)

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -78,6 +78,6 @@ class ResourceTest < MiniTest::Unit::TestCase
   end
 
   def test_updateable_fields_does_not_include_id
-    assert(!ArticleResource.updateable_fields.include?(:id))
+    assert(!CatResource.updateable_fields.include?(:id))
   end
 end

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -76,4 +76,8 @@ class ResourceTest < MiniTest::Unit::TestCase
       ArticleResource.find_by_keys([1, 3], context: author).model
     end
   end
+
+  def test_updateable_fields_does_not_include_id
+    assert(!ArticleResource.updateable_fields.include?(:id))
+  end
 end


### PR DESCRIPTION
This removes `:id` from the params before verification.
