### PR TITLE
Check for linkage key in associations [Issues #134 and #115] - Update to 140

### DIFF
--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -233,46 +233,33 @@ module JSONAPI
           type: nil,
           id: nil
         }
-      elsif raw.is_a?(Array) && !raw.any?
-        return raw
-      elsif raw.is_a?(Hash)
-        raw = raw.with_indifferent_access
-      else
+      end
+
+      if !raw.is_a?(Hash) || raw.length != 2 || !(raw.has_key?('type') && raw.has_key?('id'))
         raise JSONAPI::Exceptions::InvalidLinksObject.new
       end
 
-      if raw.has_key?('linkage') && (raw['linkage'].has_key?('type') && raw['linkage'].has_key?('id'))
-        {
-          type: raw['linkage']['type'],
-          id: raw['linkage']['id']
-        }
-      else
-        raise JSONAPI::Exceptions::InvalidLinksObject.new
-      end
+      {
+        type: raw['type'],
+        id: raw['id']
+      }
     end
 
     def parse_has_many_links_object(raw)
       if raw.nil?
         raise JSONAPI::Exceptions::InvalidLinksObject.new
-      elsif raw.is_a?(Array) && !raw.any?
-        return raw
-      elsif raw.is_a?(Hash)
-        raw = raw.with_indifferent_access
-      else
-        raise JSONAPI::Exceptions::InvalidLinksObject.new
       end
 
       links_object = {}
-      if raw.has_key?('linkage') && raw['linkage'].is_a?(Array)
-        raw['linkage'].each do |link|
-          link_object = parse_has_one_links_object({'linkage' => link})
+      if raw.is_a?(Array)
+        raw.each do |link|
+          link_object = parse_has_one_links_object(link)
           links_object[link_object[:type]] ||= []
           links_object[link_object[:type]].push(link_object[:id])
         end
       else
         raise JSONAPI::Exceptions::InvalidLinksObject.new
       end
-
       links_object
     end
 
@@ -291,7 +278,13 @@ module JSONAPI
             association = @resource_klass._association(param)
 
             if association.is_a?(JSONAPI::Association::HasOne)
-              links_object = parse_has_one_links_object(link_value)
+              if link_value.nil?
+                linkage = nil
+              else
+                linkage = link_value[:linkage]
+              end
+
+              links_object = parse_has_one_links_object(linkage)
               # Since we do not yet support polymorphic associations we will raise an error if the type does not match the
               # association's type.
               # ToDo: Support Polymorphic associations
@@ -306,7 +299,15 @@ module JSONAPI
                 checked_has_one_associations[param] = nil
               end
             elsif association.is_a?(JSONAPI::Association::HasMany)
-              links_object = parse_has_many_links_object(link_value)
+              if link_value.is_a?(Array) && link_value.length == 0
+                linkage = []
+              elsif link_value.is_a?(Hash)
+                linkage = link_value[:linkage]
+              else
+                raise JSONAPI::Exceptions::InvalidLinksObject.new
+              end
+
+              links_object = parse_has_many_links_object(linkage)
 
               # Since we do not yet support polymorphic associations we will raise an error if the type does not match the
               # association's type.
@@ -363,7 +364,7 @@ module JSONAPI
       association = resource_klass._association(association_type)
 
       if association.is_a?(JSONAPI::Association::HasMany)
-        object_params = {links: {association.name => data}}
+        object_params = {links: {association.name => {linkage: data}}}
         verified_param_set = parse_params(object_params, @resource_klass.updateable_fields(@context))
 
         @operations.push JSONAPI::CreateHasManyAssociationOperation.new(resource_klass,
@@ -377,7 +378,7 @@ module JSONAPI
       association = resource_klass._association(association_type)
 
       if association.is_a?(JSONAPI::Association::HasOne)
-        object_params = {links: {association.name => data}}
+        object_params = {links: {association.name => {linkage: data}}}
 
         verified_param_set = parse_params(object_params, @resource_klass.updateable_fields(@context))
 
@@ -386,7 +387,7 @@ module JSONAPI
                                                                         association_type,
                                                                         verified_param_set[:has_one].values[0])
       else
-        object_params = {links: {association.name => data}}
+        object_params = {links: {association.name => {linkage: data}}}
         verified_param_set = parse_params(object_params, @resource_klass.updateable_fields(@context))
 
         @operations.push JSONAPI::ReplaceHasManyAssociationOperation.new(resource_klass,

--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -233,6 +233,8 @@ module JSONAPI
           type: nil,
           id: nil
         }
+      elsif raw.is_a?(Hash) && raw.has_key?('linkage')
+        raw = raw['linkage']
       end
 
       if !raw.is_a?(Hash) || raw.length != 2 || !(raw.has_key?('type') && raw.has_key?('id'))
@@ -248,6 +250,8 @@ module JSONAPI
     def parse_has_many_links_object(raw)
       if raw.nil?
         raise JSONAPI::Exceptions::InvalidLinksObject.new
+      elsif raw.is_a?(Hash) && raw.has_key?('linkage')
+        raw = raw['linkage']
       end
 
       links_object = {}

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -707,6 +707,24 @@ class PostsControllerTest < ActionController::TestCase
     assert_match /Invalid Links Object/, response.body
   end
 
