### PR TITLE
Ensure validation errors use correct formatter

### DIFF
--- a/lib/jsonapi/exceptions.rb
+++ b/lib/jsonapi/exceptions.rb
@@ -284,6 +284,11 @@ module JSONAPI
       attr_accessor :messages
       def initialize(messages)
         @messages = messages
+        @key_formatter = JSONAPI.configuration.key_formatter
+      end
+
+      def format_key(key)
+        @key_formatter.format(key)
       end
 
       def errors
@@ -292,7 +297,7 @@ module JSONAPI
             element[1].map do |message|
               JSONAPI::Error.new(code: JSONAPI::VALIDATION_ERROR,
                                  status: :unprocessable_entity,
-                                 title: "#{element[0]} - #{message}",
+                                 title: "#{format_key(element[0])} - #{message}",
                                  detail: message,
                                  path: "/#{element[0]}")
             end

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -1662,7 +1662,7 @@ class PeopleControllerTest < ActionController::TestCase
     assert_equal 2, json_response['errors'].size
     assert_equal JSONAPI::VALIDATION_ERROR, json_response['errors'][0]['code']
     assert_equal JSONAPI::VALIDATION_ERROR, json_response['errors'][1]['code']
-    assert_match /date_joined - can't be blank/, response.body
+    assert_match /dateJoined - can't be blank/, response.body
     assert_match /name - can't be blank/, response.body
   end
 


### PR DESCRIPTION
Previously all validation errors returned to the client included keys
formatted in the ruby underscore style. To ensure clients receive
consistently formatted keys they should be formatted in the error 
message before responding.

If you can think of a better way to load the `key_formatter` into the error class I'm happy to make the changes.
