### PR TITLE
Use resource_class of relationship to apply filters, etc.

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -581,9 +581,9 @@ module JSONAPI
               resources = []
               if resource_class
                 records = public_send(associated_records_method_name)
-                records = self.class.apply_filters(records, filters)
-                records = self.class.apply_sort(records, self.class.construct_order_options(sort_criteria))
-                records = self.class.apply_pagination(records, paginator)
+                records = resource_class.apply_filters(records, filters)
+                records = resource_class.apply_sort(records, self.class.construct_order_options(sort_criteria))
+                records = resource_class.apply_pagination(records, paginator)
                 records.each do |record|
                   resources.push resource_class.new(record, @context)
                 end

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -524,6 +524,8 @@ class CommentResource < JSONAPI::Resource
   has_one :post
   has_one :author, class_name: 'Person'
   has_many :tags
+
+  filters :body
 end
 
 class TagResource < JSONAPI::Resource


### PR DESCRIPTION
This one took me a while to track down! :tada:

The source resource class was being used to apply filters, sorting, and pagination for relationships. So, if `apply_filters` et al were implemented in the resource class for the relationship, they weren't being used. That was causing incorrect results to be returned by the `get_related_resources` controller method.
