### PR TITLE
Added a meta property

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -195,6 +195,7 @@ module JSONAPI
 
     class << self
       def inherited(base)
+        base._meta = (_meta || {}).dup
         base._attributes = (_attributes || {}).dup
         base._associations = (_associations || {}).dup
         base._allowed_filters = (_allowed_filters || Set.new).dup
@@ -216,7 +217,7 @@ module JSONAPI
         resource
       end
 
-      attr_accessor :_attributes, :_associations, :_allowed_filters , :_type, :_paginator
+      attr_accessor :_attributes, :_associations, :_allowed_filters, :_type, :_paginator, :_meta
 
       def create(context)
         self.new(self.create_model, context)
@@ -285,6 +286,10 @@ module JSONAPI
 
       def primary_key(key)
         @_primary_key = key.to_sym
+      end
+
+      def meta(name, options = {})
+        @_meta[name] = options
       end
 
       # Override in your resource to filter the updateable keys

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -164,6 +164,26 @@ ActiveRecord::Schema.define do
   end
 end
 
+### META
+module JSONAPI
+  module Meta
+    module TotalCount
+      def total_count(records, options = {})
+        if records.respond_to?(:limit)
+          records.limit(nil).count
+        elsif records.respond_to?(:count)
+          records.count
+        elsif records.respond_to?(:size)
+          records.size
+        else
+          records.present? ? 1 : 0
+        end
+      end
+    end
+  end
+end
+
+
 ### MODELS
 class Person < ActiveRecord::Base
   has_many :posts, foreign_key: 'author_id'
@@ -715,6 +735,10 @@ class PreferencesResource < JSONAPI::Resource
 end
 
 class FactResource < JSONAPI::Resource
+  extend JSONAPI::Meta::TotalCount
+
+  meta :total_count
+
   attribute :spouse_name
   attribute :bio
   attribute :quality_rating
@@ -724,6 +748,7 @@ class FactResource < JSONAPI::Resource
   attribute :bedtime
   attribute :photo
   attribute :cool
+
 end
 
 module Api
@@ -782,6 +807,10 @@ module Api
     PostResource = PostResource.dup
 
     class BookResource < JSONAPI::Resource
+      extend JSONAPI::Meta::TotalCount
+
+      meta :total_count
+
       attribute :title
       attribute :isbn
 
@@ -857,6 +886,10 @@ module Api
     end
 
     class PurchaseOrderResource < JSONAPI::Resource
+      extend JSONAPI::Meta::TotalCount
+
+      meta :total_count
+
       attribute :order_date
       attribute :requested_delivery_date
       attribute :delivery_date

--- a/test/integration/requests/request_test.rb
+++ b/test/integration/requests/request_test.rb
@@ -377,6 +377,7 @@ class RequestTest < ActionDispatch::IntegrationTest
     get '/api/v2/books?page[limit]=2'
     assert_equal 200, status
     assert_equal 2, json_response['data'].size
+    assert_not_equal 2, json_response['meta']['total_size']
     assert_equal 'http://www.example.com/api/v2/books/1/book_comments',
                  json_response['data'][1]['links']['book_comments']['related']
   end
@@ -478,6 +479,7 @@ class RequestTest < ActionDispatch::IntegrationTest
     assert_equal 200, status
     po_1 = json_response['data'][0]
     assert_equal 'purchase-orders', json_response['data'][0]['type']
+    assert_equal json_response['data'].size, json_response['meta']['total-count']
 
     get po_1['links']['self']
     assert_equal 200, status
@@ -490,6 +492,7 @@ class RequestTest < ActionDispatch::IntegrationTest
     get '/api/v7/purchase_orders'
     assert_equal 200, status
     assert_equal 'purchase-orders', json_response['data'][0]['type']
+    assert_equal json_response['data'].size, json_response['meta']['total-count']
 
     po_1 = json_response['data'][0]
 

--- a/test/unit/serializer/serializer_test.rb
+++ b/test/unit/serializer/serializer_test.rb
@@ -1384,6 +1384,9 @@ class SerializerTest < ActionDispatch::IntegrationTest
 
     assert_hash_equals(
       {
+        meta: {
+          total_count: 1
+        },
         data: {
           type: 'facts',
           id: '1',
@@ -1406,4 +1409,5 @@ class SerializerTest < ActionDispatch::IntegrationTest
       JSONAPI::ResourceSerializer.new(FactResource).serialize_to_hash(facts)
     )
   end
+
 end


### PR DESCRIPTION
After writing [this comment](https://github.com/cerebris/jsonapi-resources/pull/199#issuecomment-100619435) and based upon that PR I gave it a shot and in short it allows this syntax:

```
class BookResource < JSONAPI::Resource
  attribute :title
  attribute :isbn

  # pass optional options as a second argument
  meta :total_count, filter: [:special_for_count]

  has_many :book_comments
end
```

Where, in theory, a `total_count` class-method has been autoloaded into `JSONAPI::Resource` in a gem or something. In the tests I simply extended a few resources with a module.

Let me know what can be done better and why this is a bad idea please :)
