### PR TITLE
Paginator Order Context

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,9 +427,9 @@ from the configuration settings is used.
 
 ###### Custom Paginators
 
-Custom `paginators` can be used. These should derive from `Paginator`. The `apply` method takes a `relation` and is 
-expected to return a `relation`. The `initialize` method receives the parameters from the `page` request parameters. It 
-is up to the paginator author to parse and validate these parameters.
+Custom `paginators` can be used. These should derive from `Paginator`. The `apply` method takes a `relation` and
+`order_options` and is expected to return a `relation`. The `initialize` method receives the parameters from the `page`
+request parameters. It is up to the paginator author to parse and validate these parameters.
 
 For example, here is a very simple single record at a time paginator:
 
@@ -440,7 +440,7 @@ class SingleRecordPaginator < JSONAPI::Paginator
     @page = params.to_i
   end
 
-  def apply(relation)
+  def apply(relation, order_options)
     relation.offset(@page).limit(1)
   end
 end

--- a/lib/jsonapi/paginator.rb
+++ b/lib/jsonapi/paginator.rb
@@ -3,7 +3,7 @@ module JSONAPI
     def initialize(params)
     end
 
-    def apply(relation)
+    def apply(relation, order_options)
       # relation
     end
 
@@ -22,7 +22,7 @@ class OffsetPaginator < JSONAPI::Paginator
     verify_pagination_params
   end
 
-  def apply(relation)
+  def apply(relation, order_options)
     relation.offset(@offset).limit(@limit)
   end
 
@@ -63,7 +63,7 @@ class PagedPaginator < JSONAPI::Paginator
     verify_pagination_params
   end
 
-  def apply(relation)
+  def apply(relation, order_options)
     offset = (@number - 1) * @size
     relation.offset(offset).limit(@size)
   end

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -189,7 +189,7 @@ class ResourceTest < ActiveSupport::TestCase
 
     # define apply_filters method on post resource to not respect filters
     PostResource.instance_eval do
-      def apply_pagination(records, criteria)
+      def apply_pagination(records, criteria, order_options)
         records
       end
     end
@@ -200,7 +200,7 @@ class ResourceTest < ActiveSupport::TestCase
         @page = params.to_i
       end
 
-      def apply(relation)
+      def apply(relation, order_options)
         relation.offset(@page).limit(1)
       end
     end
@@ -210,7 +210,7 @@ class ResourceTest < ActiveSupport::TestCase
 
     # reset method to original implementation
     PostResource.instance_eval do
-      def apply_pagination(records, criteria)
+      def apply_pagination(records, criteria, order_options)
         super
       end
     end


### PR DESCRIPTION
This updates #214 with the new changes in master.

To build paginators that rely on sort order (e.g. cursor pagination) the
sort order requested must be known when applying pagination. This adds
an additional argument to Paginator#apply to supply the current sort 
order and hooks it in through the resource finders.
