### PR TITLE
Allow passing routing options to jsonapi_relationships

### DIFF
--- a/lib/jsonapi/routing_ext.rb
+++ b/lib/jsonapi/routing_ext.rb
@@ -37,15 +37,15 @@ module ActionDispatch
           end
         end
 
-        def jsonapi_relationships
+        def jsonapi_relationships(options = {})
           res = JSONAPI::Resource.resource_for(resource_type_with_module_prefix(@resource_type))
           res._associations.each do |association_name, association|
             if association.is_a?(JSONAPI::Association::HasMany)
-              jsonapi_links(association_name)
-              jsonapi_related_resources(association_name)
+              jsonapi_links(association_name, options)
+              jsonapi_related_resources(association_name, options)
             else
-              jsonapi_link(association_name)
-              jsonapi_related_resource(association_name)
+              jsonapi_link(association_name, options)
+              jsonapi_related_resource(association_name, options)
             end
           end
         end


### PR DESCRIPTION
This allows passing routing options to jsonapi_relationships, which is useful if you are building read-only API, and want to limit generated methods to GET-only:

```
with_options(only: [:index, :show]) do
    jsonapi_resources :contacts do
      jsonapi_relationships
    end
end
```

`jsonapi_links` and `jsonapi_related_resources` already support these options, so it seemed logical to add it here too. 
