### PR TITLE
Fix sort param plus symbol handling [Issue #120]

### DIFF
--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -167,9 +167,9 @@ module JSONAPI
     def parse_sort_criteria(sort_criteria)
       return unless sort_criteria
 
-      @sort_criteria = CSV.parse_line(sort_criteria).collect do |sort|
+      @sort_criteria = CSV.parse_line(URI.unescape(sort_criteria)).collect do |sort|
         sort_criteria = {field: unformat_key(sort[1..-1]).to_s}
-        if sort.start_with?('+')
+        if sort.start_with?('+', ' ')
           sort_criteria[:direction] = :asc
         elsif sort.start_with?('-')
           sort_criteria[:direction] = :desc

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -181,6 +181,22 @@ class PostsControllerTest < ActionController::TestCase
     assert_equal "Delete This Later - Multiple2-1", json_response['data'][0]['title']
   end
 
+  # Plus symbol may be replaced by a space
+  def test_sorting_asc_with_space
+    get :index, {sort: ' title'}
+
+    assert_response :success
+    assert_equal "Delete This Later - Multiple2-1", json_response['data'][0]['title']
+  end
+
+  # Plus symbol may be sent uriencoded ('%2b')
+  def test_sorting_asc_with_encoded_plus
+    get :index, {sort: '%2btitle'}
+
+    assert_response :success
+    assert_equal "Delete This Later - Multiple2-1", json_response['data'][0]['title']
+  end
+
   def test_sorting_desc
     get :index, {sort: '-title'}
 


### PR DESCRIPTION
Many web servers substitute white spaces for "+". This causes

```
GET /people?sort=+age,+name
```

to reach the parse_sort_criteria method as `" age, name"` and throw an error.

This change allows the parse_sort_criteria method to accept the literal '+', a leading white space ' ', or an encoded plus '%2b' as valid sort ascending indicators.

Two really simple additional tests are included.

See #120 and https://github.com/json-api/json-api/issues/486
