### PR TITLE
Update resource naming to fix plural cases

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -457,7 +457,7 @@ module JSONAPI
       def _resource_name_from_type(type)
         class_name = @@resource_types[type]
         if class_name.nil?
-          class_name = type.to_s.singularize.camelize + 'Resource'
+          class_name = "#{type.to_s.singularize}_resource".camelize
           @@resource_types[type] = class_name
         end
         return class_name

--- a/lib/jsonapi/resource_controller.rb
+++ b/lib/jsonapi/resource_controller.rb
@@ -143,7 +143,7 @@ module JSONAPI
     end
 
     def resource_klass_name
-      @resource_klass_name ||= "#{self.class.name.sub(/Controller$/, '').singularize}Resource"
+      @resource_klass_name ||= "#{self.class.name.underscore.sub(/_controller$/, '').singularize}_resource".camelize
     end
 
     def ensure_correct_media_type


### PR DESCRIPTION
This fix is useful for some kinds of words, specially not english words:

```
ActiveSupport::Inflector.inflections { |inflect| inflect.irregular 'foo_bar', 'foos_bar' }

"foo_bar".pluralize => "foos_bar"
"foos_bar".singularize => "foo_bar"

"#{"FoosBarController".sub(/Controller$/, '').singularize}Resource"
=> "FoosBarResource" # wrong

"#{"FoosBarController".underscore.sub(/_controller$/, '').singularize}_resource".camelize
=> "FooBarResource" # right
```

All tests are passing, but I need some help to write new tests for this code.
