### PR TITLE
Support Top-level Links with self attribute

### DIFF
--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -47,6 +47,10 @@ module JSONAPI
 
       primary_hash = {data: is_resource_collection ? primary_objects : primary_objects[0]}
 
+      primary_hash[:links] = {
+        self: is_resource_collection || primary_objects[0].nil? ? self_href_primary : self_href(source)
+      }
+
       if included_objects.size > 0
         primary_hash[:included] = included_objects
       else
@@ -196,12 +200,16 @@ module JSONAPI
       end
     end
 
-    def formatted_module_path(source)
-      source.class.name =~ /::[^:]+\Z/ ? (@route_formatter.format($`).freeze.gsub('::', '/') + '/').downcase : ''
+    def formatted_module_path(class_name)
+      class_name =~ /::[^:]+\Z/ ? (@route_formatter.format($`).freeze.gsub('::', '/') + '/').downcase : ''
+    end
+
+    def self_href_primary
+      "#{@base_url}/#{formatted_module_path(@primary_resource_klass.to_s)}#{@route_formatter.format(@primary_class_name.to_s)}"
     end
 
     def self_href(source)
-      "#{@base_url}/#{formatted_module_path(source)}#{@route_formatter.format(source.class._type.to_s)}/#{source.id}"
+      "#{@base_url}/#{formatted_module_path(source.class.name)}#{@route_formatter.format(source.class._type.to_s)}/#{source.id}"
     end
 
     def already_serialized?(type, id)

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -13,6 +13,7 @@ class PostsControllerTest < ActionController::TestCase
     get :index
     assert_response :success
     assert json_response['data'].is_a?(Array)
+    assert json_response.has_key?('links')
   end
 
   def test_index_filter_with_empty_result
@@ -1926,6 +1927,9 @@ class PeopleControllerTest < ActionController::TestCase
              "linkage" => nil
             }
          }
+        },
+        links: {
+          self: 'http://test.host/people/1'
         }
       },
       json_response
@@ -1937,7 +1941,10 @@ class PeopleControllerTest < ActionController::TestCase
     assert_response :success
     assert_hash_equals json_response,
                        {
-                         data: nil
+                         data: nil,
+                         links: {
+                          self: 'http://test.host/posts'
+                         }
                        }
 
   end

--- a/test/unit/serializer/serializer_test.rb
+++ b/test/unit/serializer/serializer_test.rb
@@ -53,6 +53,9 @@ class SerializerTest < ActionDispatch::IntegrationTest
               related: 'http://example.com/posts/1/comments'
             }
           }
+        },
+        links: {
+          self: 'http://example.com/posts/1'
         }
       },
       JSONAPI::ResourceSerializer.new(PostResource,
@@ -63,7 +66,10 @@ class SerializerTest < ActionDispatch::IntegrationTest
   def test_serializer_nil_handling
     assert_hash_equals(
       {
-        data: nil
+        data: nil,
+        links: {
+          self: '/posts'
+        }
       },
       JSONAPI::ResourceSerializer.new(PostResource).serialize_to_hash(nil)
     )
@@ -100,6 +106,9 @@ class SerializerTest < ActionDispatch::IntegrationTest
               related: 'http://example.com/api/v1/posts/1/comments'
             }
           }
+        },
+        links: {
+          self: 'http://example.com/api/v1/posts/1'
         }
       },
       JSONAPI::ResourceSerializer.new(Api::V1::PostResource,
@@ -129,6 +138,9 @@ class SerializerTest < ActionDispatch::IntegrationTest
               }
             }
           }
+        },
+        links: {
+          self: '/posts/1'
         }
       },
       JSONAPI::ResourceSerializer.new(PostResource,
@@ -176,6 +188,9 @@ class SerializerTest < ActionDispatch::IntegrationTest
               related: '/posts/1/comments'
             }
           }
+        },
+        links: {
+          self: '/posts/1'
         },
         included: [
           {
@@ -259,6 +274,9 @@ class SerializerTest < ActionDispatch::IntegrationTest
             }
           }
         },
+        links: {
+          self: '/posts/1'
+        },
         included: [
           {
             type: 'people',
@@ -339,6 +357,9 @@ class SerializerTest < ActionDispatch::IntegrationTest
               ]
             }
           }
+        },
+        links: {
+          self: '/posts/1'
         },
         included: [
             {
@@ -495,6 +516,9 @@ class SerializerTest < ActionDispatch::IntegrationTest
             }
           }
         },
+        links: {
+          self: '/posts/1'
+        },
         included: [
           {
             type: 'tags',
@@ -581,6 +605,9 @@ class SerializerTest < ActionDispatch::IntegrationTest
             }
           }
         },
+        links: {
+          self: '/posts/1'
+        },
         included: [
           {
             type: 'comments',
@@ -660,6 +687,9 @@ class SerializerTest < ActionDispatch::IntegrationTest
               linkage: nil
             }
           }
+        },
+        links: {
+          self: '/people/2'
         },
         included: [
           {
@@ -815,6 +845,9 @@ class SerializerTest < ActionDispatch::IntegrationTest
             }
           }
         ],
+        links: {
+          self: '/posts'
+        },
         included: [
           {
             type: 'tags',
@@ -1027,6 +1060,9 @@ class SerializerTest < ActionDispatch::IntegrationTest
             }
           }
         ],
+        links: {
+          self: '/posts'
+        },
         included: [
           {
             type: 'posts',
@@ -1200,6 +1236,9 @@ class SerializerTest < ActionDispatch::IntegrationTest
             }
           }
         },
+        links: {
+          self: '/expenseEntries/1'
+        },
         included: [
           {
             type: 'isoCurrencies',
@@ -1263,6 +1302,9 @@ class SerializerTest < ActionDispatch::IntegrationTest
               related: '/planets/8/moons'
             }
           }
+        },
+        links: {
+          self: '/planets/8'
         }
       }, planet_hash)
   end
@@ -1331,6 +1373,9 @@ class SerializerTest < ActionDispatch::IntegrationTest
           }
         }
       ],
+      links: {
+        self: '/planets'
+      },
       included: [
         {
           type: 'planetTypes',
@@ -1371,6 +1416,9 @@ class SerializerTest < ActionDispatch::IntegrationTest
               related: '/preferences/1/friends'
             }
           }
+        },
+        links: {
+          self: '/preferences/1'
         }
       },
       JSONAPI::ResourceSerializer.new(PreferencesResource).serialize_to_hash(preferences)
@@ -1401,6 +1449,9 @@ class SerializerTest < ActionDispatch::IntegrationTest
           links: {
             self: '/facts/1'
           }
+        },
+        links: {
+          self: '/facts/1'
         }
       },
       JSONAPI::ResourceSerializer.new(FactResource).serialize_to_hash(facts)


### PR DESCRIPTION
Adds initial support for Top-level links as defined in JSON API http://jsonapi.org/format/#document-structure-top-level-links. See issue #87.

The links object is included at the top level of every resource and includes a self URL.

@lgebhardt I decided to make an initial small PR rather than a huge one so we can get the basics right first. This can then be built on by adding `related` and pagination support.
