### PR TITLE
Remove support fetching multiple resources by id

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ The system will lookup a value formatter named `DateWithTimezoneValueFormatter` 
 #### Primary Key
 
 Resources are always represented using a key of `id`. If the underlying model does not use `id` as the primary key you can use the `primary_key` method to tell the resource which field on the model to use as the primary key. Note: this doesn't have to be the actual primary key of the model. For example you may wish to use integers internally and a different scheme publicly.
+By default only integer values are allowed for primary key. To change this behavior you can override `verify_key` class method:
 
 ```ruby
 class CurrencyResource < JSONAPI::Resource
@@ -173,8 +174,11 @@ class CurrencyResource < JSONAPI::Resource
   attributes :code, :name
 
   has_many :expense_entries
-end
 
+  def self.verify_key(key, context = nil)
+    key && String(key)
+  end
+end
 ```
 
 #### Model Name
@@ -260,11 +264,11 @@ end
 
 ##### Finders
 
-Basic finding by filters is supported by resources. This is implemented in the `find`, `find_by_key` and `find_by_keys` finder methods. Currently this is implemented for `ActiveRecord` based resources. The finder methods rely on the `records` method to get an `Arel` relation. It is therefore possible to override `records` to affect the three find related methods.
+Basic finding by filters is supported by resources. This is implemented in the `find` and `find_by_key` finder methods. Currently this is implemented for `ActiveRecord` based resources. The finder methods rely on the `records` method to get an `Arel` relation. It is therefore possible to override `records` to affect the three find related methods.
 
 ###### Customizing base records for finder methods
 
-If you need to change the base records on which `find`, `find_by_key` and `find_by_keys` operate, you can override the `records` method on the resource class.
+If you need to change the base records on which `find` and `find_by_key` operate, you can override the `records` method on the resource class.
 
 For example to allow a user to only retrieve his own posts you can do the following:
 
@@ -307,7 +311,7 @@ end
 
 ###### Override finder methods
 
-Finally if you have more complex requirements for finding you can override the `find`, `find_by_key` and `find_by_keys` methods on the resource class.
+Finally if you have more complex requirements for finding you can override the `find` and `find_by_key` methods on the resource class.
 
 Here's an example that defers the `find` operation to a `current_user` set on the `context` option:
 

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -359,20 +359,8 @@ module JSONAPI
         self.new(model, context)
       end
 
-      def find_by_keys(keys, options = {})
-        context = options[:context]
-        _models = records(options).where({_primary_key => keys})
-
-        unless _models.length == keys.length
-          key = (keys - _models.pluck(_primary_key).map(&:to_s)).first
-          raise JSONAPI::Exceptions::RecordNotFound.new(key)
-        end
-
-        _models.map { |model| self.new(model, context) }
-      end
-
       # Override this method if you want to customize the relation for
-      # finder methods (find, find_by_key, find_by_keys)
+      # finder methods (find, find_by_key)
       def records(options = {})
         _model_class
       end
@@ -403,7 +391,9 @@ module JSONAPI
 
       # override to allow for key processing and checking
       def verify_key(key, context = nil)
-        return key
+        key && Integer(key)
+      rescue
+        raise JSONAPI::Exceptions::InvalidFieldValue.new(_primary_key, key)
       end
 
       # override to allow for key processing and checking

--- a/lib/jsonapi/resource_controller.rb
+++ b/lib/jsonapi/resource_controller.rb
@@ -43,15 +43,11 @@ module JSONAPI
                                                    key_formatter: key_formatter,
                                                    route_formatter: route_formatter)
 
-      keys = parse_key_array(params[resource_klass._primary_key])
+      key = resource_klass.verify_key(params[resource_klass._primary_key], context)
 
-      resource_records = if keys.length > 1
-                           resource_klass.find_by_keys(keys, context: context)
-                         else
-                           resource_klass.find_by_key(keys[0], context: context)
-                         end
+      resource_record = resource_klass.find_by_key(key, context: context)
 
-      render json: serializer.serialize_to_hash(resource_records)
+      render json: serializer.serialize_to_hash(resource_record)
     rescue => e
       handle_exceptions(e)
     end
