### PR TITLE
Spec compliance for null linkage for to-one relationships.

### DIFF
--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -250,6 +250,8 @@ module JSONAPI
       if linkage_id
         linkage[:type] = format_route(association.type)
         linkage[:id] = linkage_id
+      else
+        linkage = nil
       end
       linkage
     end

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -634,7 +634,7 @@ class PostsControllerTest < ActionController::TestCase
     assert_response :success
     assert json_response['data'].is_a?(Hash)
     assert_equal '3', json_response['data']['links']['author']['linkage']['id']
-    assert_equal nil, json_response['data']['links']['section']['linkage']['id']
+    assert_equal nil, json_response['data']['links']['section']['linkage']
     assert_equal 'A great new Post', json_response['data']['title']
     assert_equal 'AAAA', json_response['data']['body']
     assert matches_array?([],

--- a/test/unit/serializer/serializer_test.rb
+++ b/test/unit/serializer/serializer_test.rb
@@ -31,7 +31,7 @@ class SerializerTest < ActionDispatch::IntegrationTest
             section: {
               self: 'http://example.com/posts/1/links/section',
               related: 'http://example.com/posts/1/section',
-              linkage: { }
+              linkage: nil
             },
             author: {
               self: 'http://example.com/posts/1/links/author',
@@ -71,8 +71,7 @@ class SerializerTest < ActionDispatch::IntegrationTest
             section: {
               self: 'http://example.com/api/v1/posts/1/links/section',
               related: 'http://example.com/api/v1/posts/1/section',
-              linkage: {
-              }
+              linkage: nil
             },
             writer: {
               self: 'http://example.com/api/v1/posts/1/links/writer',
@@ -136,8 +135,7 @@ class SerializerTest < ActionDispatch::IntegrationTest
             section: {
               self: '/posts/1/links/section',
               related: '/posts/1/section',
-              linkage: {
-              }
+              linkage: nil
             },
             author: {
               self: '/posts/1/links/author',
@@ -205,8 +203,7 @@ class SerializerTest < ActionDispatch::IntegrationTest
             section: {
               self: '/posts/1/links/section',
               related: '/posts/1/section',
-              linkage: {
-              }
+              linkage: nil
             },
             author: {
               self: '/posts/1/links/author',
@@ -276,8 +273,7 @@ class SerializerTest < ActionDispatch::IntegrationTest
             section: {
               self: '/posts/1/links/section',
               related: '/posts/1/section',
-              linkage: {
-              }
+              linkage: nil
             },
             author: {
               self: '/posts/1/links/author',
@@ -424,8 +420,7 @@ class SerializerTest < ActionDispatch::IntegrationTest
             section: {
               self: '/posts/1/links/section',
               related: '/posts/1/section',
-              linkage: {
-              }
+              linkage: nil
             },
             author: {
               self: '/posts/1/links/author',
@@ -503,8 +498,7 @@ class SerializerTest < ActionDispatch::IntegrationTest
             section: {
               self: '/posts/1/links/section',
               related: '/posts/1/section',
-              linkage: {
-              }
+              linkage: nil
             },
             author: {
               self: '/posts/1/links/author',
@@ -587,8 +581,7 @@ class SerializerTest < ActionDispatch::IntegrationTest
             preferences: {
               self: "/people/2/links/preferences",
               related: "/people/2/preferences",
-              linkage: {
-              }
+              linkage: nil
             }
           }
         },
@@ -676,8 +669,7 @@ class SerializerTest < ActionDispatch::IntegrationTest
               section: {
                 self: '/posts/1/links/section',
                 related: '/posts/1/section',
-                linkage: {
-                }
+                linkage: nil
               },
               author: {
                 self: '/posts/1/links/author',
@@ -1129,8 +1121,7 @@ class SerializerTest < ActionDispatch::IntegrationTest
             planetType: {
               self: '/planets/8/links/planet_type',
               related: '/planets/8/planet_type',
-              linkage: {
-              }
+              linkage: nil
             },
             tags: {
               self: '/planets/8/links/tags',
@@ -1192,8 +1183,7 @@ class SerializerTest < ActionDispatch::IntegrationTest
             planetType: {
               self: '/planets/8/links/planet_type',
               related: '/planets/8/planet_type',
-              linkage: {
-              }
+              linkage: nil
             },
             tags: {
               self: '/planets/8/links/tags',
@@ -1235,8 +1225,7 @@ class SerializerTest < ActionDispatch::IntegrationTest
             author: {
               self: '/preferences/1/links/author',
               related: '/preferences/1/author',
-              linkage: {
-              }
+              linkage: nil
             },
             friends: {
               self: '/preferences/1/links/friends',


### PR DESCRIPTION
I think I'm reading the spec correctly here, it says:

```
Resource linkage MUST be represented as one of the following:
- null for empty to-one relationships.
```

http://jsonapi.org/format/#document-structure-resource-relationships

But right now these relationships return empty hashes.
