### PR TITLE
Fix 207

### DIFF
--- a/lib/jsonapi/acts_as_resource_controller.rb
+++ b/lib/jsonapi/acts_as_resource_controller.rb
@@ -39,7 +39,7 @@ module JSONAPI
                                                    key_formatter: key_formatter,
                                                    route_formatter: route_formatter)
 
-      key = resource_klass.verify_key(params[resource_klass._primary_key], context)
+      key = resource_klass.verify_key(params[:id], context)
 
       resource_record = resource_klass.find_by_key(key,
                                                    context: context,

--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -321,6 +321,8 @@ module JSONAPI
                 end
               end
             end
+          when 'id'
+            checked_attributes['id'] = unformat_value(:id, value)
           when 'attributes'
             value.each do |key, value|
               param = unformat_key(key)

--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -60,7 +60,7 @@ module JSONAPI
           when 'update'
             parse_fields(params[:fields])
             parse_include_directives(params[:include])
-            parse_replace_operation(params.require(:data), params.require(@resource_klass._primary_key))
+            parse_replace_operation(params.require(:data), params.require(:id))
           when 'destroy'
             parse_remove_operation(params)
           when 'destroy_association'
@@ -406,7 +406,7 @@ module JSONAPI
     end
 
     def parse_single_replace_operation(data, keys)
-      if data[@resource_klass._primary_key].nil?
+      if data[:id].nil?
         raise JSONAPI::Exceptions::MissingKey.new
       end
 
@@ -415,12 +415,12 @@ module JSONAPI
         raise JSONAPI::Exceptions::ParameterMissing.new(:type)
       end
 
-      key = data[@resource_klass._primary_key]
+      key = data[:id]
       if !keys.include?(key)
         raise JSONAPI::Exceptions::KeyNotIncludedInURL.new(key)
       end
 
-      if !keys.include?(@resource_klass._primary_key)
+      if !keys.include?(:id)
         data.delete(:id)
       end
 
@@ -450,7 +450,7 @@ module JSONAPI
     end
 
     def parse_remove_operation(params)
-      keys = parse_key_array(params.permit(@resource_klass._primary_key)[@resource_klass._primary_key])
+      keys = parse_key_array(params.permit(:id)[:id])
 
       keys.each do |key|
         @operations.push JSONAPI::RemoveResourceOperation.new(@resource_klass, key)

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -289,7 +289,7 @@ module JSONAPI
 
       # Override in your resource to filter the updateable keys
       def updateable_fields(context = nil)
-        _updateable_associations | _attributes.keys - [_primary_key]
+        _updateable_associations | _attributes.keys - [:id]
       end
 
       # Override in your resource to filter the createable keys
@@ -420,7 +420,7 @@ module JSONAPI
       def verify_key(key, context = nil)
         key && Integer(key)
       rescue
-        raise JSONAPI::Exceptions::InvalidFieldValue.new(_primary_key, key)
+        raise JSONAPI::Exceptions::InvalidFieldValue.new(:id, key)
       end
 
       # override to allow for key processing and checking
@@ -477,7 +477,7 @@ module JSONAPI
       end
 
       def _allowed_filters
-        !@_allowed_filters.nil? ? @_allowed_filters : Set.new([_primary_key])
+        !@_allowed_filters.nil? ? @_allowed_filters : Set.new([:id])
       end
 
       def _resource_name_from_type(type)

--- a/lib/jsonapi/routing_ext.rb
+++ b/lib/jsonapi/routing_ext.rb
@@ -58,8 +58,7 @@ module ActionDispatch
           options[:controller] ||= @resource_type
           options.merge!(res.routing_resource_options)
 
-          # Route using the primary_key. Can be overridden using routing_resource_options
-          options[:param] ||= res._primary_key
+          options[:param] = :id
 
           options[:path] = format_route(@resource_type)
 

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -1658,7 +1658,7 @@ class IsoCurrenciesControllerTest < ActionController::TestCase
   end
 
   def test_currencies_show
-    get :show, {code: 'USD'}
+    get :show, {id: 'USD'}
     assert_response :success
     assert json_response['data'].is_a?(Hash)
   end

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -1663,6 +1663,33 @@ class IsoCurrenciesControllerTest < ActionController::TestCase
     assert json_response['data'].is_a?(Hash)
   end
 
+  def test_create_currencies_client_generated_id
+    set_content_type_header!
+    JSONAPI.configuration.json_key_format = :underscored_route
+
+    post :create,
+         {
+           data: {
+             type: 'iso_currencies',
+             id: 'BTC',
+             attributes: {
+               name: 'Bit Coin',
+               'country_name' => 'global',
+               'minor_unit' => 'satoshi'
+             }
+           }
+         }
+
+    assert_response :created
+    assert_equal 'BTC', json_response['data']['id']
+    assert_equal 'Bit Coin', json_response['data']['attributes']['name']
+    assert_equal 'global', json_response['data']['attributes']['country_name']
+    assert_equal 'satoshi', json_response['data']['attributes']['minor_unit']
+
+    delete :destroy, {id: json_response['data']['id']}
+    assert_response :no_content
+  end
+
   def test_currencies_json_key_underscored_sort
     JSONAPI.configuration.json_key_format = :underscored_key
     get :index, {sort: '+country_name'}

--- a/test/integration/routes/routes_test.rb
+++ b/test/integration/routes/routes_test.rb
@@ -93,7 +93,7 @@ class RoutesTest < ActionDispatch::IntegrationTest
 
   def test_routing_v4_isoCurrencies_resources
     assert_routing({path: '/api/v4/isoCurrencies/USD', method: :get},
-                   {action: 'show', controller: 'api/v4/iso_currencies', code: 'USD'})
+                   {action: 'show', controller: 'api/v4/iso_currencies', id: 'USD'})
   end
 
   def test_routing_v4_expenseEntries_resources
@@ -112,7 +112,7 @@ class RoutesTest < ActionDispatch::IntegrationTest
 
   def test_routing_v5_isoCurrencies_resources
     assert_routing({path: '/api/v5/iso-currencies/USD', method: :get},
-                   {action: 'show', controller: 'api/v5/iso_currencies', code: 'USD'})
+                   {action: 'show', controller: 'api/v5/iso_currencies', id: 'USD'})
   end
 
   def test_routing_v5_expenseEntries_resources
@@ -136,7 +136,7 @@ class RoutesTest < ActionDispatch::IntegrationTest
   #primary_key
   def test_routing_primary_key_jsonapi_resources
     assert_routing({path: '/iso_currencies/USD', method: :get},
-                   {action: 'show', controller: 'iso_currencies', code: 'USD'})
+                   {action: 'show', controller: 'iso_currencies', id: 'USD'})
   end
 
   # ToDo: Refute routing


### PR DESCRIPTION
Fixes issue #207.
Removes use of primary_key as an alternate to :id in routes and request processing for better compliance with the spec.
