### PR TITLE
Parse patch keys

### DIFF
--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -421,7 +421,9 @@ module JSONAPI
 
     def parse_replace_operation(data, keys)
       if data.is_a?(Array)
-        keys = parse_key_array(keys).map(&:to_s)
+        unless keys.is_a?(Array)
+          keys = parse_key_array(keys).map(&:to_s)
+        end
 
         if keys.count != data.count
           raise JSONAPI::Exceptions::CountMismatch

--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -421,6 +421,8 @@ module JSONAPI
 
     def parse_replace_operation(data, keys)
       if data.is_a?(Array)
+        keys = parse_key_array(keys).map(&:to_s)
+
         if keys.count != data.count
           raise JSONAPI::Exceptions::CountMismatch
         end


### PR DESCRIPTION
I needed to bulk-patch to avoid an issue with re-indexing. And I noticed you already have implemented the possibility to PATCH multiple keys and some tests even attempt it.

It almost worked but when calling it with the proper `PATCH /x/1,2,3` http request I was getting an `ArgumentError` when it tried to call `.count` on a string. This patch fixes that error and lets me do a bulk PATCH. 

It passes all tests but am I right in believing it does not have any official support right now?

Would be great if this could be merged even it it's unofficial so I can keep using the official repo :)

Cheers!
