### PR TITLE
Fix included relationships when relationship is not direct.

### DIFF
--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -1629,7 +1629,6 @@ end
 class Api::V5::PostsControllerTest < ActionController::TestCase
   def test_limit_fields_in_included_resource_that_is_not_a_direct_relationship
     get :show, { id: "1", include: "author.preferences" }
-    puts response.body
     assert_equal response.status, 200
   end
 end

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -1619,6 +1619,22 @@ class PeopleControllerTest < ActionController::TestCase
 end
 
 class Api::V5::AuthorsControllerTest < ActionController::TestCase
+  def test_preferences_include
+    get :show, { id: '1', include: "preferences" }
+    assert_equal response.status, 200
+    assert_equal 1, json_response['included'].size
+  end
+end
+
+class Api::V5::PostsControllerTest < ActionController::TestCase
+  def test_limit_fields_in_included_resource_that_is_not_a_direct_relationship
+    get :show, { id: "1", include: "author.preferences" }
+    puts response.body
+    assert_equal response.status, 200
+  end
+end
+
+class Api::V5::AuthorsControllerTest < ActionController::TestCase
   def test_get_person_as_author
     get :index, {filter: {id: '1'}}
     assert_response :success

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -1619,7 +1619,7 @@ class PeopleControllerTest < ActionController::TestCase
 end
 
 class Api::V5::AuthorsControllerTest < ActionController::TestCase
-  def test_preferences_include
+  def test_including_resource_that_is_a_direct_relationship
     get :show, { id: '1', include: "preferences" }
     assert_equal response.status, 200
     assert_equal 1, json_response['included'].size
@@ -1627,8 +1627,12 @@ class Api::V5::AuthorsControllerTest < ActionController::TestCase
 end
 
 class Api::V5::PostsControllerTest < ActionController::TestCase
-  def test_limit_fields_in_included_resource_that_is_not_a_direct_relationship
-    get :show, { id: "1", include: "author.preferences" }
+  def test_including_resource_that_is_not_a_direct_relationship
+    id = 1
+    post = ::Post.find(id)
+    assert !post.author.nil?
+    assert !post.author.preferences.nil?
+    get :show, { id: id, include: "author.preferences" }
     assert_equal response.status, 200
   end
 end

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -696,6 +696,7 @@ module Api
       attributes :name, :email
       model_name 'Person'
       has_many :posts
+      has_one :preferences
 
       filter :name
 
@@ -720,6 +721,7 @@ module Api
     ExpenseEntryResource = ExpenseEntryResource.dup
     IsoCurrencyResource = IsoCurrencyResource.dup
     EmployeeResource = EmployeeResource.dup
+    PreferencesResource = PreferencesResource.dup
   end
 end
 
@@ -744,9 +746,12 @@ warn 'end testing Name Collisions'
 javascript = Section.create(name: 'javascript')
 ruby = Section.create(name: 'ruby')
 
+preferences = Preferences.create
+
 a = Person.create(name: 'Joe Author',
                  email: 'joe@xyz.fake',
-                 date_joined: DateTime.parse('2013-08-07 20:25:00 UTC +00:00'))
+                 date_joined: DateTime.parse('2013-08-07 20:25:00 UTC +00:00'),
+                 preferences: preferences)
 
 b = Person.create(name: 'Fred Reader',
                  email: 'fred@xyz.fake',
@@ -892,8 +897,6 @@ betax = Planet.create(name: 'Beta X', description: 'Newly discovered Planet X', 
 betay = Planet.create(name: 'Beta X', description: 'Newly discovered Planet Y', planet_type_id: unknown.id)
 betaz = Planet.create(name: 'Beta X', description: 'Newly discovered Planet Z', planet_type_id: unknown.id)
 betaw = Planet.create(name: 'Beta W', description: 'Newly discovered Planet W')
-
-preference = Preferences.create
 
 fact = Fact.create(spouse_name: 'Jane Author',
                    bio: 'First man to run across Antartica.',


### PR DESCRIPTION
If you include a resource through a relationship and the included resource is not a direct association, the request fails with:

``` json
{
  "errors":[
    {
      "title":"Invalid field",
      "detail":"preferences is not a valid association of people",
      "id":null,
      "href":null,
      "code":112,
      "path":null,
      "links":null,
      "status":"bad_request"
    }
  ]
}
```

According to the spec, this should work fine.

> In order to request resources related to other resources, a dot-separated path for each relationship name can be specified:
> 
> `GET /articles/1?include=comments.author`

I added a test that shows that the `preferences` relationship can be included from its author, and another test that fails when you try to include the `preferences` for a post through `author.preferences`.

Before I wrote a fix, I wanted to run this by the team to see if you're surprised by this behavior or if you have an opinion about how the fix should be implemented.
