### PR TITLE
Paginator Order Context

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,9 +427,9 @@ from the configuration settings is used.
 
 ###### Custom Paginators
 
-Custom `paginators` can be used. These should derive from `Paginator`. The `apply` method takes a `relation` and is 
-expected to return a `relation`. The `initialize` method receives the parameters from the `page` request parameters. It 
-is up to the paginator author to parse and validate these parameters.
+Custom `paginators` can be used. These should derive from `Paginator`. The `apply` method takes a `relation` and
+`order_options` and is expected to return a `relation`. The `initialize` method receives the parameters from the `page`
+request parameters. It is up to the paginator author to parse and validate these parameters.
 
 For example, here is a very simple single record at a time paginator:
 
@@ -440,7 +440,7 @@ class SingleRecordPaginator < JSONAPI::Paginator
     @page = params.to_i
   end
 
-  def apply(relation)
+  def apply(relation, order_options)
     relation.offset(@page).limit(1)
   end
 end

--- a/lib/jsonapi/paginator.rb
+++ b/lib/jsonapi/paginator.rb
@@ -3,7 +3,7 @@ module JSONAPI
     def initialize(params)
     end
 
-    def apply(relation)
+    def apply(relation, order_options)
       # relation
     end
 
@@ -22,7 +22,7 @@ class OffsetPaginator < JSONAPI::Paginator
     verify_pagination_params
   end
 
-  def apply(relation)
+  def apply(relation, order_options)
     relation.offset(@offset).limit(@limit)
   end
 
@@ -63,7 +63,7 @@ class PagedPaginator < JSONAPI::Paginator
     verify_pagination_params
   end
 
-  def apply(relation)
+  def apply(relation, order_options)
     offset = (@number - 1) * @size
     relation.offset(offset).limit(@size)
   end

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -311,9 +311,9 @@ module JSONAPI
         records
       end
 
-      def apply_pagination(records, paginator)
+      def apply_pagination(records, paginator, order_options)
         if paginator
-          records = paginator.apply(records)
+          records = paginator.apply(records, order_options)
         end
         records
       end
@@ -364,8 +364,9 @@ module JSONAPI
         records = records(options)
         records = apply_includes(records, include_directives)
         records = apply_filters(records, filters)
-        records = apply_sort(records, construct_order_options(sort_criteria))
-        records = apply_pagination(records, options[:paginator])
+        order_options = construct_order_options(sort_criteria)
+        records = apply_sort(records, order_options)
+        records = apply_pagination(records, options[:paginator], order_options)
 
         records.each do |model|
           resources.push self.new(model, context)
@@ -587,8 +588,9 @@ module JSONAPI
               if resource_class
                 records = public_send(associated_records_method_name)
                 records = self.class.apply_filters(records, filters)
-                records = self.class.apply_sort(records, self.class.construct_order_options(sort_criteria))
-                records = self.class.apply_pagination(records, paginator)
+                order_options = self.class.construct_order_options(sort_criteria)
+                records = self.class.apply_sort(records, order_options)
+                records = self.class.apply_pagination(records, paginator, order_options)
                 records.each do |record|
                   resources.push resource_class.new(record, @context)
                 end


### PR DESCRIPTION
To build paginators that rely on sort order (e.g. cursor pagination) the
sort order requested must be known when applying pagination. This adds
an additional argument to Paginator#apply to supply the current sort 
order and hooks it in through the resource finders.

See #45 
