### PR TITLE
Respect formatting config when validating type property 

### DIFF
--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -228,12 +228,13 @@ module JSONAPI
     end
 
     def parse_has_one_links_object(raw)
-      raw = raw["linkage"] if raw["linkage"]
       if raw.nil?
         return {
           type: nil,
           id: nil
         }
+      elsif raw.is_a?(Hash) && raw.has_key?('linkage')
+        raw = raw['linkage']
       end
 
       if !raw.is_a?(Hash) || raw.length != 2 || !(raw.has_key?('type') && raw.has_key?('id'))
@@ -247,9 +248,10 @@ module JSONAPI
     end
 
     def parse_has_many_links_object(raw)
-      raw = raw["linkage"] if raw["linkage"]
       if raw.nil?
         raise JSONAPI::Exceptions::InvalidLinksObject.new
+      elsif raw.is_a?(Hash) && raw.has_key?('linkage')
+        raw = raw['linkage']
       end
 
       links_object = {}

--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -236,6 +236,8 @@ module JSONAPI
         }
       end
 
+      Rails.logger.debug raw
+
       if !raw.is_a?(Hash) || raw.length != 2 || !(raw.has_key?('type') && raw.has_key?('id'))
         raise JSONAPI::Exceptions::InvalidLinksObject.new
       end

--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -236,7 +236,7 @@ module JSONAPI
         }
       end
 
-      Rails.logger.debug raw
+      Rails.logger.debug "jsonapi-resources has_one: #{raw}"
 
       if !raw.is_a?(Hash) || raw.length != 2 || !(raw.has_key?('type') && raw.has_key?('id'))
         raise JSONAPI::Exceptions::InvalidLinksObject.new
@@ -252,6 +252,8 @@ module JSONAPI
       if raw.nil?
         raise JSONAPI::Exceptions::InvalidLinksObject.new
       end
+
+      Rails.logger.debug "jsonapi-resources has_many: #{raw}"
 
       links_object = {}
       if raw.is_a?(Array)

--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -228,6 +228,7 @@ module JSONAPI
     end
 
     def parse_has_one_links_object(raw)
+      raw = raw["linkage"]
       if raw.nil?
         return {
           type: nil,

--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -228,15 +228,13 @@ module JSONAPI
     end
 
     def parse_has_one_links_object(raw)
-      raw = raw["linkage"]
+      raw = raw["linkage"] if raw["linkage"]
       if raw.nil?
         return {
           type: nil,
           id: nil
         }
       end
-
-      Rails.logger.debug "jsonapi-resources has_one: #{raw}"
 
       if !raw.is_a?(Hash) || raw.length != 2 || !(raw.has_key?('type') && raw.has_key?('id'))
         raise JSONAPI::Exceptions::InvalidLinksObject.new
@@ -249,11 +247,10 @@ module JSONAPI
     end
 
     def parse_has_many_links_object(raw)
+      raw = raw["linkage"] if raw["linkage"]
       if raw.nil?
         raise JSONAPI::Exceptions::InvalidLinksObject.new
       end
-
-      Rails.logger.debug "jsonapi-resources has_many: #{raw}"
 
       links_object = {}
       if raw.is_a?(Array)

--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -393,7 +393,7 @@ module JSONAPI
       end
 
       type = data[:type]
-      if type.nil? || type != @resource_klass._type.to_s
+      if type.nil? || unformat_key(type).to_s != @resource_klass._type.to_s
         raise JSONAPI::Exceptions::ParameterMissing.new(:type)
       end
 

--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -286,7 +286,8 @@ module JSONAPI
               # Since we do not yet support polymorphic associations we will raise an error if the type does not match the
               # association's type.
               # ToDo: Support Polymorphic associations
-              if links_object[:type] && (links_object[:type] != association.type.to_s)
+              links_object_type = links_object[:type]
+              if links_object_type && (unformat_key(links_object_type).to_s != association.type.to_s)
                 raise JSONAPI::Exceptions::TypeMismatch.new(links_object[:type])
               end
 
@@ -306,12 +307,12 @@ module JSONAPI
               if links_object.length == 0
                 checked_has_many_associations[param] = []
               else
-                if links_object.length > 1 || !links_object.has_key?(association.type.to_s)
+                if links_object.length > 1 || !links_object.has_key?(format_key(association.type).to_s)
                   raise JSONAPI::Exceptions::TypeMismatch.new(links_object[:type])
                 end
 
                 links_object.each_pair do |type, keys|
-                  association_resource = Resource.resource_for(@resource_klass.module_path + type)
+                  association_resource = Resource.resource_for(@resource_klass.module_path.to_s + unformat_key(type).to_s)
                   checked_has_many_associations[param] = association_resource.verify_keys(keys, @context)
                 end
               end


### PR DESCRIPTION
This is to correct various errors caused by comparison of the camelcase key vs snake formatted class names, and vice versa. Please note that I'm using `config.json_key_format = :camelized_key`.
