### PR TITLE
Correct handling for to-one nil relationships.

### DIFF
--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -110,6 +110,8 @@ module JSONAPI
           add_included_object(@primary_class_name, id, object_hash(resource,  requested_associations), true)
         end
       else
+        return {} if source.nil?
+
         resource = source
         id = resource.id
         # ToDo: See if this is actually needed

--- a/test/unit/serializer/serializer_test.rb
+++ b/test/unit/serializer/serializer_test.rb
@@ -57,6 +57,15 @@ class SerializerTest < ActionDispatch::IntegrationTest
     )
   end
 
+  def test_serializer_nil_handling
+    assert_hash_equals(
+      {
+        data: nil
+      },
+      JSONAPI::ResourceSerializer.new(PostResource).serialize_to_hash(nil)
+    )
+  end
+
   def test_serializer_namespaced_resource
     assert_hash_equals(
       {


### PR DESCRIPTION
Hey friends, hit another one—the spec says:

> A server MUST respond to a successful request to fetch an individual resource with a resource object or null provided as the response document's primary data.
> 
> _Note: null is only an appropriate response for fetching a to-one related resource URL to indicate the absence of a resource in the relationship._

Right now, JR 500's when requesting to-one relationships that are nil:

/v1/objects/123/some-resource
![traceback](https://cloud.githubusercontent.com/assets/75300/7028137/c74819ec-dd08-11e4-9c77-83d9a5bf187e.png)

I can successfully fix this with the patch below, however I'm not sure if you want this because it makes `serialize_to_hash(nil)` work without error, which seems like a bit of a broad behavior to introduce to fix this. Let me know if there's a better place to do this?
