### PR TITLE
Unformat the linkage type.

### DIFF
--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -233,7 +233,7 @@ module JSONAPI
       end
 
       {
-        type: raw['type'],
+        type: unformat_key(raw['type']).to_s,
         id: raw['id']
       }
     end
@@ -281,7 +281,7 @@ module JSONAPI
               # Since we do not yet support polymorphic associations we will raise an error if the type does not match the
               # association's type.
               # ToDo: Support Polymorphic associations
-              if links_object[:type] && (links_object[:type] != association.type.to_s)
+              if links_object[:type] && (links_object[:type].to_s != association.type.to_s)
                 raise JSONAPI::Exceptions::TypeMismatch.new(links_object[:type])
               end
 

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -1658,7 +1658,7 @@ class PeopleControllerTest < ActionController::TestCase
             id: '3',
             type: 'people',
             links: {
-              'hair-cut': {
+              'hair-cut' => {
                 linkage: {
                   type: 'hair-cuts',
                   id: '1'

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -1738,7 +1738,7 @@ class PeopleControllerTest < ActionController::TestCase
          type: 'people',
          name: 'Joe Author',
          email: 'joe@xyz.fake',
-         "date-joined": '2013-08-07 16:25:00 -0400',
+         "date-joined" => '2013-08-07 16:25:00 -0400',
          links: {
            self: 'http://test.host/people/1',
            comments: {

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -12,6 +12,7 @@ ActiveRecord::Schema.define do
     t.string     :email
     t.datetime   :date_joined
     t.belongs_to :preferences
+    t.integer :hair_cut_id, index: true
     t.timestamps null: false
   end
 
@@ -142,6 +143,10 @@ ActiveRecord::Schema.define do
     t.float    :item_cost
     t.timestamps null: false
   end
+
+  create_table :hair_cuts, force: true do |t|
+    t.string :style
+  end
 end
 
 ### MODELS
@@ -150,6 +155,7 @@ class Person < ActiveRecord::Base
   has_many :comments, foreign_key: 'author_id'
   has_many :expense_entries, foreign_key: 'employee_id', dependent: :restrict_with_exception
   belongs_to :preferences
+  belongs_to :hair_cut
 
   ### Validations
   validates :name, presence: true
@@ -439,6 +445,7 @@ class PersonResource < JSONAPI::Resource
   has_many :posts
 
   has_one :preferences
+  has_one :hair_cut
 
   filter :name
 
@@ -559,6 +566,11 @@ class PostResource < JSONAPI::Resource
     raise JSONAPI::Exceptions::RecordNotFound.new(key) unless find_by_key(key, context: context)
     return key
   end
+end
+
+class HairCutResource < JSONAPI::Resource
+  attribute :style
+  has_many :people
 end
 
 class IsoCurrencyResource < JSONAPI::Resource
@@ -703,6 +715,7 @@ module Api
     PreferencesResource = PreferencesResource.dup
     EmployeeResource = EmployeeResource.dup
     FriendResource = FriendResource.dup
+    HairCutResource = HairCutResource.dup
   end
 end
 

--- a/test/fixtures/hair_cuts.yml
+++ b/test/fixtures/hair_cuts.yml
@@ -1,0 +1,3 @@
+mohawk:
+  id: 1
+  style: mohawk

--- a/test/unit/serializer/serializer_test.rb
+++ b/test/unit/serializer/serializer_test.rb
@@ -131,6 +131,10 @@ class SerializerTest < ActionDispatch::IntegrationTest
   end
 
   def test_serializer_include
+    serialized = JSONAPI::ResourceSerializer.new(
+      PostResource,
+      include: [:author]
+    ).serialize_to_hash(PostResource.new(@post))
 
     assert_hash_equals(
       {
@@ -189,16 +193,26 @@ class SerializerTest < ActionDispatch::IntegrationTest
                  type: 'preferences',
                  id: '1'
                }
+             },
+             hairCut: {
+               self: "/people/1/links/hairCut",
+               related: "/people/1/hairCut",
+               linkage: nil
              }
             }
           }
         ]
       },
-      JSONAPI::ResourceSerializer.new(PostResource, include: [:author]).serialize_to_hash(
-        PostResource.new(@post)))
+      serialized
+    )
   end
 
   def test_serializer_key_format
+    serialized = JSONAPI::ResourceSerializer.new(
+      PostResource,
+      include: [:author],
+      key_formatter: UnderscoredKeyFormatter
+    ).serialize_to_hash(PostResource.new(@post))
 
     assert_hash_equals(
       {
@@ -257,14 +271,17 @@ class SerializerTest < ActionDispatch::IntegrationTest
                   type: 'preferences',
                   id: '1'
                 }
+              },
+              hair_cut: {
+                self: '/people/1/links/hairCut',
+                related: '/people/1/hairCut',
+                linkage: nil
               }
             }
           }
         ]
       },
-      JSONAPI::ResourceSerializer.new(PostResource,
-                                      include: [:author],
-                                      key_formatter: UnderscoredKeyFormatter).serialize_to_hash(PostResource.new(@post))
+      serialized
     )
   end
 
@@ -565,6 +582,10 @@ class SerializerTest < ActionDispatch::IntegrationTest
   end
 
   def test_serializer_different_foreign_key
+    serialized = JSONAPI::ResourceSerializer.new(
+      PersonResource,
+      include: ['comments']
+    ).serialize_to_hash(PersonResource.new(@fred))
 
     assert_hash_equals(
       {
@@ -591,6 +612,11 @@ class SerializerTest < ActionDispatch::IntegrationTest
             preferences: {
               self: "/people/2/links/preferences",
               related: "/people/2/preferences",
+              linkage: nil
+            },
+            hairCut: {
+              self: "/people/2/links/hairCut",
+              related: "/people/2/hairCut",
               linkage: nil
             }
           }
@@ -654,7 +680,7 @@ class SerializerTest < ActionDispatch::IntegrationTest
           }
         ]
       },
-      JSONAPI::ResourceSerializer.new(PersonResource, include: ['comments']).serialize_to_hash(PersonResource.new(@fred))
+      serialized
     )
   end
 


### PR DESCRIPTION
The linkage key was not being unformatted and was causing errors if there was a multiword key (because the raw key would not match the association name). This change unformats the key which fixes that bug.
