### PR TITLE
Fix issue with route names using the association name instead of the class name

### DIFF
--- a/lib/jsonapi/routing_ext.rb
+++ b/lib/jsonapi/routing_ext.rb
@@ -148,7 +148,7 @@ module ActionDispatch
           association = source._associations[association_name]
 
           formatted_association_name = format_route(association.name)
-          related_resource = JSONAPI::Resource.resource_for(resource_type_with_module_prefix(association.name.pluralize))
+          related_resource = JSONAPI::Resource.resource_for(resource_type_with_module_prefix(association.class_name.underscore.pluralize))
 
           match "#{formatted_association_name}", controller: related_resource._type.to_s,
                 association: association.name, source: resource_type_with_module_prefix(source._type),
@@ -162,7 +162,7 @@ module ActionDispatch
           association = source._associations[association_name]
 
           formatted_association_name = format_route(association.name)
-          related_resource = JSONAPI::Resource.resource_for(resource_type_with_module_prefix(association.name))
+          related_resource = JSONAPI::Resource.resource_for(resource_type_with_module_prefix(association.class_name.underscore))
 
           match "#{formatted_association_name}", controller: related_resource._type.to_s,
                 association: association.name, source: resource_type_with_module_prefix(source._type),

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -1601,7 +1601,7 @@ class PeopleControllerTest < ActionController::TestCase
   end
 end
 
-class AuthorsControllerTest < ActionController::TestCase
+class Api::V5::AuthorsControllerTest < ActionController::TestCase
   def test_get_person_as_author
     get :index, {filter: {id: '1'}}
     assert_response :success

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -361,6 +361,9 @@ module Api
   end
 
   module V5
+    class AuthorsController < JSONAPI::ResourceController
+    end
+
     class PostsController < JSONAPI::ResourceController
     end
 
@@ -392,29 +395,6 @@ class PersonResource < JSONAPI::Resource
         end
     end
     return filter, values
-  end
-end
-
-class AuthorResource < JSONAPI::Resource
-  attributes :name, :email
-  model_name 'Person'
-  has_many :posts
-
-  filter :name
-
-  def self.find(filters, options = {})
-    resources = []
-
-    filters.each do |attr, filter|
-      _model_class.where("\"#{attr}\" LIKE \"%#{filter[0]}%\"").each do |model|
-        resources.push self.new(model, options[:context])
-      end
-    end
-    return resources
-  end
-
-  def fetchable_fields
-    super - [:email]
   end
 end
 
@@ -602,7 +582,7 @@ end
 class PreferencesResource < JSONAPI::Resource
   attribute :advanced_mode
 
-  has_one :author, foreign_key: :person_id
+  has_one :author, foreign_key: :person_id, class_name: 'Person'
   has_many :friends, class_name: 'Person'
 
   def self.find_by_key(key, options = {})
@@ -652,7 +632,7 @@ module Api
       filters :writer
     end
 
-    AuthorResource = AuthorResource.dup
+    # AuthorResource = AuthorResource.dup
     PersonResource = PersonResource.dup
     CommentResource = CommentResource.dup
     TagResource = TagResource.dup
@@ -672,7 +652,7 @@ end
 module Api
   module V2
     PreferencesResource = PreferencesResource.dup
-    AuthorResource = AuthorResource.dup
+    # AuthorResource = AuthorResource.dup
     PersonResource = PersonResource.dup
     PostResource = PostResource.dup
 
@@ -712,7 +692,30 @@ end
 
 module Api
   module V5
-    AuthorResource = AuthorResource.dup
+    class AuthorResource < JSONAPI::Resource
+      attributes :name, :email
+      model_name 'Person'
+      has_many :posts
+
+      filter :name
+
+      def self.find(filters, options = {})
+        resources = []
+
+        filters.each do |attr, filter|
+          _model_class.where("\"#{attr}\" LIKE \"%#{filter[0]}%\"").each do |model|
+            resources.push self.new(model, options[:context])
+          end
+        end
+        return resources
+      end
+
+      def fetchable_fields
+        super - [:email]
+      end
+    end
+
+    PersonResource = PersonResource.dup
     PostResource = PostResource.dup
     ExpenseEntryResource = ExpenseEntryResource.dup
     IsoCurrencyResource = IsoCurrencyResource.dup

--- a/test/integration/routes/routes_test.rb
+++ b/test/integration/routes/routes_test.rb
@@ -69,11 +69,6 @@ class RoutesTest < ActionDispatch::IntegrationTest
   end
 
   # V2
