### PR TITLE
Provide options context to apply_filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ control over how the filters are applied to the `Arel` relation.
 This example shows how you can implement different approaches for different filters.
 
 ```ruby
-def self.apply_filter(records, filter, value)
+def self.apply_filter(records, filter, value, options)
   case filter
     when :visibility
       records.where('users.publicly_visible = ?', value == :public)

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -326,11 +326,11 @@ module JSONAPI
         end
       end
 
-      def apply_filter(records, filter, value)
+      def apply_filter(records, filter, value, options = {})
         records.where(filter => value)
       end
 
-      def apply_filters(records, filters)
+      def apply_filters(records, filters, options = {})
         required_includes = []
 
         if filters
@@ -338,12 +338,12 @@ module JSONAPI
             if _associations.include?(filter)
               if _associations[filter].is_a?(JSONAPI::Association::HasMany)
                 required_includes.push(filter)
-                records = apply_filter(records, "#{filter}.#{_associations[filter].primary_key}", value)
+                records = apply_filter(records, "#{filter}.#{_associations[filter].primary_key}", value, options)
               else
-                records = apply_filter(records, "#{_associations[filter].foreign_key}", value)
+                records = apply_filter(records, "#{_associations[filter].foreign_key}", value, options)
               end
             else
-              records = apply_filter(records, filter, value)
+              records = apply_filter(records, filter, value, options)
             end
           end
         end
@@ -362,7 +362,7 @@ module JSONAPI
 
         records = records(options)
         records = apply_includes(records, include_directives)
-        apply_filters(records, filters)
+        apply_filters(records, filters, options)
       end
 
       def sort_records(records, order_options)
@@ -603,7 +603,7 @@ module JSONAPI
 
               if resource_class
                 records = public_send(associated_records_method_name)
-                records = resource_class.apply_filters(records, filters)
+                records = resource_class.apply_filters(records, filters, options)
                 order_options = self.class.construct_order_options(sort_criteria)
                 records = resource_class.apply_sort(records, order_options)
                 records = resource_class.apply_pagination(records, paginator, order_options)

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -143,7 +143,7 @@ class ResourceTest < ActiveSupport::TestCase
 
     # define apply_filters method on post resource to not respect filters
     PostResource.instance_eval do
-      def apply_filters(records, filters)
+      def apply_filters(records, filters, options)
         # :nocov:
         records
         # :nocov:
@@ -155,7 +155,7 @@ class ResourceTest < ActiveSupport::TestCase
 
     # reset method to original implementation
     PostResource.instance_eval do
-      def apply_filters(records, filters)
+      def apply_filters(records, filters, options)
         # :nocov:
         super
         # :nocov:


### PR DESCRIPTION
Overriding `apply_filter` is the recommended way to implement custom 
filters. However if filtering relies on the context (e.g. `current_user`)
it was not possible to implement the custom filter. This passes the 
options context to the `apply_filter` method so it is available when 
overriding in a resource.
