### PR TITLE
Provide filter context to resource records query

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ For example to allow a user to only retrieve his own posts you can do the follow
 class PostResource < JSONAPI::Resource
   attribute :title, :body
 
-  def self.records(options = {})
+  def self.records(options = {}, filters = {})
     context = options[:context]
     context.current_user.posts
   end

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -360,7 +360,7 @@ module JSONAPI
       def filter_records(filters, options)
         include_directives = options[:include_directives]
 
-        records = records(options)
+        records = records(options, filters)
         records = apply_includes(records, include_directives)
         apply_filters(records, filters)
       end
@@ -407,7 +407,7 @@ module JSONAPI
 
       # Override this method if you want to customize the relation for
       # finder methods (find, find_by_key)
-      def records(options = {})
+      def records(options = {}, filters = {})
         _model_class
       end
 

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -3,7 +3,7 @@ require File.expand_path('../../../test_helper', __FILE__)
 class ArticleResource < JSONAPI::Resource
   model_name 'Post'
 
-  def self.records(options)
+  def self.records(options, filters = {})
     options[:context].posts
   end
 end


### PR DESCRIPTION
Sometimes when overriding the `records` method on a resource it is useful
to have access to the current filters. For instance if the underlying 
base query for the resource changes based on a filter param. This can 
not be done in the `apply_filter` method because compound filters would 
produce inconsistent results depending on the order in which they are 
run.