@@ -189,11 +185,6 @@ module JSONAPI
       if response.body.size > 0
         response.headers['Content-Type'] = JSONAPI::MEDIA_TYPE
       end
-    end
-
-    def parse_key_array(raw)
-      keys = raw.nil? || raw.empty? ? [] : raw.split(',')
-      resource_klass.verify_keys(keys, context)
     end
 
     # override to set context

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -1268,23 +1268,26 @@ class TagsControllerTest < ActionController::TestCase
 
   def test_tags_show_multiple
     get :show, {id: '6,7,8,9'}
-    assert_response :success
-    assert json_response['data'].is_a?(Array)
-    assert_equal 4, json_response['data'].size
+    assert_response :bad_request
+    assert_match /6,7,8,9 is not a valid value for id/, response.body
   end
 
   def test_tags_show_multiple_with_include
     get :show, {id: '6,7,8,9', include: 'posts,posts.tags,posts.author.posts'}
-    assert_response :success
-    assert json_response['data'].is_a?(Array)
-    assert_equal 4, json_response['data'].size
-    assert_equal 2, json_response['linked'].size
+    assert_response :bad_request
+    assert_match /6,7,8,9 is not a valid value for id/, response.body
   end
 
   def test_tags_show_multiple_with_nonexistent_ids
     get :show, {id: '6,99,9,100'}
-    assert_response :not_found
-    assert_match /The record identified by 99 could not be found./, json_response['errors'][0]['detail']
+    assert_response :bad_request
+    assert_match /6,99,9,100 is not a valid value for id/, response.body
+  end
+
+  def test_tags_show_multiple_with_nonexistent_ids_at_the_beginning
+    get :show, {id: '99,9,100'}
+    assert_response :bad_request
+    assert_match /99,9,100 is not a valid value for id/, response.body
   end
 end
 
@@ -1641,13 +1644,9 @@ class BreedsControllerTest < ActionController::TestCase
 
   def test_poro_show_multiple
     get :show, {id: '0,2'}
-    assert_response :success
-    assert json_response['data'].is_a?(Array)
-    assert_equal 2, json_response['data'].size
-    assert_equal '0', json_response['data'][0]['id']
-    assert_equal 'Persian', json_response['data'][0]['name']
-    assert_equal '2', json_response['data'][1]['id']
-    assert_equal 'Sphinx', json_response['data'][1]['name']
+
+    assert_response :bad_request
+    assert_match /0,2 is not a valid value for id/, response.body
   end
 
   def test_poro_create_simple

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -529,6 +529,10 @@ class IsoCurrencyResource < JSONAPI::Resource
   attributes :name, :country_name, :minor_unit
 
   filter :country_name
+
+  def self.verify_key(key, context = nil)
+    key && String(key)
+  end
 end
 
 class ExpenseEntryResource < JSONAPI::Resource
@@ -564,10 +568,6 @@ class BreedResource < JSONAPI::Resource
 
   def self.find_by_key(id, options = {})
     BreedResource.new($breed_data.breeds[id.to_i], options[:context])
-  end
-
-  def self.find_by_keys(keys, options = {})
-    keys.map { |key| self.find_by_key(key, options) }
   end
 end
 

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -66,17 +66,6 @@ class ResourceTest < MiniTest::Unit::TestCase
     end
   end
 
-  def test_find_by_keys_with_customized_base_records
-    author = Person.find(1)
-
-    posts = ArticleResource.find_by_keys([1, 2], context: author)
-    assert_equal(posts.length, 2)
-
-    assert_raises JSONAPI::Exceptions::RecordNotFound do
-      ArticleResource.find_by_keys([1, 3], context: author).model
-    end
-  end
-
   def test_updateable_fields_does_not_include_id
     assert(!CatResource.updateable_fields.include?(:id))
   end


### PR DESCRIPTION
This PR resolves https://github.com/cerebris/jsonapi-resources/issues/88

@lgebhardt I have doubts about assertions of some tests.
For example, the test `test_tags_show_multiple_with_include` returns `200` only because of such behavior of `ActiveRecord` finder methods. 
