### PR TITLE
Check if setup_*_action method exists before calling.

### DIFF
--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -31,7 +31,10 @@ module JSONAPI
       @resource_klass ||= Resource.resource_for(params[:controller]) if params[:controller]
 
       unless params.nil?
-        send("setup_#{params[:action]}_action", params)
+        setup_action_method_name = "setup_#{params[:action]}_action"
+        if respond_to?(setup_action_method_name)
+          send(setup_action_method_name, params)
+        end
       end
     rescue ActionController::ParameterMissing => e
       @errors.concat(JSONAPI::Exceptions::ParameterMissing.new(e.param).errors)


### PR DESCRIPTION
I added a non-RESTful route that didn't have a corresponding `setup_*_action`, so I added this check to prevent calling the method if it doesn't exist.