+  def test_update_other_has_many_links_linkage_nil
+    set_content_type_header!
+    put :update,
+        {
+          id: 3,
+          data: {
+            type: 'posts',
+            id: 3,
+            links: {
+              tags: {linkage: nil}
+            }
+          }
+        }
+
+    assert_response :bad_request
+    assert_match /Invalid Links Object/, response.body
+  end
+
   def test_update_relationship_has_one_singular_param_id_nil
     set_content_type_header!
     ruby = Section.find_by(name: 'ruby')

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -614,7 +614,7 @@ class PostsControllerTest < ActionController::TestCase
     post_object = Post.find(4)
     assert_not_equal ruby.id, post_object.section_id
 
-    put :update_association, {post_id: 4, association: 'section', data: {linkage: {type: 'sections', id: "#{ruby.id}"}}}
+    put :update_association, {post_id: 4, association: 'section', data: {type: 'sections', id: "#{ruby.id}"}}
 
     assert_response :no_content
     post_object = Post.find(4)
@@ -623,7 +623,7 @@ class PostsControllerTest < ActionController::TestCase
 
   def test_update_relationship_has_one_invalid_links_hash_keys_ids
     set_content_type_header!
-    put :update_association, {post_id: 3, association: 'section', data: {linkage: {type: 'sections', ids: 'foo'}}}
+    put :update_association, {post_id: 3, association: 'section', data: {type: 'sections', ids: 'foo'}}
 
     assert_response :bad_request
     assert_match /Invalid Links Object/, response.body
@@ -631,7 +631,7 @@ class PostsControllerTest < ActionController::TestCase
 
   def test_update_relationship_has_one_invalid_links_hash_count
     set_content_type_header!
-    put :update_association, {post_id: 3, association: 'section', data: {linkage: {type: 'sections'}}}
+    put :update_association, {post_id: 3, association: 'section', data: {type: 'sections'}}
 
     assert_response :bad_request
     assert_match /Invalid Links Object/, response.body
@@ -639,7 +639,7 @@ class PostsControllerTest < ActionController::TestCase
 
   def test_update_relationship_has_many_not_array
     set_content_type_header!
-    put :update_association, {post_id: 3, association: 'tags', data: {linkage: {type: 'tags', id: 2}}}
+    put :update_association, {post_id: 3, association: 'tags', data: {type: 'tags', id: 2}}
 
     assert_response :bad_request
     assert_match /Invalid Links Object/, response.body
@@ -647,7 +647,7 @@ class PostsControllerTest < ActionController::TestCase
 
   def test_update_relationship_has_one_invalid_links_hash_keys_type_mismatch
     set_content_type_header!
-    put :update_association, {post_id: 3, association: 'section', data: {linkage: {type: 'comment', id: '3'}}}
+    put :update_association, {post_id: 3, association: 'section', data: {type: 'comment', id: '3'}}
 
     assert_response :bad_request
     assert_match /Type Mismatch/, response.body
@@ -680,7 +680,7 @@ class PostsControllerTest < ActionController::TestCase
             type: 'posts',
             id: 3,
             links: {
-              tags: {typ: 'bad link', idd: 'as'}
+              tags: {linkage: {typ: 'bad link', idd: 'as'}}
             }
           }
         }
@@ -714,7 +714,6 @@ class PostsControllerTest < ActionController::TestCase
     post_object.section = ruby
     post_object.save!
 
-    put :update_association, {post_id: 3, association: 'section', data: {linkage: {type: 'sections', id: nil}}}
 
     assert_response :no_content
     assert_equal nil, post_object.reload.section_id
@@ -754,7 +753,7 @@ class PostsControllerTest < ActionController::TestCase
     post_object.section_id = nil
     post_object.save!
 
-    put :update_association, {post_id: 3, association: 'section', data: {linkage: {type: 'sections', id: "#{ruby.id}"}}}
+    put :update_association, {post_id: 3, association: 'section', data: {type: 'sections', id: "#{ruby.id}"}}
 
     assert_response :no_content
     post_object = Post.find(3)
@@ -769,13 +768,13 @@ class PostsControllerTest < ActionController::TestCase
     post_object = Post.find(3)
     assert_equal 0, post_object.tags.length
 
-    put :update_association, {post_id: 3, association: 'tags', data: {linkage: [{type: 'tags', id: 2}]}}
+    put :update_association, {post_id: 3, association: 'tags', data: [{type: 'tags', id: 2}]}
 
     assert_response :no_content
     post_object = Post.find(3)
     assert_equal 1, post_object.tags.length
 
-    put :update_association, {post_id: 3, association: 'tags', data: {linkage: [{type: 'tags', id: 5}]}}
+    put :update_association, {post_id: 3, association: 'tags', data: [{type: 'tags', id: 5}]}
 
     assert_response :no_content
     post_object = Post.find(3)
@@ -786,7 +785,7 @@ class PostsControllerTest < ActionController::TestCase
 
   def test_update_relationship_has_many
     set_content_type_header!
-    put :update_association, {post_id: 3, association: 'tags', data: {linkage: [{type: 'tags', id: 2}, {type: 'tags', id: 3}]}}
+    put :update_association, {post_id: 3, association: 'tags', data: [{type: 'tags', id: 2}, {type: 'tags', id: 3}]}
 
     assert_response :no_content
     post_object = Post.find(3)
@@ -796,14 +795,14 @@ class PostsControllerTest < ActionController::TestCase
 
   def test_create_relationship_has_many_join_table
     set_content_type_header!
-    put :update_association, {post_id: 3, association: 'tags', data: {linkage: [{type: 'tags', id: 2}, {type: 'tags', id: 3}]}}
+    put :update_association, {post_id: 3, association: 'tags', data: [{type: 'tags', id: 2}, {type: 'tags', id: 3}]}
 
     assert_response :no_content
     post_object = Post.find(3)
     assert_equal 2, post_object.tags.collect { |tag| tag.id }.length
     assert matches_array? [2, 3], post_object.tags.collect { |tag| tag.id }
 
