### PR TITLE
Update README to mention where to find client libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ JR is designed to work with Rails, and provides custom routes, controllers, and 
 
 We have a simple demo app, called [Peeps](https://github.com/cerebris/peeps), available to show how JR is used.
 
+## Client Libraries
+
+Any libraries listed on [JSONAPI Examples](http://jsonapi.org/examples/) should be compatible with this jsonapi-resources. For Ruby/Rails, [jsonapi_consumer](https://github.com/jsmestad/jsonapi_consumer) is a good place to start.
+
 ## Installation
 
 Add JR to your application's `Gemfile`:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ We have a simple demo app, called [Peeps](https://github.com/cerebris/peeps), av
 
 ## Client Libraries
 
-Any libraries listed on [JSONAPI Examples](http://jsonapi.org/examples/) should be compatible with this jsonapi-resources. For Ruby/Rails, [jsonapi_consumer](https://github.com/jsmestad/jsonapi-consumer) is a good place to start.
+Any libraries listed on [JSONAPI Examples](http://jsonapi.org/examples/) should be compatible with this jsonapi-resources.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ We have a simple demo app, called [Peeps](https://github.com/cerebris/peeps), av
 
 ## Client Libraries
 
-Any libraries listed on [JSONAPI Examples](http://jsonapi.org/examples/) should be compatible with this jsonapi-resources. For Ruby/Rails, [jsonapi_consumer](https://github.com/jsmestad/jsonapi_consumer) is a good place to start.
+Any libraries listed on [JSONAPI Examples](http://jsonapi.org/examples/) should be compatible with this jsonapi-resources. For Ruby/Rails, [jsonapi_consumer](https://github.com/jsmestad/jsonapi-consumer) is a good place to start.
 
 ## Installation
 


### PR DESCRIPTION
@lgebhardt  Feel free to kill off the Ruby bit if you feel its not necessary. We use `jsonapi_consumer` to consume the output of this gem so it may be worth calling out? I know personally when starting with `jsonapi-resources`, I was struggling to find a good ruby client to use even for testing.
