### PR TITLE
Fix error on column names with underscores.

### DIFF
--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -347,7 +347,7 @@ module JSONAPI
             params_not_allowed.push(links_key) unless formatted_allowed_fields.include?(links_key.to_sym)
           end
         else
-          params_not_allowed.push(key) unless formatted_allowed_fields.include?(key.to_sym)
+          params_not_allowed.push(key) unless formatted_allowed_fields.include?(format_key(key).to_sym)
         end
       end
       raise JSONAPI::Exceptions::ParametersNotAllowed.new(params_not_allowed) if params_not_allowed.length > 0


### PR DESCRIPTION
The allowed fields are formatted and collected in
`formatted_allowed_fields` array, which is used during the comparison.
During comparison though, keys from the `params[:data]` hash are not
formatted before verifying whether they are allowed. Thus keys with
underscores will always fail. This fix makes sure the comparison is done
using the formatted version of the keys.
