### PR TITLE
Auto eager load included associations

### DIFF
--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -4,7 +4,8 @@ require 'jsonapi/paginator'
 module JSONAPI
   class Request
     attr_accessor :fields, :include, :filters, :sort_criteria, :errors, :operations,
-                  :resource_klass, :context, :paginator, :source_klass, :source_id
+                  :resource_klass, :context, :paginator, :source_klass, :source_id,
+                  :include_directives
 
     def initialize(params = nil, options = {})
       @context = options.fetch(:context, nil)
@@ -17,6 +18,7 @@ module JSONAPI
       @sort_criteria = []
       @source_klass = nil
       @source_id = nil
+      @include_directives = nil
 
       setup(params) if params
     end
@@ -153,6 +155,8 @@ module JSONAPI
         check_include(@resource_klass, included_resource.partition('.'))
         @include.push(unformat_key(included_resource).to_s)
       end
+
+      @include_directives = JSONAPI::SerializerIncludeDirectives.new(@include)
     end
 
     def parse_filters(filters)

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -314,7 +314,11 @@ module JSONAPI
       end
 
       def apply_sort(records, order_options)
-        records.order(order_options)
+        if order_options.any?
+          records.order(order_options)
+        else
+          records
+        end
       end
 
       def apply_filter(records, filter, value)
@@ -335,7 +339,11 @@ module JSONAPI
             records = apply_filter(records, filter, value)
           end
         end
-        records.includes(required_includes)
+        if required_includes.any?
+          records.includes(required_includes)
+        else
+          records.all
+        end
       end
 
       # Override this method if you have more complex requirements than this basic find method provides

--- a/lib/jsonapi/resource_controller.rb
+++ b/lib/jsonapi/resource_controller.rb
@@ -10,6 +10,7 @@ module JSONAPI
     def index
       serializer = JSONAPI::ResourceSerializer.new(resource_klass,
                                                    include: @request.include,
+                                                   include_directives: @request.include_directives,
                                                    fields: @request.fields,
                                                    base_url: base_url,
                                                    key_formatter: key_formatter,
@@ -17,6 +18,7 @@ module JSONAPI
 
       resource_records = resource_klass.find(resource_klass.verify_filters(@request.filters, context),
                                              context: context,
+                                             include_directives: @request.include_directives,
                                              sort_criteria: @request.sort_criteria,
                                              paginator: @request.paginator)
 
@@ -28,6 +30,7 @@ module JSONAPI
     def show
       serializer = JSONAPI::ResourceSerializer.new(resource_klass,
                                                    include: @request.include,
+                                                   include_directives: @request.include_directives,
                                                    fields: @request.fields,
                                                    base_url: base_url,
                                                    key_formatter: key_formatter,
@@ -35,7 +38,9 @@ module JSONAPI
 
       key = resource_klass.verify_key(params[resource_klass._primary_key], context)
 
-      resource_record = resource_klass.find_by_key(key, context: context)
+      resource_record = resource_klass.find_by_key(key,
+                                                   context: context,
+                                                   include_directives: @request.include_directives)
 
       render json: serializer.serialize_to_hash(resource_record)
     rescue => e
@@ -53,6 +58,7 @@ module JSONAPI
 
       serializer = JSONAPI::ResourceSerializer.new(resource_klass,
                                                    fields: @request.fields,
+                                                   include_directives: @request.include_directives,
                                                    base_url: base_url,
                                                    key_formatter: key_formatter,
                                                    route_formatter: route_formatter)

--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -18,6 +18,7 @@ module JSONAPI
 
       @fields =  options.fetch(:fields, {})
       @include = options.fetch(:include, [])
+      @include_directives = options.fetch(:include_directives, nil)
       @key_formatter = options.fetch(:key_formatter, JSONAPI.configuration.key_formatter)
       @route_formatter = options.fetch(:route_formatter, JSONAPI.configuration.route_formatter)
       @base_url = options.fetch(:base_url, '')
@@ -28,10 +29,9 @@ module JSONAPI
       is_resource_collection = source.respond_to?(:to_ary)
 
       @included_objects = {}
+      @include_directives ||= JSONAPI::SerializerIncludeDirectives.new(@include)
 
-      include_directives = JSONAPI::SerializerIncludeDirectives.new(@include).include_directives
-
-      process_primary(source, include_directives)
+      process_primary(source, @include_directives.include_directives)
 
       included_objects = []
       primary_objects = []

--- a/lib/jsonapi/serializer_include_directives.rb
+++ b/lib/jsonapi/serializer_include_directives.rb
@@ -31,6 +31,10 @@ module JSONAPI
       @include_directives_hash
     end
 
+    def model_includes
+      get_includes(@include_directives_hash)
+    end
+
     private
     def get_related(current_path)
       current = @include_directives_hash
@@ -40,6 +44,13 @@ module JSONAPI
         current = current[:include_related][fragment]
       end
       current
+    end
+
+    def get_includes(directive)
+      directive[:include_related].map do |name, directive|
+        sub = get_includes(directive)
+        sub.any? ? { name => sub } : name
+      end
     end
 
     def parse_include(include)


### PR DESCRIPTION
I've been battling a bit in my app with really slow response times caused by quite deep relationships so eager loading of them was required. 

But I found that something in jsonapi-resources can cause the eager loaded data to be "lost" so it eager loaded AND loaded in N+1 queries, which was less than ideal but I finally fixed this with 012a6c2. 

Then I thought "hey, we know what is desired already, why not include them automatically!". So that's what d15853e does.

Just using this a request goes down from ~450 queries to ~18 (most of them because I'm still abusing attributes, which is out of the scope of this PR).

And it passes the tests (at least locally).
