### PR TITLE
Fixed bug that ignores source_type when association is loaded eagerly

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -602,7 +602,7 @@ module JSONAPI
               resources = []
 
               if resource_class
-                records = public_send(associated_records_method_name)
+                records = public_send(associated_records_method_name).all
                 records = resource_class.apply_filters(records, filters, options)
                 order_options = self.class.construct_order_options(sort_criteria)
                 records = resource_class.apply_sort(records, order_options)


### PR DESCRIPTION
With model schema:

```
class Activity < ActiveRecord::Base
  has_many :activity_roles
  has_many :event_invitations, through: :activity_roles
  has_many :users, through: :event_invitations, source_type: 'User'
  has_many :hosts, through: :event_invitations, source_type: 'Host'
  # ...
end

class ActivityRole < ActiveRecord::Base
  belongs_to :activity
  belongs_to :event_invitation
  # ...
end

class ActivityRole < ActiveRecord::Base
  belongs_to :activity
  belongs_to :event_invitation
  # ...
end

class EventInvitation < ActiveRecord::Base
  belongs_to :event
  belongs_to :user, polymorphic: true
  has_many :activity_roles
  # ...
end
```

Getting `Activity` with `includes(:users)` returns CollectionProxy with both `Users` and `Hosts`. For activity with 10 users and 2 hosts:

```
Activity.includes(:users).find(Activity.first.id).users.size
=> 12 
Activity.includes(:users).find(Activity.first.id).users.count
=> 10
Activity.includes(:users).find(Activity.first.id).users.all,size
=> 10
```

This bug with this model design makes resource to be applied to different classes and return wrong data (or raise exception if class have different attributes). After patch everything seems to work fine.
