### PR TITLE
Filter includes that are not valid associations

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -307,7 +307,16 @@ module JSONAPI
       end
 
       def apply_includes(records, directives)
-        records = records.includes(*directives.model_includes) if directives
+        if directives
+          includes = *directives.model_includes.select do |elem|
+            if elem.is_a? Hash
+              true
+            elsif not @model.nil?
+              @model.reflect_on_association(elem)
+            end
+          end
+          records = records.includes(includes)
+        end
         records
       end
 


### PR DESCRIPTION
When resource have has_many ot has_one that are not real associations they are still getting included in eager loading of a record. This PR fixes this issue by filtering those *directives.model_includes that are not real associations of a resource.
