### PR TITLE
Allow `{"data":null}` to clear has-one relationship

### DIFF
--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -55,7 +55,7 @@ module JSONAPI
                                             params.require(:association),
                                             params.require(@resource_klass._as_parent_key))
           when 'update_association'
-            parse_update_association_operation(params.require(:data),
+            parse_update_association_operation(params.fetch(:data),
                                                params.require(:association),
                                                params.require(@resource_klass._as_parent_key))
           when 'update'

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -627,7 +627,7 @@ class PostsControllerTest < ActionController::TestCase
 
   def test_update_relationship_has_one_invalid_links_hash_keys_ids
     set_content_type_header!
-    put :update_association, {post_id: 3, association: 'section', data: {types: 'sections', ids: 'foo'}}
+    put :update_association, {post_id: 3, association: 'section', data: {type: 'sections', ids: 'foo'}}
 
     assert_response :bad_request
     assert_match /Invalid Links Object/, response.body
@@ -635,7 +635,7 @@ class PostsControllerTest < ActionController::TestCase
 
   def test_update_relationship_has_one_invalid_links_hash_count
     set_content_type_header!
-    put :update_association, {post_id: 3, association: 'section', data: {types: 'sections'}}
+    put :update_association, {post_id: 3, association: 'section', data: {type: 'sections'}}
 
     assert_response :bad_request
     assert_match /Invalid Links Object/, response.body
@@ -707,14 +707,26 @@ class PostsControllerTest < ActionController::TestCase
     set_content_type_header!
     ruby = Section.find_by(name: 'ruby')
     post_object = Post.find(3)
-    post_object.section_id = ruby.id
+    post_object.section = ruby
     post_object.save!
 
     put :update_association, {post_id: 3, association: 'section', data: {type: 'sections', id: nil}}
 
     assert_response :no_content
+    assert_equal nil, post_object.reload.section_id
+  end
+
+  def test_update_relationship_has_one_data_nil
+    set_content_type_header!
+    ruby = Section.find_by(name: 'ruby')
     post_object = Post.find(3)
-    assert_equal nil, post_object.section_id
+    post_object.section = ruby
+    post_object.save!
+
+    put :update_association, {post_id: 3, association: 'section', data: nil}
+
+    assert_response :no_content
+    assert_equal nil, post_object.reload.section_id
   end
 
   def test_remove_relationship_has_one

--- a/test/unit/operation/operations_processor_test.rb
+++ b/test/unit/operation/operations_processor_test.rb
@@ -129,6 +129,18 @@ class OperationsProcessorTest < MiniTest::Unit::TestCase
     saturn.reload
     assert_equal(saturn.planet_type_id, gas_giant.id)
 
+    # Remove link
+    operations = [
+      JSONAPI::ReplaceHasOneAssociationOperation.new(PlanetResource, saturn.id, :planet_type, nil)
+    ]
+
+    request = JSONAPI::Request.new
+    request.operations = operations
+
+    results = op.process(request)
+    saturn.reload
+    assert_equal(saturn.planet_type_id, nil)
+
     # Reset
     operations = [
       JSONAPI::ReplaceHasOneAssociationOperation.new(PlanetResource, saturn.id, :planet_type, 5)


### PR DESCRIPTION
This PR resolves https://github.com/cerebris/jsonapi-resources/issues/84
