### PR TITLE
Add PATCH support to updating association

### DIFF
--- a/lib/jsonapi/routing_ext.rb
+++ b/lib/jsonapi/routing_ext.rb
@@ -102,7 +102,7 @@ module ActionDispatch
 
           if methods.include?(:update)
             match "links/#{formatted_association_name}", controller: res._type.to_s,
-                  action: 'update_association', association: link_type.to_s, via: [:put]
+                  action: 'update_association', association: link_type.to_s, via: [:put, :patch]
           end
 
           if methods.include?(:destroy)
@@ -132,7 +132,7 @@ module ActionDispatch
 
           if methods.include?(:update) && res._association(link_type).acts_as_set
             match "links/#{formatted_association_name}", controller: res._type.to_s,
-                  action: 'update_association', association: link_type.to_s, via: [:put]
+                  action: 'update_association', association: link_type.to_s, via: [:put, :patch]
           end
 
           if methods.include?(:destroy)

--- a/test/integration/requests/request_test.rb
+++ b/test/integration/requests/request_test.rb
@@ -139,12 +139,19 @@ class RequestTest < ActionDispatch::IntegrationTest
 
   def test_update_association_without_content_type
     ruby = Section.find_by(name: 'ruby')
-    put '/posts/3/links/section', { 'sections' => {type: 'sections', id: ruby.id.to_s }}.to_json
+    patch '/posts/3/links/section', { 'sections' => {type: 'sections', id: ruby.id.to_s }}.to_json
 
     assert_equal 415, status
   end
 
-  def test_update_association_has_one
+  def test_patch_update_association_has_one
+    ruby = Section.find_by(name: 'ruby')
+    patch '/posts/3/links/section', { 'data' => {type: 'sections', id: ruby.id.to_s }}.to_json, "CONTENT_TYPE" => JSONAPI::MEDIA_TYPE
+
+    assert_equal 204, status
+  end
+
+  def test_put_update_association_has_one
     ruby = Section.find_by(name: 'ruby')
     put '/posts/3/links/section', { 'data' => {type: 'sections', id: ruby.id.to_s }}.to_json, "CONTENT_TYPE" => JSONAPI::MEDIA_TYPE
 
@@ -163,6 +170,22 @@ class RequestTest < ActionDispatch::IntegrationTest
 
   def test_put_content_type
     put '/posts/3',
+        {
+          'data' => {
+            'type' => 'posts',
+            'id' => '3',
+            'title' => 'A great new Post',
+            'links' => {
+              'tags' => {type: 'tags', ids: [3, 4]}
+            }
+          }
+        }.to_json, "CONTENT_TYPE" => JSONAPI::MEDIA_TYPE
+
+    assert_match JSONAPI::MEDIA_TYPE, headers['Content-Type']
+  end
+
+  def test_patch_content_type
+    patch '/posts/3',
         {
           'data' => {
             'type' => 'posts',

--- a/test/integration/routes/routes_test.rb
+++ b/test/integration/routes/routes_test.rb
@@ -7,8 +7,8 @@ class RoutesTest < ActionDispatch::IntegrationTest
                    {controller: 'posts', action: 'create'})
   end
 
-  def test_routing_put
-    assert_routing({path: '/posts/1', method: :put},
+  def test_routing_patch
+    assert_routing({path: '/posts/1', method: :patch},
                    {controller: 'posts', action: 'update', id: '1'})
   end
 
@@ -28,7 +28,7 @@ class RoutesTest < ActionDispatch::IntegrationTest
   end
 
   def test_routing_posts_links_author_update
-    assert_routing({path: '/posts/1/links/author', method: :put},
+    assert_routing({path: '/posts/1/links/author', method: :patch},
                    {controller: 'posts', action: 'update_association', post_id: '1', association: 'author'})
   end
 
@@ -48,7 +48,7 @@ class RoutesTest < ActionDispatch::IntegrationTest
   end
 
   def test_routing_posts_links_tags_update_acts_as_set
-    assert_routing({path: '/posts/1/links/tags', method: :put},
+    assert_routing({path: '/posts/1/links/tags', method: :patch},
                    {controller: 'posts', action: 'update_association', post_id: '1', association: 'tags'})
   end
 


### PR DESCRIPTION
Adds PATCH support to updating associations.
  Leaving PUT support in place for updating a resource.
  Adding tests to ensure PATCH is supported for updating.

Fixes #103
