### PR TITLE
Check for key on association.type should reference unformatted key

### DIFF
--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -309,7 +309,7 @@ module JSONAPI
               if links_object.length == 0
                 checked_has_many_associations[param] = []
               else
-                if links_object.length > 1 || !links_object.has_key?(format_key(association.type))
+                if links_object.length > 1 || !links_object.has_key?(unformat_key(association.type).to_s)
                   raise JSONAPI::Exceptions::TypeMismatch.new(links_object[:type])
                 end
 


### PR DESCRIPTION
I wasn't able to get has_many associations with multiword keys to pass `has_key?` check unless they are unformatted.  Note that line 317 uses the unformatted key, too.