-    post :create_association, {post_id: 3, association: 'tags', data: {linkage: [{type: 'tags', id: 5}]}}
+    post :create_association, {post_id: 3, association: 'tags', data: [{type: 'tags', id: 5}]}
 
     assert_response :no_content
     post_object = Post.find(3)
@@ -813,7 +812,7 @@ class PostsControllerTest < ActionController::TestCase
 
   def test_create_relationship_has_many_mismatched_type
     set_content_type_header!
-    post :create_association, {post_id: 3, association: 'tags', data: {linkage: [{type: 'comments', id: 5}]}}
+    post :create_association, {post_id: 3, association: 'tags', data: [{type: 'comments', id: 5}]}
 
     assert_response :bad_request
     assert_match /Type Mismatch/, response.body
@@ -821,7 +820,7 @@ class PostsControllerTest < ActionController::TestCase
 
   def test_create_relationship_has_many_missing_id
     set_content_type_header!
-    post :create_association, {post_id: 3, association: 'tags', data: {linkage: [{type: 'tags', idd: 5}]}}
+    post :create_association, {post_id: 3, association: 'tags', data: [{type: 'tags', idd: 5}]}
 
     assert_response :bad_request
     assert_match /Data is not a valid Links Object./, response.body
@@ -829,7 +828,7 @@ class PostsControllerTest < ActionController::TestCase
 
   def test_create_relationship_has_many_not_array
     set_content_type_header!
-    post :create_association, {post_id: 3, association: 'tags', data: {linkage: {type: 'tags', id: 5}}}
+    post :create_association, {post_id: 3, association: 'tags', data: {type: 'tags', id: 5}}
 
     assert_response :bad_request
     assert_match /Data is not a valid Links Object./, response.body
@@ -845,20 +844,20 @@ class PostsControllerTest < ActionController::TestCase
 
   def test_create_relationship_has_many_join
     set_content_type_header!
-    post :create_association, {post_id: 4, association: 'tags', data: {linkage: [{type: 'tags', id: 1}, {type: 'tags', id: 2}, {type: 'tags', id: 3}]}}
+    post :create_association, {post_id: 4, association: 'tags', data: [{type: 'tags', id: 1}, {type: 'tags', id: 2}, {type: 'tags', id: 3}]}
     assert_response :no_content
   end
 
   def test_create_relationship_has_many_join_table_record_exists
     set_content_type_header!
-    put :update_association, {post_id: 3, association: 'tags', data: {linkage: [{type: 'tags', id: 2}, {type: 'tags', id: 3}]}}
+    put :update_association, {post_id: 3, association: 'tags', data: [{type: 'tags', id: 2}, {type: 'tags', id: 3}]}
 
     assert_response :no_content
     post_object = Post.find(3)
     assert_equal 2, post_object.tags.collect { |tag| tag.id }.length
     assert matches_array? [2, 3], post_object.tags.collect { |tag| tag.id }
 
-    post :create_association, {post_id: 3, association: 'tags', data: {linkage: [{type: 'tags', id: 2}, {type: 'tags', id: 5}]}}
+    post :create_association, {post_id: 3, association: 'tags', data: [{type: 'tags', id: 2}, {type: 'tags', id: 5}]}
 
     assert_response :bad_request
     assert_match /The relation to 2 already exists./, response.body
@@ -874,7 +873,7 @@ class PostsControllerTest < ActionController::TestCase
 
   def test_delete_relationship_has_many
     set_content_type_header!
-    put :update_association, {post_id: 14, association: 'tags', data: {linkage: [{type: 'tags', id: 2}, {type: 'tags', id: 3}]}}
+    put :update_association, {post_id: 14, association: 'tags', data: [{type: 'tags', id: 2}, {type: 'tags', id: 3}]}
     assert_response :no_content
     p = Post.find(14)
     assert_equal [2, 3], p.tag_ids
@@ -888,7 +887,7 @@ class PostsControllerTest < ActionController::TestCase
 
   def test_delete_relationship_has_many_does_not_exist
     set_content_type_header!
-    put :update_association, {post_id: 14, association: 'tags', data: {linkage: [{type: 'tags', id: 2}, {type: 'tags', id: 3}]}}
+    put :update_association, {post_id: 14, association: 'tags', data: [{type: 'tags', id: 2}, {type: 'tags', id: 3}]}
     assert_response :no_content
     p = Post.find(14)
     assert_equal [2, 3], p.tag_ids
@@ -902,7 +901,7 @@ class PostsControllerTest < ActionController::TestCase
 
   def test_delete_relationship_has_many_with_empty_data
     set_content_type_header!
-    put :update_association, {post_id: 14, association: 'tags', data: {linkage: [{type: 'tags', id: 2}, {type: 'tags', id: 3}]}}
+    put :update_association, {post_id: 14, association: 'tags', data: [{type: 'tags', id: 2}, {type: 'tags', id: 3}]}
     assert_response :no_content
     p = Post.find(14)
     assert_equal [2, 3], p.tag_ids

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -587,6 +587,23 @@ class PostsControllerTest < ActionController::TestCase
         {
           id: 3,
           data: {
+            id: '3',
+            type: 'posts',
+            title: 'A great new Post',
+            links: {
+              section: {linkage: {type: 'sections', id: 1}},
+              tags: {linkage: [{type: 'tags', id: 3}, {type: 'tags', id: 4}]}
+            }
+          },
+          include: 'tags'
+        }
+
+    assert_response :success
+
+    put :update,
+        {
+          id: 3,
+          data: {
             type: 'posts',
             id: 3,
             title: 'A great new Post',

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -278,7 +278,7 @@ class PostsControllerTest < ActionController::TestCase
              title: 'JR is Great',
              body: 'JSONAPIResources is the greatest thing since unsliced bread.',
              links: {
-               author: {type: 'people', id: '3'}
+               author: {linkage: {type: 'people', id: '3'}}
              }
            }
          }
