### PR TITLE
Allow passing options to attributes the same way as to attribute

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -278,8 +278,9 @@ module JSONAPI
 
       # Methods used in defining a resource class
       def attributes(*attrs)
+        options = attrs.extract_options!.dup
         attrs.each do |attr|
-          attribute(attr)
+          attribute(attr, options)
         end
       end
 


### PR DESCRIPTION
Like this

```
attributes :starts_at, :ends_at, format: :timestamp
```
