### PR TITLE
Fix routing with non-array `except` value

### DIFF
--- a/lib/jsonapi/routing_ext.rb
+++ b/lib/jsonapi/routing_ext.rb
@@ -70,6 +70,7 @@ module ActionDispatch
           options[:path] = format_route(@resource_type)
 
           if options[:except]
+            options[:except] = Array(options[:except])
             options[:except] << :new unless options[:except].include?(:new) || options[:except].include?('new')
             options[:except] << :edit unless options[:except].include?(:edit) || options[:except].include?('edit')
           else
@@ -92,7 +93,7 @@ module ActionDispatch
           if only = options[:only]
             Array(only).map(&:to_sym)
           elsif except = options[:except]
-            default_methods - except
+            default_methods - Array(except)
           else
             default_methods
           end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -110,7 +110,7 @@ TestApp.routes.draw do
     JSONAPI.configuration.route_format = :underscored_route
     namespace :v2 do
       jsonapi_resources :posts do
-        jsonapi_link :author, except: [:destroy]
+        jsonapi_link :author, except: :destroy
       end
 
       jsonapi_resource :preferences, except: [:create, :destroy]


### PR DESCRIPTION
A route like `jsonapi_resources :users, except: :destroy` causes an unhandled exception because jsonapi-resources doesn't allow a single non-array `except` value, which is inconsistent with Rails.

This PR fixes that, allowing both array and non-array `except` values.