@@ -299,7 +299,7 @@ class PostsControllerTest < ActionController::TestCase
              title: 'JR is Great',
              body: 'JSONAPIResources is the greatest thing since unsliced bread.',
              links: {
-               author: {type: 'people', id: '304567'}
+               author: {linkage: {type: 'people', id: '304567'}}
              }
            }
          }
@@ -319,7 +319,7 @@ class PostsControllerTest < ActionController::TestCase
              title: 'JR is Great',
              body: 'JSONAPIResources is the greatest thing since unsliced bread.',
              links: {
-               author: {type: 'people', id: '3'}
+               author: {linkage: {type: 'people', id: '3'}}
              }
            }
          }
@@ -363,7 +363,7 @@ class PostsControllerTest < ActionController::TestCase
                title: 'JR is Great',
                body: 'JSONAPIResources is the greatest thing since unsliced bread.',
                links: {
-                 author: {type: 'people', id: '3'}
+                 author: {linkage: {type: 'people', id: '3'}}
                }
              },
              {
@@ -371,7 +371,7 @@ class PostsControllerTest < ActionController::TestCase
                title: 'Ember is Great',
                body: 'Ember is the greatest thing since unsliced bread.',
                links: {
-                 author: {type: 'people', id: '3'}
+                 author: {linkage: {type: 'people', id: '3'}}
                }
              }
            ]
@@ -395,7 +395,7 @@ class PostsControllerTest < ActionController::TestCase
                Title: 'JR is Great',
                body: 'JSONAPIResources is the greatest thing since unsliced bread.',
                links: {
-                 author: {type: 'people', id: '3'}
+                 author: {linkage: {type: 'people', id: '3'}}
                }
              },
              {
@@ -403,7 +403,7 @@ class PostsControllerTest < ActionController::TestCase
                title: 'Ember is Great',
                BODY: 'Ember is the greatest thing since unsliced bread.',
                links: {
-                 author: {type: 'people', id: '3'}
+                 author: {linkage: {type: 'people', id: '3'}}
                }
              }
            ]
@@ -422,7 +422,7 @@ class PostsControllerTest < ActionController::TestCase
              title: 'JR is Great',
              body: 'JSONAPIResources is the greatest thing since unsliced bread.',
              links: {
-               author: {type: 'people', id: '3'}
+               author: {linkage: {type: 'people', id: '3'}}
              }
            }
          }
@@ -440,7 +440,7 @@ class PostsControllerTest < ActionController::TestCase
              title: 'JR is Great',
              body: 'JSONAPIResources is the greatest thing since unsliced bread.',
              links: {
-               author: {type: 'people', id: '3'}
+               author: {linkage: {type: 'people', id: '3'}}
              }
            }
          }
@@ -457,7 +457,7 @@ class PostsControllerTest < ActionController::TestCase
              title: 'JR is Great',
              body: 'JSONAPIResources is the greatest thing since unsliced bread.',
              links: {
-               author: {type: 'people', id: '3'}
+               author: {linkage: {type: 'people', id: '3'}}
              }
            }
          }
@@ -475,7 +475,7 @@ class PostsControllerTest < ActionController::TestCase
              subject: 'JR is Great',
              body: 'JSONAPIResources is the greatest thing since unsliced bread.',
              links: {
-               author: {type: 'people', id: '3'}
+               author: {linkage: {type: 'people', id: '3'}}
              }
            }
          }
@@ -493,8 +493,8 @@ class PostsControllerTest < ActionController::TestCase
              title: 'JR is Great',
              body: 'JSONAPIResources is the greatest thing since unsliced bread.',
              links: {
-               author: {type: 'people', id: '3'},
-               tags: [{type: 'tags', id: 3}, {type: 'tags', id: 4}]
+               author: {linkage: {type: 'people', id: '3'}},
+               tags: {linkage: [{type: 'tags', id: 3}, {type: 'tags', id: 4}]}
              }
            }
          }
@@ -515,8 +515,8 @@ class PostsControllerTest < ActionController::TestCase
              title: 'JR is Great',
              body: 'JSONAPIResources is the greatest thing since unsliced bread.',
              links: {
-               author: {type: 'people', id: '3'},
-               tags: [{type: 'tags', id: '3'}, {type: 'tags', id: '4'}]
+               author: {linkage: {type: 'people', id: '3'}},
+               tags: {linkage: [{type: 'tags', id: 3}, {type: 'tags', id: 4}]}
              }
            }
          }
@@ -537,8 +537,8 @@ class PostsControllerTest < ActionController::TestCase
              title: 'JR is Great!',
              body: 'JSONAPIResources is the greatest thing since unsliced bread!',
              links: {
-               author: {type: 'people', id: '3'},
-               tags: [{type: 'tags', id: 3}, {type: 'tags', id: 4}]
+               author: {linkage: {type: 'people', id: '3'}},
+               tags: {linkage: [{type: 'tags', id: 3}, {type: 'tags', id: 4}]}
              }
            },
            include: 'author,author.posts',
