### PR TITLE
Rework context in operations

### DIFF
--- a/lib/jsonapi/active_record_operations_processor.rb
+++ b/lib/jsonapi/active_record_operations_processor.rb
@@ -16,7 +16,7 @@ class ActiveRecordOperationsProcessor < JSONAPI::OperationsProcessor
   end
 
   def process_operation(operation)
-    operation.apply(@context)
+    operation.apply
   rescue ActiveRecord::DeleteRestrictionError => e
     record_locked_error = JSONAPI::Exceptions::RecordLocked.new(e.message)
     return JSONAPI::ErrorsOperationResult.new(record_locked_error.errors[0].code, record_locked_error.errors)

--- a/lib/jsonapi/operations_processor.rb
+++ b/lib/jsonapi/operations_processor.rb
@@ -27,7 +27,6 @@ module JSONAPI
     def process(request)
       @results = JSONAPI::OperationResults.new
       @request = request
-      @context = request.context
       @operations = request.operations
 
       # Use transactions if more than one operation and if one of the operations can be transactional
@@ -82,7 +81,7 @@ module JSONAPI
     end
 
     def process_operation(operation)
-      operation.apply(@context)
+      operation.apply
     end
   end
 end

--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -264,6 +264,7 @@ module JSONAPI
       @operations.push JSONAPI::FindOperation.new(
                          @resource_klass,
                          {
+                           context: @context,
                            filters: @filters,
                            include_directives: @include_directives,
                            sort_criteria: @sort_criteria,
@@ -276,6 +277,7 @@ module JSONAPI
       @operations.push JSONAPI::ShowOperation.new(
                          @resource_klass,
                          {
+                           context: @context,
                            id: @id,
                            include_directives: @include_directives
                          }
@@ -286,6 +288,7 @@ module JSONAPI
       @operations.push JSONAPI::ShowAssociationOperation.new(
                          @resource_klass,
                          {
+                           context: @context,
                            association_type: association_type,
                            parent_key: @resource_klass.verify_key(parent_key)
                          }
@@ -296,6 +299,7 @@ module JSONAPI
       @operations.push JSONAPI::ShowRelatedResourceOperation.new(
                          @resource_klass,
                          {
+                           context: @context,
                            association_type: association_type,
                            source_klass: @source_klass,
                            source_id: @source_id
@@ -307,6 +311,7 @@ module JSONAPI
       @operations.push JSONAPI::ShowRelatedResourcesOperation.new(
                          @resource_klass,
                          {
+                           context: @context,
                            association_type: association_type,
                            source_klass: @source_klass,
                            source_id: @source_id,
@@ -336,6 +341,7 @@ module JSONAPI
         @operations.push JSONAPI::CreateResourceOperation.new(
                            @resource_klass,
                            {
+                             context: @context,
                              data: data
                            }
                          )
@@ -519,6 +525,7 @@ module JSONAPI
         @operations.push JSONAPI::CreateHasManyAssociationOperation.new(
                            resource_klass,
                            {
+                             context: @context,
                              resource_id: parent_key,
                              association_type: association_type,
                              data: verified_param_set[:has_many].values[0]
@@ -537,6 +544,7 @@ module JSONAPI
         @operations.push JSONAPI::ReplaceHasOneAssociationOperation.new(
                            resource_klass,
                            {
+                             context: @context,
                              resource_id: parent_key,
                              association_type: association_type,
                              key_value: verified_param_set[:has_one].values[0]
@@ -553,6 +561,7 @@ module JSONAPI
         @operations.push JSONAPI::ReplaceHasManyAssociationOperation.new(
                            resource_klass,
                            {
+                             context: @context,
                              resource_id: parent_key,
                              association_type: association_type,
                              data: verified_param_set[:has_many].values[0]
@@ -585,6 +594,7 @@ module JSONAPI
       @operations.push JSONAPI::ReplaceFieldsOperation.new(
                          @resource_klass,
                          {
+                           context: @context,
                            resource_id: key,
                            data: parse_params(data, updatable_fields)
                          }
@@ -615,6 +625,7 @@ module JSONAPI
         @operations.push JSONAPI::RemoveResourceOperation.new(
                            @resource_klass,
                            {
+                             context: @context,
                              resource_id: key
                            }
                          )
@@ -637,6 +648,7 @@ module JSONAPI
           @operations.push JSONAPI::RemoveHasManyAssociationOperation.new(
                              resource_klass,
                              {
+                               context: @context,
                                resource_id: parent_key,
                                association_type: association_type,
                                associated_key: key
@@ -647,6 +659,7 @@ module JSONAPI
         @operations.push JSONAPI::RemoveHasOneAssociationOperation.new(
                            resource_klass,
                            {
+                             context: @context,
                              resource_id: parent_key,
                              association_type: association_type
                            }


### PR DESCRIPTION
Store the context when the operation is created, not when it’s applied.
Fixes #263
