### PR TITLE
Protect against page[number]=0 param

### DIFF
--- a/lib/jsonapi/paginator.rb
+++ b/lib/jsonapi/paginator.rb
@@ -34,6 +34,7 @@ class OffsetPaginator < JSONAPI::Paginator
       validparams = params.permit(:offset, :limit)
 
       @offset = validparams[:offset] ? validparams[:offset].to_i : 0
+      @offset = 0 if @offset < 0
       @limit = validparams[:limit] ? validparams[:limit].to_i : JSONAPI.configuration.default_page_size
 
       if @limit < 1

--- a/lib/jsonapi/paginator.rb
+++ b/lib/jsonapi/paginator.rb
@@ -19,6 +19,7 @@ end
 class OffsetPaginator < JSONAPI::Paginator
   def initialize(params)
     parse_pagination_params(params)
+    verify_pagination_params
   end
 
   def apply(relation)
@@ -34,26 +35,32 @@ class OffsetPaginator < JSONAPI::Paginator
       validparams = params.permit(:offset, :limit)
 
       @offset = validparams[:offset] ? validparams[:offset].to_i : 0
-      @offset = 0 if @offset < 0
       @limit = validparams[:limit] ? validparams[:limit].to_i : JSONAPI.configuration.default_page_size
-
-      if @limit < 1
-        raise JSONAPI::Exceptions::InvalidPageValue.new(:limit, validparams[:limit])
-      elsif @limit > JSONAPI.configuration.maximum_page_size
-        raise JSONAPI::Exceptions::InvalidPageValue.new(:limit, validparams[:limit],
-                                                        "Limit exceeds maximum page size of #{JSONAPI.configuration.maximum_page_size}.")
-      end
     else
       raise JSONAPI::Exceptions::InvalidPageObject.new
     end
   rescue ActionController::UnpermittedParameters => e
     raise JSONAPI::Exceptions::PageParametersNotAllowed.new(e.params)
   end
+
+  def verify_pagination_params
+    if @limit < 1
+      raise JSONAPI::Exceptions::InvalidPageValue.new(:limit, @limit)
+    elsif @limit > JSONAPI.configuration.maximum_page_size
+      raise JSONAPI::Exceptions::InvalidPageValue.new(:limit, @limit,
+        "Limit exceeds maximum page size of #{JSONAPI.configuration.maximum_page_size}.")
+    end
+
+    if @offset < 0
+      raise JSONAPI::Exceptions::InvalidPageValue.new(:offset, @offset)
+    end
+  end
 end
 
 class PagedPaginator < JSONAPI::Paginator
   def initialize(params)
     parse_pagination_params(params)
+    verify_pagination_params
   end
 
   def apply(relation)
@@ -71,18 +78,25 @@ class PagedPaginator < JSONAPI::Paginator
 
       @size = validparams[:size] ? validparams[:size].to_i : JSONAPI.configuration.default_page_size
       @number = validparams[:number] ? validparams[:number].to_i : 1
-
-      if @size < 1
-        raise JSONAPI::Exceptions::InvalidPageValue.new(:size, validparams[:size])
-      elsif @size > JSONAPI.configuration.maximum_page_size
-        raise JSONAPI::Exceptions::InvalidPageValue.new(:size, validparams[:size],
-                                                        "size exceeds maximum page size of #{JSONAPI.configuration.maximum_page_size}.")
-      end
     else
       @size = JSONAPI.configuration.default_page_size
       @number = params.to_i
     end
   rescue ActionController::UnpermittedParameters => e
     raise JSONAPI::Exceptions::PageParametersNotAllowed.new(e.params)
+  end
+
+
+  def verify_pagination_params
+    if @size < 1
+      raise JSONAPI::Exceptions::InvalidPageValue.new(:size, @size)
+    elsif @size > JSONAPI.configuration.maximum_page_size
+      raise JSONAPI::Exceptions::InvalidPageValue.new(:size, @size,
+        "size exceeds maximum page size of #{JSONAPI.configuration.maximum_page_size}.")
+    end
+
+    if @number < 1
+      raise JSONAPI::Exceptions::InvalidPageValue.new(:number, @number)
+    end
   end
 end

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -2065,13 +2065,12 @@ class Api::V2::BooksControllerTest < ActionController::TestCase
     assert_match /-1 is not a valid value for size page parameter./, json_response['errors'][0]['detail']
   end
 
-  def test_books_paged_pagination_invalid_page_format_interpret_int_text
+  def test_books_paged_pagination_invalid_page_format_incorrect
     Api::V2::BookResource.paginator :paged
 
     get :index, {page: 'qwerty'}
-    assert_response :success
-    assert_equal 10, json_response['data'].size
-    assert_equal 'Book 0', json_response['data'][0]['title']
+    assert_response :bad_request
+    assert_match /0 is not a valid value for number page parameter./, json_response['errors'][0]['detail']
   end
 
   def test_books_paged_pagination_invalid_page_format_interpret_int


### PR DESCRIPTION
My Ember app tries to send a `page[number]=0` parameter, and jsonapi-resources blows up with a negative offset MySQL error. This protects against that.
