### PR TITLE
Remove unused @key attribute

### DIFF
--- a/lib/jsonapi/association.rb
+++ b/lib/jsonapi/association.rb
@@ -19,7 +19,7 @@ module JSONAPI
         super
         @class_name = options.fetch(:class_name, name.to_s.capitalize)
         @type = class_name.underscore.pluralize.to_sym
-        @foreign_key ||= @key.nil? ? "#{name}_id".to_sym : @key
+        @foreign_key ||= "#{name}_id".to_sym
       end
     end
 
@@ -28,7 +28,7 @@ module JSONAPI
         super
         @class_name = options.fetch(:class_name, name.to_s.capitalize.singularize)
         @type = class_name.underscore.pluralize.to_sym
-        @foreign_key  ||= @key.nil? ? "#{name.to_s.singularize}_ids".to_sym : @key
+        @foreign_key  ||= "#{name.to_s.singularize}_ids".to_sym
       end
     end
   end


### PR DESCRIPTION
It seems that this @key attribute is no longer used (replaced by @foreign_key which is set in the base class from the options hash in https://github.com/cerebris/jsonapi-resources/commit/7b2459a6e83d923572e747b1089b7f7e2de7811d)
