### PR TITLE
Type only post requests

### DIFF
--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -199,8 +199,8 @@ module JSONAPI
 
     def parse_add_operation(data)
       Array.wrap(data).each do |p|
-          values = parse_params(verify_and_remove_type(p), @resource_klass.createable_fields(@context))
-          @operations.push JSONAPI::CreateResourceOperation.new(@resource_klass, values)
+        values = parse_params(verify_and_remove_type(p), @resource_klass.createable_fields(@context))
+        @operations.push JSONAPI::CreateResourceOperation.new(@resource_klass, values)
       end
     rescue JSONAPI::Exceptions::Error => e
       @errors.concat(e.errors)

--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -198,16 +198,9 @@ module JSONAPI
     end
 
     def parse_add_operation(data)
-      if data.is_a?(Array)
-        data.each do |p|
-          @operations.push JSONAPI::CreateResourceOperation.new(@resource_klass,
-                                                                parse_params(verify_and_remove_type(p),
-                                                                             @resource_klass.createable_fields(@context)))
-        end
-      else
-        @operations.push JSONAPI::CreateResourceOperation.new(@resource_klass,
-                                                              parse_params(verify_and_remove_type(data),
-                                                                           @resource_klass.createable_fields(@context)))
+      Array.wrap(data).each do |p|
+          values = parse_params(verify_and_remove_type(p), @resource_klass.createable_fields(@context))
+          @operations.push JSONAPI::CreateResourceOperation.new(@resource_klass, values)
       end
     rescue JSONAPI::Exceptions::Error => e
       @errors.concat(e.errors)

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -46,7 +46,7 @@ module JSONAPI
           @changing = true
           run_callbacks callback do
             yield
-            save if @save_needed
+            save if @save_needed || is_new?
           end
         end
       end

--- a/test/integration/requests/request_test.rb
+++ b/test/integration/requests/request_test.rb
@@ -156,6 +156,17 @@ class RequestTest < ActionDispatch::IntegrationTest
     assert_equal 201, status
   end
 
+  def test_post_single_minimal_invalid
+    post '/posts',
+      {
+        'data' => {
+          'type' => 'posts'
+        }
+      }.to_json, "CONTENT_TYPE" => JSONAPI::MEDIA_TYPE
+
+    assert_equal 422, status
+  end
+
   def test_update_association_without_content_type
     ruby = Section.find_by(name: 'ruby')
     patch '/posts/3/links/section', { 'data' => {type: 'sections', id: ruby.id.to_s }}.to_json
@@ -189,7 +200,7 @@ class RequestTest < ActionDispatch::IntegrationTest
   def test_post_update_association_has_many
     rogue = Comment.find_by(body: 'Rogue Comment Here')
     post '/posts/5/links/comments', { 'data' => [{type: 'comments', id: rogue.id.to_s }]}.to_json, "CONTENT_TYPE" => JSONAPI::MEDIA_TYPE
-    
+
     assert_equal 204, status
   end
 


### PR DESCRIPTION
First shot at addressing POST where the data object only contains a "type" member.

Relates to discussion in #151. Created resources with only "type" in the data don't get @save_needed set, so they never actually save the ActiveRecord model and they don't get a change to generate validation errors, leading to incorrect 201 status.

I've added an explicit check to Resource#change to save if the object is_new, but that's ugly. Any thoughts on where this should be fixed?
