### PR TITLE
Key type config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,18 +170,34 @@ The system will lookup a value formatter named `DateWithTimezoneValueFormatter` 
 #### Primary Key
 
 Resources are always represented using a key of `id`. If the underlying model does not use `id` as the primary key you can use the `primary_key` method to tell the resource which field on the model to use as the primary key. Note: this doesn't have to be the actual primary key of the model. For example you may wish to use integers internally and a different scheme publicly.
-By default only integer values are allowed for primary key. To change this behavior you can override `verify_key` class method:
+By default only integer values are allowed for primary key. To change this behavior you can set the `resource_key_type` in your initializer. For example, in your `config/initializers/jsonapi_resources.rb`:
 
 ```ruby
-class CurrencyResource < JSONAPI::Resource
-  primary_key :code
-  attributes :code, :name
+JSONAPI.configure do |config|
+  # Allowed values are :integer(default), :uuid, :string, or a proc
+  config.resource_key_type = :uuid
+end
+```
 
-  has_many :expense_entries
+##### Override key type on a resource
 
-  def self.verify_key(key, context = nil)
-    key && String(key)
-  end
+You can override the default resource key type on a per-resource basis by calling `key_type` in the resource class.
+
+```ruby
+class ContactResource < JSONAPI::Resource
+  attribute :id
+  attributes :name_first, :name_last, :email, :twitter
+  key_type :uuid
+end
+```
+
+##### Custom resource key validators
+
+If you need more control over the key, you can override the #verify_key method on your resource, or set a lambda that accepts key and context arguments in `config/initializers/jsonapi_resources.rb`:
+
+```ruby
+JSONAPI.configure do |config|
+  config.resource_key_type = -> (key, context) { key && String(key) }
 end
 ```
 

--- a/lib/jsonapi/configuration.rb
+++ b/lib/jsonapi/configuration.rb
@@ -3,6 +3,7 @@ require 'jsonapi/formatter'
 module JSONAPI
   class Configuration
     attr_reader :json_key_format,
+                :resource_key_type,
                 :key_formatter,
                 :route_format,
                 :route_formatter,
@@ -14,6 +15,9 @@ module JSONAPI
     def initialize
       #:underscored_key, :camelized_key, :dasherized_key, or custom
       self.json_key_format = :dasherized_key
+
+      #:integer, :uuid, :string, or custom
+      self.resource_key_type = :integer
 
       #:underscored_route, :camelized_route, :dasherized_route, or custom
       self.route_format = :dasherized_route
@@ -30,6 +34,10 @@ module JSONAPI
     def json_key_format=(format)
       @json_key_format = format
       @key_formatter = JSONAPI::Formatter.formatter_for(format)
+    end
+
+    def resource_key_type=(key_type)
+      @resource_key_type = key_type
     end
 
     def route_format=(format)

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -390,9 +390,26 @@ module JSONAPI
         end
       end
 
-      # override to allow for key processing and checking
+      def key_type(key_type)
+        @_resource_key_type = key_type.to_sym
+      end
+
       def verify_key(key, context = nil)
-        key && Integer(key)
+        key_type = @_resource_key_type || JSONAPI.configuration.resource_key_type
+        verification_proc = case key_type
+
+        when :integer
+          -> (key, context) { key && Integer(key) }
+        when :string
+          -> (key, context) { key && String(key) }
+        when :uuid
+          -> (key, context) { key.match(
+            /[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f0-9]{12}/) }
+        else
+          key_type
+        end
+
+        verification_proc.call(key, context)
       rescue
         raise JSONAPI::Exceptions::InvalidFieldValue.new(_primary_key, key)
       end

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -496,7 +496,7 @@ class PostResource < JSONAPI::Resource
   end
 
   def self.verify_key(key, context = nil)
-    raise JSONAPI::Exceptions::InvalidFieldValue.new(:id, key) unless is_num?(key)
+    super(key)
     raise JSONAPI::Exceptions::RecordNotFound.new(key) unless find_by_key(key, context: context)
     return key
   end
@@ -508,9 +508,7 @@ class IsoCurrencyResource < JSONAPI::Resource
 
   filter :country_name
 
-  def self.verify_key(key, context = nil)
-    key && String(key)
-  end
+  key_type :string
 end
 
 class ExpenseEntryResource < JSONAPI::Resource


### PR DESCRIPTION
Addresses #104. Allows users to set :integer, :uuid, :string, or custom lambda validation globally instead of overriding each resource. 

All current tests passing with minor mods to existing verify_key methods in the existing tests, it's working on my app as well - if you like this approach I can expand coverage to include the non-integer options. I noticed there is a resource, `IsoCurrencyResource`, in the test setup that was configured to verify String keys but I didn't see any tests that seem to use it.