@@ -564,8 +564,8 @@ class PostsControllerTest < ActionController::TestCase
             type: 'posts',
             title: 'A great new Post',
             links: {
-              section: {type: 'sections', id: "#{javascript.id}"},
-              tags: [{type: 'tags', id: 3}, {type: 'tags', id: 4}]
+              section: {linkage: {type: 'sections', id: "#{javascript.id}"}},
+              tags: {linkage: [{type: 'tags', id: 3}, {type: 'tags', id: 4}]}
             }
           },
           include: 'tags'
@@ -614,7 +614,7 @@ class PostsControllerTest < ActionController::TestCase
     post_object = Post.find(4)
     assert_not_equal ruby.id, post_object.section_id
 
-    put :update_association, {post_id: 4, association: 'section', data: {type: 'sections', id: "#{ruby.id}"}}
+    put :update_association, {post_id: 4, association: 'section', data: {linkage: {type: 'sections', id: "#{ruby.id}"}}}
 
     assert_response :no_content
     post_object = Post.find(4)
@@ -623,7 +623,7 @@ class PostsControllerTest < ActionController::TestCase
 
   def test_update_relationship_has_one_invalid_links_hash_keys_ids
     set_content_type_header!
-    put :update_association, {post_id: 3, association: 'section', data: {type: 'sections', ids: 'foo'}}
+    put :update_association, {post_id: 3, association: 'section', data: {linkage: {type: 'sections', ids: 'foo'}}}
 
     assert_response :bad_request
     assert_match /Invalid Links Object/, response.body
@@ -631,7 +631,7 @@ class PostsControllerTest < ActionController::TestCase
 
   def test_update_relationship_has_one_invalid_links_hash_count
     set_content_type_header!
-    put :update_association, {post_id: 3, association: 'section', data: {type: 'sections'}}
+    put :update_association, {post_id: 3, association: 'section', data: {linkage: {type: 'sections'}}}
 
     assert_response :bad_request
     assert_match /Invalid Links Object/, response.body
@@ -639,7 +639,7 @@ class PostsControllerTest < ActionController::TestCase
 
   def test_update_relationship_has_many_not_array
     set_content_type_header!
-    put :update_association, {post_id: 3, association: 'tags', data: {type: 'tags', id: 2}}
+    put :update_association, {post_id: 3, association: 'tags', data: {linkage: {type: 'tags', id: 2}}}
 
     assert_response :bad_request
     assert_match /Invalid Links Object/, response.body
@@ -647,7 +647,7 @@ class PostsControllerTest < ActionController::TestCase
 
   def test_update_relationship_has_one_invalid_links_hash_keys_type_mismatch
     set_content_type_header!
-    put :update_association, {post_id: 3, association: 'section', data: {type: 'comment', id: '3'}}
+    put :update_association, {post_id: 3, association: 'section', data: {linkage: {type: 'comment', id: '3'}}}
 
     assert_response :bad_request
     assert_match /Type Mismatch/, response.body
@@ -714,7 +714,7 @@ class PostsControllerTest < ActionController::TestCase
     post_object.section = ruby
     post_object.save!
 
-    put :update_association, {post_id: 3, association: 'section', data: {type: 'sections', id: nil}}
+    put :update_association, {post_id: 3, association: 'section', data: {linkage: {type: 'sections', id: nil}}}
 
     assert_response :no_content
     assert_equal nil, post_object.reload.section_id
@@ -754,7 +754,7 @@ class PostsControllerTest < ActionController::TestCase
     post_object.section_id = nil
     post_object.save!
 
-    put :update_association, {post_id: 3, association: 'section', data: {type: 'sections', id: "#{ruby.id}"}}
+    put :update_association, {post_id: 3, association: 'section', data: {linkage: {type: 'sections', id: "#{ruby.id}"}}}
 
     assert_response :no_content
     post_object = Post.find(3)
@@ -769,13 +769,13 @@ class PostsControllerTest < ActionController::TestCase
     post_object = Post.find(3)
     assert_equal 0, post_object.tags.length
 
-    put :update_association, {post_id: 3, association: 'tags', data: [{type: 'tags', id: 2}]}
+    put :update_association, {post_id: 3, association: 'tags', data: {linkage: [{type: 'tags', id: 2}]}}
 
     assert_response :no_content
     post_object = Post.find(3)
     assert_equal 1, post_object.tags.length
 
-    put :update_association, {post_id: 3, association: 'tags', data: [{type: 'tags', id: 5}]}
+    put :update_association, {post_id: 3, association: 'tags', data: {linkage: [{type: 'tags', id: 5}]}}
 
     assert_response :no_content
     post_object = Post.find(3)
@@ -786,7 +786,7 @@ class PostsControllerTest < ActionController::TestCase
 
   def test_update_relationship_has_many
     set_content_type_header!
-    put :update_association, {post_id: 3, association: 'tags', data: [{type: 'tags', id: 2}, {type: 'tags', id: 3}]}
+    put :update_association, {post_id: 3, association: 'tags', data: {linkage: [{type: 'tags', id: 2}, {type: 'tags', id: 3}]}}
 
     assert_response :no_content
     post_object = Post.find(3)
@@ -796,14 +796,14 @@ class PostsControllerTest < ActionController::TestCase
 
   def test_create_relationship_has_many_join_table
     set_content_type_header!
