### PR TITLE
Specify Rails 4.0+

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Like JSON API itself, JR's design is focused on the resources served by an API. JR needs little more than a definition of your resources, including their attributes and relationships, to make your server compliant with JSON API.
 
-JR is designed to work with Rails, and provides custom routes, controllers, and serializers. JR's resources may be backed by ActiveRecord models or by custom objects.
+JR is designed to work with Rails 4.0+, and provides custom routes, controllers, and serializers. JR's resources may be backed by ActiveRecord models or by custom objects.
 
 ## Demo App
 

--- a/jsonapi-resources.gemspec
+++ b/jsonapi-resources.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest-spec-rails'
   spec.add_development_dependency 'minitest-reporters'
   spec.add_development_dependency 'simplecov'
-  spec.add_development_dependency 'rails', '>= 4.0'
+  spec.add_dependency 'rails', '>= 4.0'
 end


### PR DESCRIPTION
So, this is a very nice gem.

However....

I just spent about a day integrating it into a largish Rails 3.2 app, but when I got to posting to create a new resource, I get this:

![error](http://clrsight.co/jh/2015-04-07-oku13.png?+)

After about an hour of banging my head against this, I realized that it's a Rails 4+ specific method.

It's possible that this gem could support Rails 3.2 relatively easily, but I don't know yet how many new Rails 4.0+ methods like this I'd run into. I'm not sure if I'll tackle it.

In any event, having a runtime dependency (not just a test dependency) on Rails 4.0 would have saved me a lot of frustration. Not to mention a README note. So here you are. Tests pass.