-  # def test_routing_v2_posts_show
-  #   assert_routing({path: '/api/v2/authors/1', method: :get},
-  #                  {action: 'show', controller: 'api/v2/authors', id: '1'})
-  # end
-
   def test_routing_v2_posts_links_author_show
     assert_routing({path: '/api/v2/posts/1/links/author', method: :get},
                    {controller: 'api/v2/posts', action: 'show_association', post_id: '1', association: 'author'})

--- a/test/integration/routes/routes_test.rb
+++ b/test/integration/routes/routes_test.rb
@@ -52,22 +52,6 @@ class RoutesTest < ActionDispatch::IntegrationTest
                    {controller: 'posts', action: 'update_association', post_id: '1', association: 'tags'})
   end
 
-  def test_routing_authors_show
-    assert_routing({path: '/authors/1', method: :get},
-                   {action: 'show', controller: 'authors', id: '1'})
-  end
-
-  def test_routing_author_links_posts_create_not_acts_as_set
-    assert_routing({path: '/authors/1/links/posts', method: :post},
-                   {controller: 'authors', action: 'create_association', author_id: '1', association: 'posts'})
-  end
-
-  # ToDo: Test that non acts as set has_many association update route is not created
-  # def test_routing_author_links_posts_update_not_acts_as_set
-  #   refute_routing({ path: '/authors/1/links/posts', method: :put },
-  #                  { controller: 'authors', action: 'update_association', author_id: '1', association: 'posts' })
-  # end
-
   # V1
   def test_routing_v1_posts_show
     assert_routing({path: '/api/v1/posts/1', method: :get},
@@ -85,10 +69,10 @@ class RoutesTest < ActionDispatch::IntegrationTest
   end
 
   # V2
-  def test_routing_v2_posts_show
-    assert_routing({path: '/api/v2/authors/1', method: :get},
-                   {action: 'show', controller: 'api/v2/authors', id: '1'})
-  end
+  # def test_routing_v2_posts_show
+  #   assert_routing({path: '/api/v2/authors/1', method: :get},
+  #                  {action: 'show', controller: 'api/v2/authors', id: '1'})
+  # end
 
   def test_routing_v2_posts_links_author_show
     assert_routing({path: '/api/v2/posts/1/links/author', method: :get},
@@ -142,6 +126,16 @@ class RoutesTest < ActionDispatch::IntegrationTest
 
     assert_routing({path: '/api/v5/expense-entries/1/links/iso-currency', method: :get},
                    {controller: 'api/v5/expense_entries', action: 'show_association', expense_entry_id: '1', association: 'iso_currency'})
+  end
+
+  def test_routing_authors_show
+    assert_routing({path: '/api/v5/authors/1', method: :get},
+                   {action: 'show', controller: 'api/v5/authors', id: '1'})
+  end
+
+  def test_routing_author_links_posts_create_not_acts_as_set
+    assert_routing({path: '/api/v5/authors/1/links/posts', method: :post},
+                   {controller: 'api/v5/authors', action: 'create_association', author_id: '1', association: 'posts'})
   end
 
   #primary_key

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -45,7 +45,6 @@ TestApp.initialize!
 require File.expand_path('../fixtures/active_record', __FILE__)
 JSONAPI.configuration.route_format = :underscored_route
 TestApp.routes.draw do
-  jsonapi_resources :authors
   jsonapi_resources :people
   jsonapi_resources :comments
   jsonapi_resources :tags
@@ -62,7 +61,6 @@ TestApp.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      jsonapi_resources :authors
       jsonapi_resources :people
       jsonapi_resources :comments
       jsonapi_resources :tags
@@ -80,9 +78,6 @@ TestApp.routes.draw do
 
     JSONAPI.configuration.route_format = :underscored_route
     namespace :v2 do
-      jsonapi_resources :authors do
-      end
-
       jsonapi_resources :posts do
         jsonapi_link :author, except: [:destroy]
       end
@@ -123,6 +118,7 @@ TestApp.routes.draw do
       jsonapi_resources :posts do
       end
 
+      jsonapi_resources :authors
       jsonapi_resources :expense_entries
       jsonapi_resources :iso_currencies
 

--- a/test/unit/serializer/serializer_test.rb
+++ b/test/unit/serializer/serializer_test.rb
@@ -1127,7 +1127,7 @@ class SerializerTest < MiniTest::Unit::TestCase
             author: {
               self: '/preferences/1/links/author',
               resource: '/preferences/1/author',
-              type: 'authors',
+              type: 'people',
               id: nil
             },
             friends: {


### PR DESCRIPTION
Routes were being created using resources based on the association name, instead of the class name for the association. This broke associations that used a different class name from the association name, for example the post.author association references the people resource, not the author resource.
