### PR TITLE
Allow custom resource serializer

### DIFF
--- a/lib/jsonapi/acts_as_resource_controller.rb
+++ b/lib/jsonapi/acts_as_resource_controller.rb
@@ -64,6 +64,10 @@ module JSONAPI
       @resource_klass ||= resource_klass_name.safe_constantize
     end
 
+    def resource_serializer_klass
+      @resource_serializer_klass ||= JSONAPI::ResourceSerializer
+    end
+
     def base_url
       @base_url ||= request.protocol + request.host_with_port
     end
@@ -142,7 +146,8 @@ module JSONAPI
           base_url: base_url,
           key_formatter: key_formatter,
           route_formatter: route_formatter,
-          base_meta: base_response_meta
+          base_meta: base_response_meta,
+          resource_serializer_klass: resource_serializer_klass
         }
       )
     end

--- a/lib/jsonapi/response_document.rb
+++ b/lib/jsonapi/response_document.rb
@@ -27,7 +27,7 @@ module JSONAPI
     private
 
     def serializer
-      @serializer ||= JSONAPI::ResourceSerializer.new(
+      @serializer ||= @options.fetch(:resource_serializer_klass, JSONAPI::ResourceSerializer).new(
         @options.fetch(:primary_resource_klass),
         include_directives: @options[:include_directives],
         fields: @options[:fields],


### PR DESCRIPTION
A slight tweak to allow for my use case where I need to customize `JSONAPI::ResourceSerializer`.  I think it could be useful for others.

Does this work?
