### PR TITLE
Save after 2nd callback in Resource#change

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -46,8 +46,9 @@ module JSONAPI
           @changing = true
           run_callbacks callback do
             yield
-            save if @save_needed || is_new?
           end
+
+          save if @save_needed || is_new?
         end
       end
     end


### PR DESCRIPTION
Instead of saving directly after the yield in the second `run_callbacks`
call, save after the second `run_callbacks` is finished when the resource
is not `@changing`.

This allows for using callbacks like `after_replace_fields` to work with
the model with the newly set attributes before it gets saved. This is
useful when doing authorization before creation, as well as using
non-datastore persisted attributes on the model to set specific data
on the model before it gets persisted.

Fixes https://github.com/cerebris/jsonapi-resources/issues/184
