### PR TITLE
Adds default value to filter option

### DIFF
--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -43,6 +43,7 @@ module JSONAPI
     def setup_index_action(params)
       parse_fields(params[:fields])
       parse_include_directives(params[:include])
+      set_default_filters
       parse_filters(params[:filter])
       parse_sort_criteria(params[:sort])
       parse_pagination(params[:page])
@@ -53,6 +54,7 @@ module JSONAPI
       initialize_source(params)
       parse_fields(params[:fields])
       parse_include_directives(params[:include])
+      set_default_filters
       parse_filters(params[:filter])
       parse_sort_criteria(params[:sort])
       parse_pagination(params[:page])
@@ -63,6 +65,7 @@ module JSONAPI
       initialize_source(params)
       parse_fields(params[:fields])
       parse_include_directives(params[:include])
+      set_default_filters
       parse_filters(params[:filter])
       parse_sort_criteria(params[:sort])
       parse_pagination(params[:page])
@@ -207,7 +210,7 @@ module JSONAPI
 
     def parse_filters(filters)
       return unless filters
-      @filters = {}
+
       filters.each do |key, value|
         filter = unformat_key(key)
         if @resource_klass._allowed_filter?(filter)
@@ -215,6 +218,13 @@ module JSONAPI
         else
           @errors.concat(JSONAPI::Exceptions::FilterNotAllowed.new(filter).errors)
         end
+      end
+    end
+
+    def set_default_filters
+      @resource_klass._allowed_filters.each do |filter, opts|
+        next if opts[:default].nil? || !@filters[filter].nil?
+        @filters[filter] = opts[:default]
       end
     end
 

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -279,8 +279,8 @@ module JSONAPI
         @_allowed_filters.merge!(attrs.inject( Hash.new ) { |h, attr| h[attr] = {}; h })
       end
 
-      def filter(attr, opts={})
-        @_allowed_filters[attr.to_sym] = opts
+      def filter(attr, *args)
+        @_allowed_filters[attr.to_sym] = args.extract_options!
       end
 
       def primary_key(key)

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -276,11 +276,11 @@ module JSONAPI
       end
 
       def filters(*attrs)
-        @_allowed_filters.merge(attrs)
+        @_allowed_filters.merge!(attrs.inject( Hash.new ) { |h, attr| h[attr] = {}; h })
       end
 
-      def filter(attr)
-        @_allowed_filters.add(attr.to_sym)
+      def filter(attr, opts={})
+        @_allowed_filters[attr.to_sym] = opts
       end
 
       def primary_key(key)
@@ -480,7 +480,7 @@ module JSONAPI
       end
 
       def _allowed_filters
-        !@_allowed_filters.nil? ? @_allowed_filters : Set.new([:id])
+        !@_allowed_filters.nil? ? @_allowed_filters : { :id => {} }
       end
 
       def _resource_name_from_type(type)
@@ -505,7 +505,7 @@ module JSONAPI
       end
 
       def _allowed_filter?(filter)
-        _allowed_filters.include?(filter)
+        !_allowed_filters[filter].nil?
       end
 
       def module_path

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -2306,3 +2306,19 @@ class Api::V4::BooksControllerTest < ActionController::TestCase
     JSONAPI.configuration.operations_processor = :active_record
   end
 end
+
+class CategoriesControllerTest < ActionController::TestCase
+  def test_index_default_filter
+    get :index
+    assert_response :success
+    assert json_response['data'].is_a?(Array)
+    assert_equal 3, json_response['data'].size
+  end
+
+  def test_index_default_filter_override
+    get :index, { filter: { status: 'inactive' } }
+    assert_response :success
+    assert json_response['data'].is_a?(Array)
+    assert_equal 4, json_response['data'].size
+  end
+end

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -162,6 +162,11 @@ ActiveRecord::Schema.define do
     t.string   :numero_telefone
     t.timestamps null: false
   end
+
+  create_table :categories, force: true do |t|
+    t.string :name
+    t.string :status, limit: 10
+  end
 end
 
 ### MODELS
@@ -329,6 +334,9 @@ end
 class NumeroTelefone < ActiveRecord::Base
 end
 
+class Category < ActiveRecord::Base
+end
+
 ### PORO Data - don't do this in a production app
 $breed_data = BreedData.new
 $breed_data.add(Breed.new(0, 'persian'))
@@ -379,6 +387,9 @@ class BreedsController < JSONAPI::ResourceController
 end
 
 class FactsController < JSONAPI::ResourceController
+end
+
+class CategoriesController < JSONAPI::ResourceController
 end
 
 ### CONTROLLERS
@@ -741,6 +752,10 @@ class FactResource < JSONAPI::Resource
   attribute :cool
 end
 
+class CategoryResource < JSONAPI::Resource
+  filter :status, default: 'active'
+end
+
 module Api
   module V1
     class WriterResource < JSONAPI::Resource
@@ -958,3 +973,10 @@ betax = Planet.create(name: 'Beta X', description: 'Newly discovered Planet X', 
 betay = Planet.create(name: 'Beta X', description: 'Newly discovered Planet Y', planet_type_id: unknown.id)
 betaz = Planet.create(name: 'Beta X', description: 'Newly discovered Planet Z', planet_type_id: unknown.id)
 betaw = Planet.create(name: 'Beta W', description: 'Newly discovered Planet W')
+Category.create(name: 'Category A', status: 'active')
+Category.create(name: 'Category B', status: 'active')
+Category.create(name: 'Category C', status: 'active')
+Category.create(name: 'Category D', status: 'inactive')
+Category.create(name: 'Category E', status: 'inactive')
+Category.create(name: 'Category F', status: 'inactive')
+Category.create(name: 'Category G', status: 'inactive')

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -88,6 +88,7 @@ TestApp.routes.draw do
   jsonapi_resources :moons
   jsonapi_resources :preferences
   jsonapi_resources :facts
+  jsonapi_resources :categories
 
   namespace :api do
     namespace :v1 do


### PR DESCRIPTION
Adds ability to define a default value for a filter

```
filter :status, default: 'active'
```

This value is passed to filter parse, so:

```
filter :status, default: 'active,normal'
```

should work as it would come from a request parameter.

Rebase of #215