-    put :update_association, {post_id: 3, association: 'tags', data: [{type: 'tags', id: 2}, {type: 'tags', id: 3}]}
+    put :update_association, {post_id: 3, association: 'tags', data: {linkage: [{type: 'tags', id: 2}, {type: 'tags', id: 3}]}}
 
     assert_response :no_content
     post_object = Post.find(3)
     assert_equal 2, post_object.tags.collect { |tag| tag.id }.length
     assert matches_array? [2, 3], post_object.tags.collect { |tag| tag.id }
 
-    post :create_association, {post_id: 3, association: 'tags', data: [{type: 'tags', id: 5}]}
+    post :create_association, {post_id: 3, association: 'tags', data: {linkage: [{type: 'tags', id: 5}]}}
 
     assert_response :no_content
     post_object = Post.find(3)
@@ -813,7 +813,7 @@ class PostsControllerTest < ActionController::TestCase
 
   def test_create_relationship_has_many_mismatched_type
     set_content_type_header!
-    post :create_association, {post_id: 3, association: 'tags', data: [{type: 'comments', id: 5}]}
+    post :create_association, {post_id: 3, association: 'tags', data: {linkage: [{type: 'comments', id: 5}]}}
 
     assert_response :bad_request
     assert_match /Type Mismatch/, response.body
@@ -821,7 +821,7 @@ class PostsControllerTest < ActionController::TestCase
 
   def test_create_relationship_has_many_missing_id
     set_content_type_header!
-    post :create_association, {post_id: 3, association: 'tags', data: [{type: 'tags', idd: 5}]}
+    post :create_association, {post_id: 3, association: 'tags', data: {linkage: [{type: 'tags', idd: 5}]}}
 
     assert_response :bad_request
     assert_match /Data is not a valid Links Object./, response.body
@@ -829,7 +829,7 @@ class PostsControllerTest < ActionController::TestCase
 
   def test_create_relationship_has_many_not_array
     set_content_type_header!
-    post :create_association, {post_id: 3, association: 'tags', data: {type: 'tags', id: 5}}
+    post :create_association, {post_id: 3, association: 'tags', data: {linkage: {type: 'tags', id: 5}}}
 
     assert_response :bad_request
     assert_match /Data is not a valid Links Object./, response.body
@@ -845,20 +845,20 @@ class PostsControllerTest < ActionController::TestCase
 
   def test_create_relationship_has_many_join
     set_content_type_header!
-    post :create_association, {post_id: 4, association: 'tags', data: [{type: 'tags', id: 1}, {type: 'tags', id: 2}, {type: 'tags', id: 3}]}
+    post :create_association, {post_id: 4, association: 'tags', data: {linkage: [{type: 'tags', id: 1}, {type: 'tags', id: 2}, {type: 'tags', id: 3}]}}
     assert_response :no_content
   end
 
   def test_create_relationship_has_many_join_table_record_exists
     set_content_type_header!
-    put :update_association, {post_id: 3, association: 'tags', data: [{type: 'tags', id: 2}, {type: 'tags', id: 3}]}
+    put :update_association, {post_id: 3, association: 'tags', data: {linkage: [{type: 'tags', id: 2}, {type: 'tags', id: 3}]}}
 
     assert_response :no_content
     post_object = Post.find(3)
     assert_equal 2, post_object.tags.collect { |tag| tag.id }.length
     assert matches_array? [2, 3], post_object.tags.collect { |tag| tag.id }
 
-    post :create_association, {post_id: 3, association: 'tags', data: [{type: 'tags', id: 2}, {type: 'tags', id: 5}]}
+    post :create_association, {post_id: 3, association: 'tags', data: {linkage: [{type: 'tags', id: 2}, {type: 'tags', id: 5}]}}
 
     assert_response :bad_request
     assert_match /The relation to 2 already exists./, response.body
@@ -874,7 +874,7 @@ class PostsControllerTest < ActionController::TestCase
 
   def test_delete_relationship_has_many
     set_content_type_header!
-    put :update_association, {post_id: 14, association: 'tags', data: [{type: 'tags', id: 2}, {type: 'tags', id: 3}]}
+    put :update_association, {post_id: 14, association: 'tags', data: {linkage: [{type: 'tags', id: 2}, {type: 'tags', id: 3}]}}
     assert_response :no_content
     p = Post.find(14)
     assert_equal [2, 3], p.tag_ids
@@ -888,7 +888,7 @@ class PostsControllerTest < ActionController::TestCase
 
   def test_delete_relationship_has_many_does_not_exist
     set_content_type_header!
-    put :update_association, {post_id: 14, association: 'tags', data: [{type: 'tags', id: 2}, {type: 'tags', id: 3}]}
+    put :update_association, {post_id: 14, association: 'tags', data: {linkage: [{type: 'tags', id: 2}, {type: 'tags', id: 3}]}}
     assert_response :no_content
     p = Post.find(14)
     assert_equal [2, 3], p.tag_ids
@@ -902,7 +902,7 @@ class PostsControllerTest < ActionController::TestCase
 
   def test_delete_relationship_has_many_with_empty_data
     set_content_type_header!
-    put :update_association, {post_id: 14, association: 'tags', data: [{type: 'tags', id: 2}, {type: 'tags', id: 3}]}
+    put :update_association, {post_id: 14, association: 'tags', data: {linkage: [{type: 'tags', id: 2}, {type: 'tags', id: 3}]}}
     assert_response :no_content
     p = Post.find(14)
     assert_equal [2, 3], p.tag_ids
