### PR TITLE
Add associated_records method to enable override.

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,13 +283,29 @@ class PostResource < JSONAPI::Resource
 end
 ```
 
-You can also customize how associated records are found by overriding the `associated_records` method in the resource class.
-
-For example, raise an error if the user is not authorized to view the association records.
+When you create a relationship, a method is created to fetch record(s) for that relationship. This method calls `records_for(association_name)` by default.
 
 ```ruby
 class PostResource < JSONAPI::Resource
-  def associated_records(association_name, options={})
+  has_one :author
+  has_many :comments
+
+  # def record_for_author(options = {})
+  #   records_for("author", options)
+  # end
+
+  # def records_for_comments(options = {})
+  #   records_for("comments", options)
+  # end
+end
+
+```
+
+For example, you may want raise an error if the user is not authorized to view the associated records.
+
+```ruby
+class BaseResource < JSONAPI::Resource
+  def records_for(association_name, options={})
     context = options[:context]
     records = model.public_send(association_name)
 

--- a/README.md
+++ b/README.md
@@ -283,6 +283,25 @@ class PostResource < JSONAPI::Resource
 end
 ```
 
+You can also customize how associated records are found by overriding the `associated_records` method in the resource class.
+
+For example, raise an error if the user is not authorized to view the association records.
+
+```ruby
+class PostResource < JSONAPI::Resource
+  def associated_records(association_name, options={})
+    context = options[:context]
+    records = model.public_send(association_name)
+
+    unless context.current_user.can_view?(records)
+      raise NotAuthorizedError
+    end
+
+    records
+  end
+end
+```
+
 ###### Applying Filters
 
 The `apply_filter` method is called to apply each filter to the `Arel` relation. You may override this method to gain control over how the filters are applied to the `Arel` relation.

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -103,7 +103,7 @@ module JSONAPI
 
     # Override this on a resource to customize how the associated records
     # are fetched for a model. Particularly helpful for authoriztion.
-    def associated_records(association_name, options = {})
+    def records_for(association_name, options = {})
       model.send association_name
     end
 
@@ -551,12 +551,21 @@ module JSONAPI
             @model.method("#{foreign_key}=").call(value)
           end unless method_defined?("#{foreign_key}=")
 
+          associated_records_method_name = case @_associations[attr]
+          when JSONAPI::Association::HasOne then "record_for_#{attr}"
+          when JSONAPI::Association::HasMany then "records_for_#{attr}"
+          end
+
+          define_method associated_records_method_name do |options={}|
+            records_for(attr, options)
+          end unless method_defined?(associated_records_method_name)
+
           if @_associations[attr].is_a?(JSONAPI::Association::HasOne)
             define_method attr do
               type_name = self.class._associations[attr].type.to_s
               resource_class = self.class.resource_for(self.class.module_path + type_name)
               if resource_class
-                associated_model = associated_records(attr, context: @context)
+                associated_model = public_send(associated_records_method_name)
                 return associated_model ? resource_class.new(associated_model, @context) : nil
               end
             end unless method_defined?(attr)
@@ -570,7 +579,7 @@ module JSONAPI
 
               resources = []
               if resource_class
-                records = associated_records(attr, context: @context)
+                records = public_send(associated_records_method_name)
                 records = self.class.apply_filters(records, filters)
                 records = self.class.apply_sort(records, self.class.construct_order_options(sort_criteria))
                 records = self.class.apply_pagination(records, paginator)

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -383,6 +383,8 @@ class PersonResource < JSONAPI::Resource
   has_many :comments
   has_many :posts
 
+  has_one :preferences
+
   filter :name
 
   def self.verify_custom_filter(filter, values, context)

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -18,15 +18,24 @@ class CatResource < JSONAPI::Resource
   has_one :father, class_name: 'Cat'
 end
 
-class PersonWithCustomAssociatedRecordsResource < PersonResource
-  def associated_records(association_name, context)
-    :associated_records
+class PersonWithCustomRecordsForResource < PersonResource
+  def records_for(association_name, context)
+    :records_for
   end
 end
 
-class PersonWithCustomAssociatedRecordsErrorResource < PersonResource
+class PersonWithCustomRecordsForRelationshipsResource < PersonResource
+  def records_for_posts(options = {})
+    :records_for_posts
+  end
+  def record_for_preferences(options = {})
+    :record_for_preferences
+  end
+end
+
+class PersonWithCustomRecordsForErrorResource < PersonResource
   class AuthorizationError < StandardError; end
-  def associated_records(association_name, context)
+  def records_for(association_name, context)
     raise AuthorizationError
   end
 end
@@ -68,7 +77,7 @@ class ResourceTest < MiniTest::Unit::TestCase
     refute(posts.include?(Post.find(3)))
   end
 
-  def test_associated_records
+  def test_records_for
     author = Person.find(1)
     preferences = Preferences.first
     refute(preferences == nil)
@@ -76,13 +85,41 @@ class ResourceTest < MiniTest::Unit::TestCase
     author_resource = PersonResource.new(author)
     assert_equal(author_resource.preferences.model, preferences)
 
-    author_resource = PersonWithCustomAssociatedRecordsResource.new(author)
-    assert_equal(author_resource.preferences.model, :associated_records)
+    author_resource = PersonWithCustomRecordsForResource.new(author)
+    assert_equal(author_resource.preferences.model, :records_for)
 
-    author_resource = PersonWithCustomAssociatedRecordsErrorResource.new(author)
-    assert_raises PersonWithCustomAssociatedRecordsErrorResource::AuthorizationError do
+    author_resource = PersonWithCustomRecordsForErrorResource.new(author)
+    assert_raises PersonWithCustomRecordsForErrorResource::AuthorizationError do
       author_resource.posts
     end
+  end
+
+  def test_records_for_meta_method_for_has_one
+    author = Person.find(1)
+    author.update! preferences: Preferences.first
+    author_resource = PersonWithCustomRecordsForRelationshipsResource.new(author)
+    assert_equal(author_resource.record_for_preferences, :record_for_preferences)
+  end
+
+  def test_records_for_meta_method_for_has_one_calling_records_for
+    author = Person.find(1)
+    author.update! preferences: Preferences.first
+    author_resource = PersonWithCustomRecordsForResource.new(author)
+    assert_equal(author_resource.record_for_preferences, :records_for)
+  end
+
+  def test_associated_records_meta_method_for_has_many
+    author = Person.find(1)
+    author.posts << Post.find(1)
+    author_resource = PersonWithCustomRecordsForRelationshipsResource.new(author)
+    assert_equal(author_resource.records_for_posts, :records_for_posts)
+  end
+
+  def test_associated_records_meta_method_for_has_many_calling_records_for
+    author = Person.find(1)
+    author.posts << Post.find(1)
+    author_resource = PersonWithCustomRecordsForResource.new(author)
+    assert_equal(author_resource.records_for_posts, :records_for)
   end
 
   def test_find_by_key_with_customized_base_records

--- a/test/unit/serializer/serializer_test.rb
+++ b/test/unit/serializer/serializer_test.rb
@@ -167,6 +167,12 @@ class SerializerTest < MiniTest::Unit::TestCase
              posts: {
                self: '/people/1/links/posts',
                related: '/people/1/posts'
+             },
+             preferences: {
+               self: "/people/1/links/preferences",
+               related: "/people/1/preferences",
+               type: "preferences",
+               id: "1"
              }
             }
           }
@@ -226,6 +232,12 @@ class SerializerTest < MiniTest::Unit::TestCase
               posts: {
                 self: '/people/1/links/posts',
                 related: '/people/1/posts'
+              },
+              preferences: {
+                self: "/people/1/links/preferences",
+                related: "/people/1/preferences",
+                type: "preferences",
+                id: "1"
               }
             }
           }
@@ -533,6 +545,12 @@ class SerializerTest < MiniTest::Unit::TestCase
               related: '/people/2/comments',
               type: 'comments',
               ids: ['2', '3']
+            },
+            preferences: {
+              self: "/people/2/links/preferences",
+              related: "/people/2/preferences",
+              type: "preferences",
+              id: nil
             }
           }
         },


### PR DESCRIPTION
This implements the idea that we discussed in issue https://github.com/cerebris/jsonapi-resources/issues/108. I made the `associated_records` method similar to the `records` method as @lgebhardt suggested and I think that it works nicely and is clear.
