### PR TITLE
add options :key and :readonly for JSONAPI::Resource.attribute

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -248,15 +248,16 @@ module JSONAPI
           ActiveSupport::Deprecation.warn('Id without format is no longer supported. Please remove ids from attributes, or specify a format.')
         end
 
+        model_attr = options.fetch(:key, attr)
         @_attributes ||= {}
         @_attributes[attr] = options
         define_method attr do
-          @model.send(attr)
+          @model.send(model_attr)
         end unless method_defined?(attr)
 
         define_method "#{attr}=" do |value|
-          @model.send "#{attr}=", value
-        end unless method_defined?("#{attr}=")
+          @model.send "#{model_attr}=", value
+        end unless method_defined?("#{attr}=") || options[:readonly]
       end
 
       def default_attribute_options

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -39,6 +39,14 @@ class PersonWithCustomRecordsForErrorResource < PersonResource
   end
 end
 
+class PostWithKeyAttribute < JSONAPI::Resource
+  attribute :name, key: :title
+end
+
+class PostWithReadonlyAttribute < JSONAPI::Resource
+  attribute :title, readonly: true
+end
+
 class ResourceTest < ActiveSupport::TestCase
   def setup
     @post = Post.first
@@ -225,6 +233,28 @@ class ResourceTest < ActiveSupport::TestCase
         super
         # :nocov:
       end
+    end
+  end
+
+  def test_key_attribute
+    post = Post.find(1)
+    post.update!(title: 'default title')
+    post_resource = PostWithKeyAttribute.new(post)
+    assert_equal(post_resource.name, post.title)
+
+    post_resource.name = 'some title'
+    assert_equal(post_resource.name, post.title)
+  end
+
+  def test_readonly_attribute
+    post = Post.find(1)
+    post.update!(title: 'default title')
+    post_resource = PostWithReadonlyAttribute.new(post)
+
+    assert_equal(post_resource.title, post.title)
+
+    assert_raises NoMethodError do
+      post_resource.title = 'some title'
     end
   end
 end


### PR DESCRIPTION
key option allows you to prettify attribute names ( column name in model can be different from attribute name in resource).
readonly option allows you to define readonly attributes correctly (if you call something like title= it will raise NoMethodError in resource but not in model).

i think its pretty useful :)