@@ -1054,8 +1054,8 @@ class PostsControllerTest < ActionController::TestCase
               id: 3,
               title: 'A great new Post QWERTY',
               links: {
-                section: {type: 'sections', id: "#{javascript.id}"},
-                tags: [{type: 'tags', id: 3}, {type: 'tags', id: 4}]
+                section: {linkage: {type: 'sections', id: "#{javascript.id}"}},
+                tags: {linkage: [{type: 'tags', id: 3}, {type: 'tags', id: 4}]}
               }
             },
             {
@@ -1063,8 +1063,8 @@ class PostsControllerTest < ActionController::TestCase
               id: 16,
               title: 'A great new Post ASDFG',
               links: {
-                section: {type: 'sections', id: "#{javascript.id}"},
-                tags: [{type: 'tags', id: 3}, {type: 'tags', id: 4}]
+                section: {linkage: {type: 'sections', id: "#{javascript.id}"}},
+                tags: {linkage: [{type: 'tags', id: 3}, {type: 'tags', id: 4}]}
               }
             }
           ],
@@ -1131,8 +1131,8 @@ class PostsControllerTest < ActionController::TestCase
               id: 3,
               title: 'A great new Post ASDFG',
               links: {
-                section: {type: 'sections', id: "#{javascript.id}"},
-                tags: [{type: 'tags', id: 3}, {type: 'tags', id: 4}]
+                section: {linkage: {type: 'sections', id: "#{javascript.id}"}},
+                tags: {linkage: [{type: 'tags', id: 3}, {type: 'tags', id: 4}]}
               }
             },
             {
@@ -1140,8 +1140,8 @@ class PostsControllerTest < ActionController::TestCase
               id: 8,
               title: 'A great new Post QWERTY',
               links: {
-                section: {type: 'sections', id: "#{javascript.id}"},
-                tags: [{type: 'tags', id: 3}, {type: 'tags', id: 4}]
+                section: {linkage: {type: 'sections', id: "#{javascript.id}"}},
+                tags: {linkage: [{type: 'tags', id: 3}, {type: 'tags', id: 4}]}
               }
             }
           ]}
@@ -1385,8 +1385,8 @@ class ExpenseEntriesControllerTest < ActionController::TestCase
              transaction_date: '2014/04/15',
              cost: 50.58,
              links: {
-               employee: {type: 'people', id: '3'},
-               iso_currency: {type: 'iso_currencies', id: 'USD'}
+               employee: {linkage: {type: 'people', id: '3'}},
+               iso_currency: {linkage: {type: 'iso_currencies', id: 'USD'}}
              }
            },
            include: 'iso_currency',
@@ -1414,8 +1414,8 @@ class ExpenseEntriesControllerTest < ActionController::TestCase
              transactionDate: '2014/04/15',
              cost: 50.58,
              links: {
-               employee: {type: 'people', id: '3'},
-               isoCurrency: {type: 'iso_currencies', id: 'USD'}
+               employee: {linkage: {type: 'people', id: '3'}},
+               isoCurrency: {linkage: {type: 'iso_currencies', id: 'USD'}}
              }
            },
            include: 'isoCurrency',
@@ -1443,8 +1443,8 @@ class ExpenseEntriesControllerTest < ActionController::TestCase
              'transaction-date' => '2014/04/15',
              cost: 50.58,
              links: {
-               employee: {type: 'people', id: '3'},
-               'iso-currency' => {type: 'iso_currencies', id: 'USD'}
+               employee: {linkage: {type: 'people', id: '3'}},
+               'iso-currency' => {linkage: {type: 'iso_currencies', id: 'USD'}}
              }
            },
            include: 'iso-currency',
@@ -1772,7 +1772,7 @@ class Api::V1::PostsControllerTest < ActionController::TestCase
              title: 'JR - now with Namespacing',
              body: 'JSONAPIResources is the greatest thing since unsliced bread now that it has namespaced resources.',
              links: {
-               writer: {type: 'writers', id: '3'}
+               writer: { linkage: {type: 'writers', id: '3'}}
              }
            }
          }

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -732,6 +732,7 @@ class PostsControllerTest < ActionController::TestCase
     post_object.section = ruby
     post_object.save!
 
+    put :update_association, {post_id: 3, association: 'section', data: {type: 'sections', id: nil}}
 
     assert_response :no_content
     assert_equal nil, post_object.reload.section_id

--- a/test/integration/requests/request_test.rb
+++ b/test/integration/requests/request_test.rb
@@ -165,14 +165,14 @@ class RequestTest < ActionDispatch::IntegrationTest
 
   def test_patch_update_association_has_one
     ruby = Section.find_by(name: 'ruby')
-    patch '/posts/3/links/section', { 'data' => {linkage: {type: 'sections', id: ruby.id.to_s }}}.to_json, "CONTENT_TYPE" => JSONAPI::MEDIA_TYPE
+    patch '/posts/3/links/section', { 'data' => {type: 'sections', id: ruby.id.to_s }}.to_json, "CONTENT_TYPE" => JSONAPI::MEDIA_TYPE
 
     assert_equal 204, status
   end
 
   def test_put_update_association_has_one
     ruby = Section.find_by(name: 'ruby')
-    put '/posts/3/links/section', { 'data' => {linkage: {type: 'sections', id: ruby.id.to_s }}}.to_json, "CONTENT_TYPE" => JSONAPI::MEDIA_TYPE
+    put '/posts/3/links/section', { 'data' => {type: 'sections', id: ruby.id.to_s }}.to_json, "CONTENT_TYPE" => JSONAPI::MEDIA_TYPE
 
     assert_equal 204, status
   end
