### PR TITLE
Allow the use of a different base controller for JSONAPI::ResourceController

### DIFF
--- a/lib/jsonapi/configuration.rb
+++ b/lib/jsonapi/configuration.rb
@@ -10,7 +10,8 @@ module JSONAPI
                 :default_paginator,
                 :default_page_size,
                 :maximum_page_size,
-                :use_text_errors
+                :use_text_errors,
+                :base_controller
 
     def initialize
       #:underscored_key, :camelized_key, :dasherized_key, or custom
@@ -27,6 +28,8 @@ module JSONAPI
       self.default_page_size = 10
       self.maximum_page_size = 20
       self.use_text_errors = false
+
+      self.base_controller = "ActionController::Base"
     end
 
     def json_key_format=(format)
@@ -57,6 +60,10 @@ module JSONAPI
 
     def use_text_errors=(use_text_errors)
       @use_text_errors = use_text_errors
+    end
+
+    def base_controller=(base_controller)
+      @base_controller = base_controller
     end
   end
 

--- a/lib/jsonapi/resource_controller.rb
+++ b/lib/jsonapi/resource_controller.rb
@@ -9,7 +9,7 @@ require 'jsonapi/active_record_operations_processor'
 require 'csv'
 
 module JSONAPI
-  class ResourceController < ActionController::Base
+  class ResourceController < "#{JSONAPI.configuration.base_controller}".constantize
     before_filter :ensure_correct_media_type, only: [:create, :update, :create_association, :update_association]
     before_filter :setup_request
     after_filter :setup_response


### PR DESCRIPTION
I'm already using [Rails API](https://github.com/rails-api/rails-api) and I would like to continue using its `ActionController::API` controller as the base for my controllers.

Here's my first stab at a pull request for allowing the base controller for `JSONAPI::ResourceController` to be configurable from the configuration block.  This almost works perfectly except I've learned that the `JSONAPI::ResourceController`  is loaded before the initializer can be run (meaning I can't actually change the super class) so I've used the following workaround.
1. Change the line in my `Gemfile` to add `:require => false`
2. Create an initializer that looks as follows:

``` javascript
# config/initializers/jsonapi_resources.rb

require 'jsonapi/configuration'

JSONAPI.configure do |config|
  config.base_controller = "ActionController::API"
end

require "jsonapi-resources"
```

As you can see this is less than ideal (unless of course there is no other way).  Any suggestions?

Thanks
