### PR TITLE
Primary key sorting

### DIFF
--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -15,7 +15,7 @@ module JSONAPI
       @fields = {}
       @include = []
       @filters = {}
-      @sort_criteria = []
+      @sort_criteria = [{field: 'id', direction: :asc}]
       @source_klass = nil
       @source_id = nil
       @include_directives = nil

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -511,7 +511,8 @@ module JSONAPI
 
       def construct_order_options(sort_params)
         sort_params.each_with_object({}) { |sort, order_hash|
-          order_hash[sort[:field]] = sort[:direction]
+          field = sort[:field] == 'id' ? _primary_key : sort[:field]
+          order_hash[field] = sort[:direction]
         }
       end
 

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -1690,6 +1690,20 @@ class IsoCurrenciesControllerTest < ActionController::TestCase
     assert_response :no_content
   end
 
+  def test_currencies_primary_key_sort
+    get :index, {sort: '+id'}
+    assert_response :success
+    assert_equal 3, json_response['data'].size
+    assert_equal 'CAD', json_response['data'][0]['id']
+    assert_equal 'EUR', json_response['data'][1]['id']
+    assert_equal 'USD', json_response['data'][2]['id']
+  end
+
+  def test_currencies_code_sort
+    get :index, {sort: '+code'}
+    assert_response :bad_request
+  end
+
   def test_currencies_json_key_underscored_sort
     JSONAPI.configuration.json_key_format = :underscored_key
     get :index, {sort: '+country_name'}


### PR DESCRIPTION
This PR fixes #210 by using primary_key when trying to sort on "id". With some tests to catch regressions.