@@ -372,7 +372,7 @@ class RequestTest < ActionDispatch::IntegrationTest
     post_1 = json_response['data'][4]
 
     post post_1['links']['tags']['self'],
-         {'data' => {'linkage' => [{'type' => 'tags', 'id' => '10'}]}}.to_json,
+         {'data' => [{'type' => 'tags', 'id' => '10'}]}.to_json,
          "CONTENT_TYPE" => JSONAPI::MEDIA_TYPE
 
     assert_equal 204, status

--- a/test/integration/requests/request_test.rb
+++ b/test/integration/requests/request_test.rb
@@ -108,10 +108,12 @@ class RequestTest < ActionDispatch::IntegrationTest
             'id' => '3',
             'title' => 'A great new Post',
             'links' => {
-              'tags' => [
-                {type: 'tags', id: 3},
-                {type: 'tags', id: 4}
-              ]
+              'tags' => {
+                'linkage' => [
+                  {type: 'tags', id: 3},
+                  {type: 'tags', id: 4}
+                ]
+              }
             }
           }
         }.to_json, "CONTENT_TYPE" => JSONAPI::MEDIA_TYPE
@@ -125,10 +127,12 @@ class RequestTest < ActionDispatch::IntegrationTest
         'posts' => {
           'title' => 'A great new Post',
           'links' => {
-            'tags' => [
-              {type: 'tags', id: 3},
-              {type: 'tags', id: 4}
-            ]
+            'tags' => {
+              'linkage' => [
+                  {type: 'tags', id: 3},
+                  {type: 'tags', id: 4}
+                ]
+            }
           }
         }
       }.to_json, "CONTENT_TYPE" => "application/json"
@@ -144,7 +148,7 @@ class RequestTest < ActionDispatch::IntegrationTest
           'title' => 'A great new Post',
           'body' => 'JSONAPIResources is the greatest thing since unsliced bread.',
           'links' => {
-            'author' => {type: 'people', id: '3'}
+            'author' => {'linkage' => {type: 'people', id: '3'}}
           }
         }
       }.to_json, "CONTENT_TYPE" => JSONAPI::MEDIA_TYPE
@@ -161,14 +165,14 @@ class RequestTest < ActionDispatch::IntegrationTest
 
   def test_patch_update_association_has_one
     ruby = Section.find_by(name: 'ruby')
-    patch '/posts/3/links/section', { 'data' => {type: 'sections', id: ruby.id.to_s }}.to_json, "CONTENT_TYPE" => JSONAPI::MEDIA_TYPE
+    patch '/posts/3/links/section', { 'data' => {linkage: {type: 'sections', id: ruby.id.to_s }}}.to_json, "CONTENT_TYPE" => JSONAPI::MEDIA_TYPE
 
     assert_equal 204, status
   end
 
   def test_put_update_association_has_one
     ruby = Section.find_by(name: 'ruby')
-    put '/posts/3/links/section', { 'data' => {type: 'sections', id: ruby.id.to_s }}.to_json, "CONTENT_TYPE" => JSONAPI::MEDIA_TYPE
+    put '/posts/3/links/section', { 'data' => {linkage: {type: 'sections', id: ruby.id.to_s }}}.to_json, "CONTENT_TYPE" => JSONAPI::MEDIA_TYPE
 
     assert_equal 204, status
   end
@@ -191,10 +195,12 @@ class RequestTest < ActionDispatch::IntegrationTest
             'id' => '3',
             'title' => 'A great new Post',
             'links' => {
-              'tags' => [
-                {type: 'tags', id: 3},
-                {type: 'tags', id: 4}
-              ]
+              'tags' => {
+                'linkage' => [
+                  {type: 'tags', id: 3},
+                  {type: 'tags', id: 4}
+                ]
+              }
             }
           }
         }.to_json, "CONTENT_TYPE" => JSONAPI::MEDIA_TYPE
@@ -210,10 +216,12 @@ class RequestTest < ActionDispatch::IntegrationTest
             'id' => '3',
             'title' => 'A great new Post',
             'links' => {
-              'tags' => [
-                {type: 'tags', id: 3},
-                {type: 'tags', id: 4}
-              ]
+              'tags' => {
+                'linkage' => [
+                  {type: 'tags', id: 3},
+                  {type: 'tags', id: 4}
+                ]
+              }
             }
           }
         }.to_json, "CONTENT_TYPE" => JSONAPI::MEDIA_TYPE
@@ -228,7 +236,7 @@ class RequestTest < ActionDispatch::IntegrationTest
          'type' => 'posts',
          'title' => 'A great new Post',
          'links' => {
-           'author' => {type: 'people', id: '3'}
+           'author' => {'linkage' => {type: 'people', id: '3'}}
          }
        }
      }.to_json, "CONTENT_TYPE" => JSONAPI::MEDIA_TYPE
@@ -364,7 +372,7 @@ class RequestTest < ActionDispatch::IntegrationTest
     post_1 = json_response['data'][4]
 
     post post_1['links']['tags']['self'],
-         {'data' => [{'type' => 'tags', 'id' => '10'}]}.to_json,
+         {'data' => {'linkage' => [{'type' => 'tags', 'id' => '10'}]}}.to_json,
          "CONTENT_TYPE" => JSONAPI::MEDIA_TYPE
 
     assert_equal 204, status


### PR DESCRIPTION
This PR updates #140, since the the updates to associations should not include the `linkage` key, only the value. See:
http://jsonapi.org/format/#crud-updating-to-one-relationships
http://jsonapi.org/format/#crud-updating-to-many-relationships

Thanks for the initial work @sirvine.
