### PR TITLE
Add support for creating resources with polymorphic has one.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # JSONAPI::Resources [![Build Status](https://secure.travis-ci.org/cerebris/jsonapi-resources.png?branch=master)](http://travis-ci.org/cerebris/jsonapi-resources)
 
-`JSONAPI::Resources`, or "JR", provides a framework for developing a server that complies with the 
+`JSONAPI::Resources`, or "JR", provides a framework for developing a server that complies with the
 [JSON API](http://jsonapi.org/) specification.
 
-Like JSON API itself, JR's design is focused on the resources served by an API. JR needs little more than a definition 
+Like JSON API itself, JR's design is focused on the resources served by an API. JR needs little more than a definition
 of your resources, including their attributes and relationships, to make your server compliant with JSON API.
 
-JR is designed to work with Rails 4.0+, and provides custom routes, controllers, and serializers. JR's resources may be 
+JR is designed to work with Rails 4.0+, and provides custom routes, controllers, and serializers. JR's resources may be
 backed by ActiveRecord models or by custom objects.
 
 ## Demo App
@@ -15,7 +15,7 @@ We have a simple demo app, called [Peeps](https://github.com/cerebris/peeps), av
 
 ## Client Libraries
 
-JSON API maintains a (non-verified) listing of [client libraries](http://jsonapi.org/implementations/#client-libraries) 
+JSON API maintains a (non-verified) listing of [client libraries](http://jsonapi.org/implementations/#client-libraries)
 which *should* be compatible with JSON API compliant server implementations such as JR.
 
 ## Installation
@@ -36,10 +36,10 @@ Or install it yourself as:
 
 ### Resources
 
-Resources define the public interface to your API. A resource defines which attributes are exposed, as well as 
+Resources define the public interface to your API. A resource defines which attributes are exposed, as well as
 relationships to other resources.
 
-Resource definitions should by convention be placed in a directory under app named resources, `app/resources`. The class 
+Resource definitions should by convention be placed in a directory under app named resources, `app/resources`. The class
 name should be the single underscored name of the model that backs the resource with `_resource.rb` appended. For example,
 a `Contact` model's resource should have a class named `ContactResource` defined in a file named `contact_resource.rb`.
 
@@ -56,7 +56,7 @@ end
 
 #### Attributes
 
-Any of a resource's attributes that are accessible must be explicitly declared. Single attributes can be declared using 
+Any of a resource's attributes that are accessible must be explicitly declared. Single attributes can be declared using
 the `attribute` method, and multiple attributes can be declared with the `attributes` method on the resource class.
 
 For example:
@@ -68,10 +68,10 @@ class ContactResource < JSONAPI::Resource
 end
 ```
 
-This resource has 4 defined attributes: `name_first`, `name_last`, `email`, `twitter`, as well as the automatically 
+This resource has 4 defined attributes: `name_first`, `name_last`, `email`, `twitter`, as well as the automatically
 defined attributes `id` and `type`. By default these attributes must exist on the model that is handled by the resource.
 
-A resource object wraps a Ruby object, usually an `ActiveModel` record, which is available as the `@model` variable. 
+A resource object wraps a Ruby object, usually an `ActiveModel` record, which is available as the `@model` variable.
 This allows a resource's methods to access the underlying model.
 
 For example, a computed attribute for `full_name` could be defined as such:
@@ -89,7 +89,7 @@ end
 
 ##### Fetchable Attributes
 
-By default all attributes are assumed to be fetchable. The list of fetchable attributes can be filtered by overriding 
+By default all attributes are assumed to be fetchable. The list of fetchable attributes can be filtered by overriding
 the `fetchable_fields` method.
 
 Here's an example that prevents guest users from seeing the `email` field:
@@ -115,7 +115,7 @@ value).
 
 ##### Creatable and Updatable Attributes
 
-By default all attributes are assumed to be updatable and creatable. To prevent some attributes from being accepted by 
+By default all attributes are assumed to be updatable and creatable. To prevent some attributes from being accepted by
 the `update` or `create` methods, override the `self.updatable_fields` and `self.creatable_fields` methods on a resource.
 
 This example prevents `full_name` from being set:
@@ -145,7 +145,7 @@ By using the context you have the option to determine the creatable and updatabl
 
 JR supports [sorting primary resources by multiple sort criteria](http://jsonapi.org/format/#fetching-sorting).
 
-By default all attributes are assumed to be sortable. To prevent some attributes from being sortable, override the 
+By default all attributes are assumed to be sortable. To prevent some attributes from being sortable, override the
 `self.sortable_fields` method on a resource.
 
 Here's an example that prevents sorting by post's `body`:
@@ -162,7 +162,7 @@ end
 
 ##### Attribute Formatting
 
-Attributes can have a `Format`. By default all attributes use the default formatter. If an attribute has the `format` 
+Attributes can have a `Format`. By default all attributes use the default formatter. If an attribute has the `format`
 option set the system will attempt to find a formatter based on this name. In the following example the `last_login_time`
 will be returned formatted to a certain time zone:
 
@@ -178,12 +178,12 @@ updating the attribute. See the [Value Formatters](#value-formatters) section fo
 
 #### Primary Key
 
-Resources are always represented using a key of `id`. If the underlying model does not use `id` as the primary key you 
-can use the `primary_key` method to tell the resource which field on the model to use as the primary key. Note: this 
-doesn't have to be the actual primary key of the model. For example you may wish to use integers internally and a 
+Resources are always represented using a key of `id`. If the underlying model does not use `id` as the primary key you
+can use the `primary_key` method to tell the resource which field on the model to use as the primary key. Note: this
+doesn't have to be the actual primary key of the model. For example you may wish to use integers internally and a
 different scheme publicly.
 
-By default only integer values are allowed for primary key. To change this behavior you can override 
+By default only integer values are allowed for primary key. To change this behavior you can override
 `verify_key` class method:
 
 ```ruby
@@ -201,7 +201,7 @@ end
 
 #### Model Name
 
-The name of the underlying model is inferred from the Resource name. It can be overridden by use of the `model_name` 
+The name of the underlying model is inferred from the Resource name. It can be overridden by use of the `model_name`
 method. For example:
 
 ```ruby
@@ -243,7 +243,7 @@ The association methods support the following options:
  * `class_name` - a string specifying the underlying class for the related resource
  * `foreign_key` - the method on the resource used to fetch the related resource. Defaults to `<resource_name>_id` for has_one and `<resource_name>_ids` for has_many relationships.
  * `acts_as_set` - allows the entire set of related records to be replaced in one operation. Defaults to false if not set.
- * `polymorphic` - set to true to identify `has_one` associations that are polymorphic.
+ * `polymorphic` - set to true to identify associations that are polymorphic.
 
 Examples:
 
@@ -274,10 +274,10 @@ The polymorphic association will require the resource and controller to exist, a
 class TaggableResource < JSONAPI::Resource; end
 class TaggablesController < JSONAPI::ResourceController; end
 ```
- 
+
 #### Filters
 
-Filters for locating objects of the resource type are specified in the resource definition. Single filters can be 
+Filters for locating objects of the resource type are specified in the resource definition. Single filters can be
 declared using the `filter` method, and multiple filters can be declared with the `filters` method on the resource class.
 
 For example:
@@ -304,7 +304,7 @@ For example:
   attributes :body, :status
   has_one :post
   has_one :author
-  
+
   filter :status, default: 'published,pending'
 end
 ```
@@ -313,13 +313,13 @@ The default value is used as if it came from the request.
 
 ##### Finders
 
-Basic finding by filters is supported by resources. This is implemented in the `find` and `find_by_key` finder methods. 
+Basic finding by filters is supported by resources. This is implemented in the `find` and `find_by_key` finder methods.
 Currently this is implemented for `ActiveRecord` based resources. The finder methods rely on the `records` method to get
 an `Arel` relation. It is therefore possible to override `records` to affect the three find related methods.
 
 ###### Customizing base records for finder methods
 
-If you need to change the base records on which `find` and `find_by_key` operate, you can override the `records` method 
+If you need to change the base records on which `find` and `find_by_key` operate, you can override the `records` method
 on the resource class.
 
 For example to allow a user to only retrieve his own posts you can do the following:
@@ -335,7 +335,7 @@ class PostResource < JSONAPI::Resource
 end
 ```
 
-When you create a relationship, a method is created to fetch record(s) for that relationship. This method calls 
+When you create a relationship, a method is created to fetch record(s) for that relationship. This method calls
 `records_for(association_name)` by default.
 
 ```ruby
@@ -373,7 +373,7 @@ end
 
 ###### Applying Filters
 
-The `apply_filter` method is called to apply each filter to the `Arel` relation. You may override this method to gain 
+The `apply_filter` method is called to apply each filter to the `Arel` relation. You may override this method to gain
 control over how the filters are applied to the `Arel` relation.
 
 This example shows how you can implement different approaches for different filters.
@@ -400,7 +400,7 @@ end
 
 ###### Override finder methods
 
-Finally if you have more complex requirements for finding you can override the `find` and `find_by_key` methods on the 
+Finally if you have more complex requirements for finding you can override the `find` and `find_by_key` methods on the
 resource class.
 
 Here's an example that defers the `find` operation to a `current_user` set on the `context` option:
@@ -426,24 +426,24 @@ end
 
 #### Pagination
 
-Pagination is performed using a `paginator`, which is a class responsible for parsing the `page` request parameters and 
+Pagination is performed using a `paginator`, which is a class responsible for parsing the `page` request parameters and
 applying the pagination logic to the results.
 
 ##### Paginators
 
-`JSONAPI::Resource` supports several pagination methods by default, and allows you to implement a custom system if the 
+`JSONAPI::Resource` supports several pagination methods by default, and allows you to implement a custom system if the
 defaults do not meet your needs.
 
 ###### Paged Paginator
 
-The `paged` `paginator` returns results based on pages of a fixed size. Valid `page` parameters are `number` and `size`. 
-If `number` is omitted the first page is returned. If `size` is omitted the `default_page_size` from the configuration 
+The `paged` `paginator` returns results based on pages of a fixed size. Valid `page` parameters are `number` and `size`.
+If `number` is omitted the first page is returned. If `size` is omitted the `default_page_size` from the configuration
 settings is used.
 
 ###### Offset Paginator
 
-The `offset` `paginator` returns results based on an offset from the beginning of the resultset. Valid `page` parameters 
-are `offset` and `limit`. If `offset` is omitted a value of 0 will be used. If `limit` is omitted the `default_page_size` 
+The `offset` `paginator` returns results based on an offset from the beginning of the resultset. Valid `page` parameters
+are `offset` and `limit`. If `offset` is omitted a value of 0 will be used. If `limit` is omitted the `default_page_size`
 from the configuration settings is used.
 
 ###### Custom Paginators
@@ -469,7 +469,7 @@ end
 
 ##### Paginator Configuration
 
-The default paginator, which will be used for all resources, is set using `JSONAPI.configure`. For example, in your 
+The default paginator, which will be used for all resources, is set using `JSONAPI.configure`. For example, in your
 `config/initializers/jsonapi_resources.rb`:
 
 ```ruby
@@ -484,7 +484,7 @@ end
 
 If no `default_paginator` is configured, pagination will be disabled by default.
 
-Paginators can also be set at the resource-level, which will override the default setting. This is done using the 
+Paginators can also be set at the resource-level, which will override the default setting. This is done using the
 `paginator` method:
 
 ```ruby
@@ -500,7 +500,7 @@ To disable pagination in a resource, specify `:none` for `paginator`.
 
 #### Callbacks
 
-`ActiveSupport::Callbacks` is used to provide callback functionality, so the behavior is very similar to what you may be 
+`ActiveSupport::Callbacks` is used to provide callback functionality, so the behavior is very similar to what you may be
 used to from `ActiveRecord`.
 
 For example, you might use a callback to perform authorization on your resource before an action.
@@ -556,13 +556,13 @@ Callbacks can also be defined for `JSONAPI::OperationsProcessor` events:
 - `:remove_has_one_association_operation`: A `remove_has_one_association_operation`.
 
 The operation callbacks have access to two meta data hashes, `@operations_meta` and `@operation_meta`, two links hashes,
-`@operations_links` and `@operation_links`, the full list of `@operations`, each individual `@operation` and the 
+`@operations_links` and `@operation_links`, the full list of `@operations`, each individual `@operation` and the
 `@result` variables.
 
 ##### Custom `OperationsProcessor` Example to Return total_count in Meta
 
 Note: this can also be accomplished with the `top_level_meta_include_record_count` option, and in most cases that will
-be the better option. 
+be the better option.
 
 To return the total record count of a find operation in the meta data of a find operation you can create a custom
 OperationsProcessor. For example:
@@ -577,14 +577,14 @@ end
 
 Set the configuration option `operations_processor` to use the new `CountingActiveRecordOperationsProcessor` by
 specifying the snake cased name of the class (without the `OperationsProcessor`).
- 
+
 ```ruby
 JSONAPI.configure do |config|
   config.operations_processor = :counting_active_record
 end
 ```
 
-The callback code will be called after each find. It will use the same options as the find operation, without the 
+The callback code will be called after each find. It will use the same options as the find operation, without the
 pagination, to collect the record count. This is stored in the `operation_meta`, which will be returned in the top level
 meta element.
 
@@ -595,8 +595,8 @@ the `ActsAsResourceController` module.
 
 ##### ResourceController
 
-`JSONAPI::Resources` provides a class, `ResourceController`, that can be used as the base class for your controllers. 
-`ResourceController` supports `index`, `show`, `create`, `update`, and `destroy` methods. Just deriving your controller 
+`JSONAPI::Resources` provides a class, `ResourceController`, that can be used as the base class for your controllers.
+`ResourceController` supports `index`, `show`, `create`, `update`, and `destroy` methods. Just deriving your controller
 from `ResourceController` will give you a fully functional controller.
 
 For example:
@@ -646,7 +646,7 @@ JSONAPI::Resources supports namespacing of controllers and resources. With names
 
 If you namespace your controller it will require a namespaced resource.
 
-In the following example we have a `resource` that isn't namespaced, and one the has now been namespaced. There are 
+In the following example we have a `resource` that isn't namespaced, and one the has now been namespaced. There are
 slight differences between the two resources, as might be seen in a new version of an API:
 
 ```ruby
@@ -853,7 +853,7 @@ An array of resources. Nested resources can be specified with dot notation.
 
 A hash of resource types and arrays of fields for each resource type.
 
-  *Purpose*: determines which fields are serialized for a resource type. This encompasses both attributes and 
+  *Purpose*: determines which fields are serialized for a resource type. This encompasses both attributes and
   association ids in the links section for a resource. Fields are global for a resource type.
 
   *Example*: ```fields: { people: [:email, :comments], posts: [:title, :author], comments: [:body, :post]}```
@@ -948,7 +948,7 @@ gives routes that are only related to the primary resource, and none for its rel
 ```
 
 To manually add in the nested routes you can use the `jsonapi_links`, `jsonapi_related_resources` and
-`jsonapi_related_resource` inside the block. Or, you can add the default set of nested routes using the 
+`jsonapi_related_resource` inside the block. Or, you can add the default set of nested routes using the
 `jsonapi_relationships` method. For example:
 
 ```ruby
@@ -1045,11 +1045,11 @@ phone_number_contact GET    /phone-numbers/:phone_number_id/contact(.:format) co
 
 #### Formatting
 
-JR by default uses some simple rules to format an attribute for serialization. Strings and Integers are output to JSON 
-as is, and all other values have `.to_s` applied to them. This outputs something in all cases, but it is certainly not 
+JR by default uses some simple rules to format an attribute for serialization. Strings and Integers are output to JSON
+as is, and all other values have `.to_s` applied to them. This outputs something in all cases, but it is certainly not
 correct for every situation.
 
-If you want to change the way an attribute is serialized you have a couple of ways. The simplest method is to create a 
+If you want to change the way an attribute is serialized you have a couple of ways. The simplest method is to create a
 getter method on the resource which overrides the attribute and apply the formatting there. For example:
 
 ```ruby
@@ -1063,13 +1063,13 @@ class PersonResource < JSONAPI::Resource
 end
 ```
 
-This is simple to implement for a one off situation, but not for example if you want to apply the same formatting rules 
-to all DateTime fields in your system. Another issue is the attribute on the resource will always return a formatted 
+This is simple to implement for a one off situation, but not for example if you want to apply the same formatting rules
+to all DateTime fields in your system. Another issue is the attribute on the resource will always return a formatted
 response, whether you want it or not.
 
 ##### Value Formatters
 
-To overcome the above limitations JR uses Value Formatters. Value Formatters allow you to control the way values are 
+To overcome the above limitations JR uses Value Formatters. Value Formatters allow you to control the way values are
 handled for an attribute. The `format` can be set per attribute as it is declared in the resource. For example:
 
 ```ruby
@@ -1079,7 +1079,7 @@ class PersonResource < JSONAPI::Resource
 end
 ```
 
-A Value formatter has a `format` and an `unformat` method. Here's the base ValueFormatter and DefaultValueFormatter for 
+A Value formatter has a `format` and an `unformat` method. Here's the base ValueFormatter and DefaultValueFormatter for
 reference:
 
 ```ruby
@@ -1112,21 +1112,21 @@ class DefaultValueFormatter < JSONAPI::ValueFormatter
 end
 ```
 
-You can also create your own Value Formatter. Value Formatters must be named with the `format` name followed by 
+You can also create your own Value Formatter. Value Formatters must be named with the `format` name followed by
 `ValueFormatter`, i.e. `DateWithUTCTimezoneValueFormatter` and derive from `JSONAPI::ValueFormatter`. It is
 recommended that you create a directory for your formatters, called `formatters`.
 
-The `format` method is called by the `ResourceSerializer` as is serializing a resource. The format method takes the 
+The `format` method is called by the `ResourceSerializer` as is serializing a resource. The format method takes the
 `raw_value` parameter. `raw_value` is the value as read from the model.
 
-The `unformat` method is called when processing the request. Each incoming attribute (except `links`) are run through 
-the `unformat` method. The `unformat` method takes a `value`, which is the value as it comes in on the 
+The `unformat` method is called when processing the request. Each incoming attribute (except `links`) are run through
+the `unformat` method. The `unformat` method takes a `value`, which is the value as it comes in on the
 request. This allows you process the incoming value to alter its state before it is stored in the model.
 
 ###### Use a Different Default Value Formatter
 
-Another way to handle formatting is to set a different default value formatter. This will affect all attributes that do 
-not have a `format` set. You can do this by overriding the `default_attribute_options` method for a resource (or a base 
+Another way to handle formatting is to set a different default value formatter. This will affect all attributes that do
+not have a `format` set. You can do this by overriding the `default_attribute_options` method for a resource (or a base
 resource for a system wide change).
 
 ```ruby
@@ -1158,11 +1158,11 @@ This way all DateTime values will be formatted to display in the UTC timezone.
 
 #### Key Format
 
-By default JR uses dasherized keys as per the 
-[JSON API naming recommendations](http://jsonapi.org/recommendations/#naming).  This can be changed by specifying a 
+By default JR uses dasherized keys as per the
+[JSON API naming recommendations](http://jsonapi.org/recommendations/#naming).  This can be changed by specifying a
 different key formatter.
 
-For example, to use camel cased keys with an initial lowercase character (JSON's default) create an initializer and add 
+For example, to use camel cased keys with an initial lowercase character (JSON's default) create an initializer and add
 the following:
 
 ```ruby
@@ -1172,7 +1172,7 @@ JSONAPI.configure do |config|
 end
 ```
 
-This will cause the serializer to use the `CamelizedKeyFormatter`. You can also create your own `KeyFormatter`, for 
+This will cause the serializer to use the `CamelizedKeyFormatter`. You can also create your own `KeyFormatter`, for
 example:
 
 ```ruby
@@ -1189,7 +1189,7 @@ You would specify this in `JSONAPI.configure` as `:upper_camelized`.
 
 ## Configuration
 
-JR has a few configuration options. Some have already been mentioned above. To set configuration options create an 
+JR has a few configuration options. Some have already been mentioned above. To set configuration options create an
 initializer and add the options you wish to set. All options have defaults, so you only need to set the options that
 are different. The default options are shown below.
 

--- a/README.md
+++ b/README.md
@@ -239,31 +239,42 @@ end
 ##### Options
 
 The association methods support the following options:
+
  * `class_name` - a string specifying the underlying class for the related resource
- * `foreign_key` - the method on the resource used to fetch the related resource. Defaults to `<resource_name>_id` for 
-    has_one and `<resource_name>_ids` for has_many relationships.
+ * `foreign_key` - the method on the resource used to fetch the related resource. Defaults to `<resource_name>_id` for has_one and `<resource_name>_ids` for has_many relationships.
  * `acts_as_set` - allows the entire set of related records to be replaced in one operation. Defaults to false if not set.
+ * `polymorphic` - set to true to identify `has_one` associations that are polymorphic.
 
 Examples:
 
 ```ruby
- class CommentResource < JSONAPI::Resource
+class CommentResource < JSONAPI::Resource
   attributes :body
   has_one :post
   has_one :author, class_name: 'Person'
   has_many :tags, acts_as_set: true
- end
-```
+end
 
-```ruby
 class ExpenseEntryResource < JSONAPI::Resource
   attributes :cost, :transaction_date
 
   has_one :currency, class_name: 'Currency', foreign_key: 'currency_code'
   has_one :employee
 end
+
+class TagResource < JSONAPI::Resource
+  attributes :name
+  has_one :taggable, polymorphic: true
+end
 ```
 
+The polymorphic association will require the resource and controller to exist, although routing to them will cause an error.
+
+```ruby
+class TaggableResource < JSONAPI::Resource; end
+class TaggablesController < JSONAPI::ResourceController; end
+```
+ 
 #### Filters
 
 Filters for locating objects of the resource type are specified in the resource definition. Single filters can be 
@@ -279,6 +290,7 @@ class ContactResource < JSONAPI::Resource
   filters :name_first, :name_last
 end
 ```
+
 
 ##### Default Filters
 

--- a/lib/jsonapi-resources.rb
+++ b/lib/jsonapi-resources.rb
@@ -20,4 +20,3 @@ require 'jsonapi/include_directives'
 require 'jsonapi/operation_result'
 require 'jsonapi/operation_results'
 require 'jsonapi/callbacks'
-

--- a/lib/jsonapi/association.rb
+++ b/lib/jsonapi/association.rb
@@ -1,34 +1,52 @@
 module JSONAPI
   class Association
-    attr_reader :acts_as_set, :foreign_key, :type, :options, :name, :class_name
+    attr_reader :acts_as_set, :foreign_key, :type, :options, :name,
+                :class_name, :polymorphic
 
-    def initialize(name, options={})
-      @name                = name.to_s
-      @options             = options
-      @acts_as_set         = options.fetch(:acts_as_set, false) == true
-      @foreign_key         = options[:foreign_key ] ? options[:foreign_key ].to_sym : nil
-      @module_path         = options[:module_path] || ''
+    def initialize(name, options = {})
+      @name = name.to_s
+      @options = options
+      @acts_as_set = options.fetch(:acts_as_set, false) == true
+      @foreign_key = options[:foreign_key] ? options[:foreign_key].to_sym : nil
+      @module_path = options[:module_path] || ''
+      @polymorphic = options.fetch(:polymorphic, false) == true
     end
 
     def primary_key
       @primary_key ||= Resource.resource_for(@module_path + @name)._primary_key
     end
 
+    alias_method :polymorphic?, :polymorphic
+
+    def type_for_source(source)
+      if polymorphic?
+        resource = source.public_send(name)
+        resource.class._type if resource
+      else
+        type
+      end
+    end
+
     class HasOne < Association
-      def initialize(name, options={})
+      def initialize(name, options = {})
         super
         @class_name = options.fetch(:class_name, name.to_s.capitalize)
         @type = class_name.underscore.pluralize.to_sym
         @foreign_key ||= "#{name}_id".to_sym
       end
+
+      def polymorphic_type
+        "#{type.to_s.singularize}_type" if polymorphic?
+      end
     end
 
     class HasMany < Association
-      def initialize(name, options={})
+      def initialize(name, options = {})
         super
-        @class_name = options.fetch(:class_name, name.to_s.capitalize.singularize)
+        @class_name = options.fetch(:class_name,
+                                    name.to_s.capitalize.singularize)
         @type = class_name.underscore.pluralize.to_sym
-        @foreign_key  ||= "#{name.to_s.singularize}_ids".to_sym
+        @foreign_key ||= "#{name.to_s.singularize}_ids".to_sym
       end
     end
   end

--- a/lib/jsonapi/operation.rb
+++ b/lib/jsonapi/operation.rb
@@ -238,6 +238,25 @@ module JSONAPI
     end
   end
 
+  class ReplacePolymorphicHasOneAssociationOperation < Operation
+    attr_reader :resource_id, :association_type, :key_value, :key_type
+
+    def initialize(resource_klass, options = {})
+      @resource_id = options.fetch(:resource_id)
+      @key_value = options.fetch(:key_value)
+      @key_type = options.fetch(:key_type)
+      @association_type = options.fetch(:association_type).to_sym
+      super(resource_klass, options)
+    end
+
+    def apply
+      resource = @resource_klass.find_by_key(@resource_id, context: @context)
+      result = resource.replace_polymorphic_has_one_link(@association_type, @key_value, @key_type)
+
+      return JSONAPI::OperationResult.new(result == :completed ? :no_content : :accepted)
+    end
+  end
+
   class CreateHasManyAssociationOperation < Operation
     attr_reader :resource_id, :association_type, :data
 

--- a/lib/jsonapi/operations_processor.rb
+++ b/lib/jsonapi/operations_processor.rb
@@ -12,6 +12,7 @@ module JSONAPI
                                        :remove_resource_operation,
                                        :replace_fields_operation,
                                        :replace_has_one_association_operation,
+                                       :replace_polymorphic_has_one_association_operation,
                                        :create_has_many_association_operation,
                                        :replace_has_many_association_operation,
                                        :remove_has_many_association_operation,

--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -185,7 +185,7 @@ module JSONAPI
       association = resource_klass._association(association_name)
       if association && format_key(association_name) == include_parts.first
         unless include_parts.last.empty?
-          check_include(Resource.resource_for(@resource_klass.module_path + association.class_name.to_s), include_parts.last.partition('.'))
+          check_include(Resource.resource_for(@resource_klass.module_path + association.class_name.to_s.underscore), include_parts.last.partition('.'))
         end
       else
         @errors.concat(JSONAPI::Exceptions::InvalidInclude.new(format_key(resource_klass._type),
@@ -417,10 +417,8 @@ module JSONAPI
                 end
 
                 links_object = parse_has_one_links_object(linkage)
-                # Since we do not yet support polymorphic associations we will raise an error if the type does not match the
-                # association's type.
-                # ToDo: Support Polymorphic associations
-                if links_object[:type] && (links_object[:type].to_s != association.type.to_s)
+
+                if !association.polymorphic? && links_object[:type] && (links_object[:type].to_s != association.type.to_s)
                   raise JSONAPI::Exceptions::TypeMismatch.new(links_object[:type])
                 end
 
@@ -536,8 +534,21 @@ module JSONAPI
 
     def parse_update_association_operation(data, association_type, parent_key)
       association = resource_klass._association(association_type)
+      if association.polymorphic?
+        object_params = {relationships: {format_key(association.name) => {data: data}}}
+        verified_param_set = parse_params(object_params, updatable_fields)
 
-      if association.is_a?(JSONAPI::Association::HasOne)
+        @operations.push JSONAPI::ReplacePolymorphicHasOneAssociationOperation.new(
+                           resource_klass,
+                           {
+                             context: @context,
+                             resource_id: parent_key,
+                             association_type: association_type,
+                             key_value: verified_param_set[:has_one].values[0],
+                             key_type: data['type']
+                           }
+                         )
+      elsif association.is_a?(JSONAPI::Association::HasOne)
         object_params = {relationships: {format_key(association.name) => {data: data}}}
         verified_param_set = parse_params(object_params, updatable_fields)
 

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -199,10 +199,10 @@ module JSONAPI
     end
 
     def _replace_polymorphic_has_one_link(association_type, key_value, key_type)
-      association = self.class._associations[association_type]
+      association = self.class._associations[association_type.to_sym]
 
-      send("#{association.foreign_key}=", key_value)
-      send("#{association.polymorphic_type}=", key_type.singularize.capitalize)
+      model.send("#{association_type}_id=", key_value)
+      model.send("#{association_type}_type=", key_type.to_s.classify)
 
       @save_needed = true
 
@@ -242,7 +242,12 @@ module JSONAPI
         if value.nil?
           remove_has_one_link(association_type)
         else
-          replace_has_one_link(association_type, value)
+          case value
+          when Hash
+            replace_polymorphic_has_one_link(association_type.to_s, value.fetch(:id), value.fetch(:type))
+          else
+            replace_has_one_link(association_type, value)
+          end
         end
       end if field_data[:has_one]
 

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -685,13 +685,16 @@ module JSONAPI
 
               resources = []
 
-              if resource_class
+              if resource_class || association.polymorphic?
                 records = public_send(associated_records_method_name)
                 records = resource_class.apply_filters(records, filters, options)
                 order_options = self.class.construct_order_options(sort_criteria)
                 records = resource_class.apply_sort(records, order_options)
                 records = resource_class.apply_pagination(records, paginator, order_options)
                 records.each do |record|
+                  if association.polymorphic?
+                    resource_class = Resource.resource_for(self.class.module_path + record.class.to_s.underscore)
+                  end
                   resources.push resource_class.new(record, @context)
                 end
               end

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -17,6 +17,7 @@ module JSONAPI
                                        :replace_has_many_links,
                                        :create_has_one_link,
                                        :replace_has_one_link,
+                                       :replace_polymorphic_has_one_link,
                                        :remove_has_many_link,
                                        :remove_has_one_link,
                                        :replace_fields
@@ -78,6 +79,12 @@ module JSONAPI
     def replace_has_one_link(association_type, association_key_value)
       change :replace_has_one_link do
         _replace_has_one_link(association_type, association_key_value)
+      end
+    end
+
+    def replace_polymorphic_has_one_link(association_type, association_key_value, association_key_type)
+      change :replace_polymorphic_has_one_link do
+        _replace_polymorphic_has_one_link(association_type, association_key_value, association_key_type)
       end
     end
 
@@ -186,6 +193,17 @@ module JSONAPI
       association = self.class._associations[association_type]
 
       send("#{association.foreign_key}=", association_key_value)
+      @save_needed = true
+
+      return :completed
+    end
+
+    def _replace_polymorphic_has_one_link(association_type, key_value, key_type)
+      association = self.class._associations[association_type]
+
+      send("#{association.foreign_key}=", key_value)
+      send("#{association.polymorphic_type}=", key_type.singularize.capitalize)
+
       @save_needed = true
 
       return :completed
@@ -618,10 +636,9 @@ module JSONAPI
 
         attrs.each do |attr|
           check_reserved_association_name(attr)
+          @_associations[attr] = association = klass.new(attr, options)
 
-          @_associations[attr] = klass.new(attr, options)
-
-          foreign_key = @_associations[attr].foreign_key
+          foreign_key = association.foreign_key
 
           define_method foreign_key do
             @model.method(foreign_key).call
@@ -631,7 +648,7 @@ module JSONAPI
             @model.method("#{foreign_key}=").call(value)
           end unless method_defined?("#{foreign_key}=")
 
-          associated_records_method_name = case @_associations[attr]
+          associated_records_method_name = case association
           when JSONAPI::Association::HasOne then "record_for_#{attr}"
           when JSONAPI::Association::HasMany then "records_for_#{attr}"
           end
@@ -640,16 +657,20 @@ module JSONAPI
             records_for(attr, options)
           end unless method_defined?(associated_records_method_name)
 
-          if @_associations[attr].is_a?(JSONAPI::Association::HasOne)
+          if association.is_a?(JSONAPI::Association::HasOne)
             define_method attr do
               type_name = self.class._associations[attr].type.to_s
-              resource_class = Resource.resource_for(self.class.module_path + type_name)
-              if resource_class
+              if association.polymorphic?
                 associated_model = public_send(associated_records_method_name)
-                return associated_model ? resource_class.new(associated_model, @context) : nil
+                resource_class = Resource.resource_for(self.class.module_path + associated_model.class.to_s.underscore) if associated_model
+                return resource_class.new(associated_model, @context) if resource_class
+              else
+                resource_class = Resource.resource_for(self.class.module_path + type_name)
+                associated_model = public_send(associated_records_method_name) if resource_class
+                return resource_class.new(associated_model, @context) if associated_model
               end
             end unless method_defined?(attr)
-          elsif @_associations[attr].is_a?(JSONAPI::Association::HasMany)
+          elsif association.is_a?(JSONAPI::Association::HasMany)
             define_method attr do |options = {}|
               type_name = self.class._associations[attr].type.to_s
               resource_class = Resource.resource_for(self.class.module_path + type_name)

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -201,8 +201,8 @@ module JSONAPI
     def _replace_polymorphic_has_one_link(association_type, key_value, key_type)
       association = self.class._associations[association_type.to_sym]
 
-      model.send("#{association_type}_id=", key_value)
-      model.send("#{association_type}_type=", key_type.to_s.classify)
+      model.send("#{association.foreign_key}=", key_value)
+      model.send("#{association.polymorphic_type}=", key_type.to_s.classify)
 
       @save_needed = true
 

--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -172,6 +172,7 @@ module JSONAPI
               resource = source.send(name)
               if resource
                 id = resource.id
+                type = association.type_for_source(source)
                 associations_only = already_serialized?(type, id)
                 if include_linkage && !associations_only
                   add_included_object(type, id, object_hash(resource, ia))
@@ -236,7 +237,7 @@ module JSONAPI
       linkage = {}
       linkage_id = foreign_key_value(source, association)
       if linkage_id
-        linkage[:type] = format_key(association.type)
+        linkage[:type] = format_key(association.type_for_source(source))
         linkage[:id] = linkage_id
       else
         linkage = nil

--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -236,6 +236,7 @@ module JSONAPI
     def has_one_linkage(source, association)
       linkage = {}
       linkage_id = foreign_key_value(source, association)
+
       if linkage_id
         linkage[:type] = format_key(association.type_for_source(source))
         linkage[:id] = linkage_id
@@ -247,9 +248,10 @@ module JSONAPI
 
     def has_many_linkage(source, association)
       linkage = []
-      linkage_ids = foreign_key_value(source, association)
-      linkage_ids.each do |linkage_id|
-        linkage.append({type: format_key(association.type), id: linkage_id})
+      linkage_types_and_values = foreign_key_types_and_values(source, association)
+
+      linkage_types_and_values.each do |type, value|
+        linkage.append({type: format_key(type), id: value})
       end
       linkage
     end
@@ -289,6 +291,20 @@ module JSONAPI
         value.map { |value| IdValueFormatter.format(value) }
       elsif association.is_a?(JSONAPI::Association::HasOne)
         IdValueFormatter.format(value)
+      end
+    end
+
+    def foreign_key_types_and_values(source, association)
+      if association.is_a?(JSONAPI::Association::HasMany)
+        if association.polymorphic?
+          source.model.send(association.name).pluck(:type, :id).map do |type, id|
+            [type.pluralize, IdValueFormatter.format(id)]
+          end
+        else
+          source.send(association.foreign_key).map do |value|
+            [association.type, IdValueFormatter.format(value)]
+          end
+        end
       end
     end
 

--- a/lib/jsonapi/routing_ext.rb
+++ b/lib/jsonapi/routing_ext.rb
@@ -164,9 +164,13 @@ module ActionDispatch
           association = source._associations[association_name]
 
           formatted_association_name = format_route(association.name)
-          related_resource = JSONAPI::Resource.resource_for(resource_type_with_module_prefix(association.class_name.underscore.pluralize))
-          options[:controller] ||= related_resource._type.to_s
 
+          if association.polymorphic?
+            options[:controller] ||= association.class_name.underscore.pluralize
+          else
+            related_resource = JSONAPI::Resource.resource_for(resource_type_with_module_prefix(association.class_name.underscore.pluralize))
+            options[:controller] ||= related_resource._type.to_s
+          end
 
           match "#{formatted_association_name}", controller: options[:controller],
                 association: association.name, source: resource_type_with_module_prefix(source._type),

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -1917,7 +1917,13 @@ class PeopleControllerTest < ActionController::TestCase
                "related" => "http://test.host/people/1/hair_cut"
              },
              "data" => nil
-            }
+           },
+           vehicles: {
+             links: {
+               self: "http://test.host/people/1/relationships/vehicles",
+               related: "http://test.host/people/1/vehicles"
+             }
+           }
          }
         }
       },

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -167,6 +167,23 @@ ActiveRecord::Schema.define do
     t.string :name
     t.string :status, limit: 10
   end
+
+  create_table :pictures, force: true do |t|
+    t.string  :name
+    t.integer :imageable_id
+    t.string  :imageable_type
+    t.timestamps null: false
+  end
+
+  create_table :documents, force: true do |t|
+    t.string  :name
+    t.timestamps null: false
+  end
+
+  create_table :products, force: true do |t|
+    t.string  :name
+    t.timestamps null: false
+  end
 end
 
 ### MODELS
@@ -343,6 +360,18 @@ end
 class Category < ActiveRecord::Base
 end
 
+class Picture < ActiveRecord::Base
+  belongs_to :imageable, polymorphic: true
+end
+
+class Document < ActiveRecord::Base
+  has_many :pictures, as: :imageable
+end
+
+class Product < ActiveRecord::Base
+  has_one :picture, as: :imageable
+end
+
 ### PORO Data - don't do this in a production app
 $breed_data = BreedData.new
 $breed_data.add(Breed.new(0, 'persian'))
@@ -391,6 +420,18 @@ class FactsController < JSONAPI::ResourceController
 end
 
 class CategoriesController < JSONAPI::ResourceController
+end
+
+class PicturesController < JSONAPI::ResourceController
+end
+
+class DocumentsController < JSONAPI::ResourceController
+end
+
+class ProductsController < JSONAPI::ResourceController
+end
+
+class ImageablesController < JSONAPI::ResourceController
 end
 
 ### CONTROLLERS
@@ -762,6 +803,32 @@ end
 
 class CategoryResource < JSONAPI::Resource
   filter :status, default: 'active'
+end
+
+class PictureResource < JSONAPI::Resource
+  attribute :name
+  has_one :imageable, polymorphic: true
+
+  def imageable_type=(type)
+    model.imageable_type = type
+  end
+end
+
+class DocumentResource < JSONAPI::Resource
+  attribute :name
+  has_many :pictures
+end
+
+class ProductResource < JSONAPI::Resource
+  attribute :name
+  has_one :picture
+
+  def picture_id
+    model.picture.id
+  end
+end
+
+class ImageableResource < JSONAPI::Resource
 end
 
 module Api

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -184,6 +184,11 @@ ActiveRecord::Schema.define do
     t.string  :name
     t.timestamps null: false
   end
+
+  create_table :vehicles, force: true do |t|
+    t.string :type
+    t.integer :person_id
+  end
 end
 
 ### MODELS
@@ -191,6 +196,7 @@ class Person < ActiveRecord::Base
   has_many :posts, foreign_key: 'author_id'
   has_many :comments, foreign_key: 'author_id'
   has_many :expense_entries, foreign_key: 'employee_id', dependent: :restrict_with_exception
+  has_many :vehicles
   belongs_to :preferences
   belongs_to :hair_cut
 
@@ -362,6 +368,16 @@ end
 
 class Picture < ActiveRecord::Base
   belongs_to :imageable, polymorphic: true
+end
+
+class Vehicle < ActiveRecord::Base
+  belongs_to :person
+end
+
+class Car < Vehicle
+end
+
+class Boat < Vehicle
 end
 
 class Document < ActiveRecord::Base
@@ -566,6 +582,7 @@ class PersonResource < JSONAPI::Resource
 
   has_many :comments
   has_many :posts
+  has_many :vehicles, polymorphic: true
 
   has_one :preferences
   has_one :hair_cut
@@ -583,6 +600,16 @@ class PersonResource < JSONAPI::Resource
     end
     return filter, values
   end
+end
+
+class VehicleResource < JSONAPI::Resource
+  has_one :person
+end
+
+class CarResource < VehicleResource
+end
+
+class BoatResource < VehicleResource
 end
 
 class CommentResource < JSONAPI::Resource
@@ -876,6 +903,9 @@ module Api
     EmployeeResource = EmployeeResource.dup
     FriendResource = FriendResource.dup
     HairCutResource = HairCutResource.dup
+    VehicleResource = VehicleResource.dup
+    CarResource = CarResource.dup
+    BoatResource = BoatResource.dup
   end
 end
 

--- a/test/fixtures/documents.yml
+++ b/test/fixtures/documents.yml
@@ -1,0 +1,3 @@
+document_1:
+  id: 1
+  name: Company Brochure

--- a/test/fixtures/pictures.yml
+++ b/test/fixtures/pictures.yml
@@ -1,0 +1,15 @@
+picture_1:
+  id: 1
+  name: enterprise_gizmo.jpg
+  imageable_id: 1
+  imageable_type: Product
+
+picture_2:
+  id: 2
+  name: company_brochure.jpg
+  imageable_id: 1
+  imageable_type: Document
+
+picture_3:
+  id: 3
+  name: group_photo.jpg

--- a/test/fixtures/products.yml
+++ b/test/fixtures/products.yml
@@ -1,0 +1,3 @@
+product_1:
+  id: 1
+  name: Enterprise Gizmo

--- a/test/fixtures/vehicles.yml
+++ b/test/fixtures/vehicles.yml
@@ -1,0 +1,8 @@
+car:
+  id: 1
+  type: Car
+  person_id: 1
+boat:
+  id: 2
+  type: Boat
+  person_id: 1

--- a/test/integration/routes/routes_test.rb
+++ b/test/integration/routes/routes_test.rb
@@ -52,6 +52,53 @@ class RoutesTest < ActionDispatch::IntegrationTest
                    {controller: 'posts', action: 'update_association', post_id: '1', association: 'tags'})
   end
 
+  # Polymorphic
+  def test_routing_polymorphic_get_related_resource
+    assert_routing(
+      {
+        path: '/pictures/1/imageable',
+        method: :get
+      },
+      {
+        association: 'imageable',
+        source: 'pictures',
+        controller: 'imageables',
+        action: 'get_related_resource',
+        picture_id: '1'
+      }
+    )
+  end
+
+  def test_routing_polymorphic_patch_related_resource
+    assert_routing(
+      {
+        path: '/pictures/1/relationships/imageable',
+        method: :patch
+      },
+      {
+        association: 'imageable',
+        controller: 'pictures',
+        action: 'update_association',
+        picture_id: '1'
+      }
+    )
+  end
+
+  def test_routing_polymorphic_delete_related_resource
+    assert_routing(
+      {
+        path: '/pictures/1/relationships/imageable',
+        method: :delete
+      },
+      {
+        association: 'imageable',
+        controller: 'pictures',
+        action: 'destroy_association',
+        picture_id: '1'
+      }
+    )
+  end
+
   # V1
   def test_routing_v1_posts_show
     assert_routing({path: '/api/v1/posts/1', method: :get},

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -89,6 +89,9 @@ TestApp.routes.draw do
   jsonapi_resources :preferences
   jsonapi_resources :facts
   jsonapi_resources :categories
+  jsonapi_resources :pictures
+  jsonapi_resources :documents
+  jsonapi_resources :products
 
   namespace :api do
     namespace :v1 do

--- a/test/unit/serializer/polymorphic_serializer_test.rb
+++ b/test/unit/serializer/polymorphic_serializer_test.rb
@@ -1,0 +1,249 @@
+require File.expand_path('../../../test_helper', __FILE__)
+require 'jsonapi-resources'
+require 'json'
+
+class PolymorphismTest < ActionDispatch::IntegrationTest
+  def setup
+    @pictures = Picture.all
+
+    JSONAPI.configuration.json_key_format = :camelized_key
+    JSONAPI.configuration.route_format = :camelized_route
+  end
+
+  def after_teardown
+    JSONAPI.configuration.json_key_format = :underscored_key
+  end
+
+  def test_polymorphic_association
+    associations = PictureResource._associations
+    imageable = associations[:imageable]
+
+    assert_equal associations.size, 1
+    assert imageable.polymorphic?
+  end
+
+  def test_polymorphic_serialization
+    serialized_data = JSONAPI::ResourceSerializer.new(
+      PictureResource,
+      include: %w(imageable)
+    ).serialize_to_hash(@pictures.map { |p| PictureResource.new p })
+
+    assert_hash_equals(
+      {
+        data: [
+          {
+            id: '1',
+            type: 'pictures',
+            links: {
+              self: '/pictures/1'
+            },
+            attributes: {
+              name: 'enterprise_gizmo.jpg'
+            },
+            relationships: {
+              imageable: {
+                links: {
+                  self: '/pictures/1/relationships/imageable',
+                  related: '/pictures/1/imageable'
+                },
+                data: {
+                  type: 'products',
+                  id: '1'
+                }
+              }
+            }
+          },
+          {
+            id: '2',
+            type: 'pictures',
+            links: {
+              self: '/pictures/2'
+            },
+            attributes: {
+              name: 'company_brochure.jpg'
+            },
+            relationships: {
+              imageable: {
+                links: {
+                  self: '/pictures/2/relationships/imageable',
+                  related: '/pictures/2/imageable'
+                },
+                data: {
+                  type: 'documents',
+                  id: '1'
+                }
+              }
+            }
+          },
+          {
+            id: '3',
+            type: 'pictures',
+            links: {
+              self: '/pictures/3'
+            },
+            attributes: {
+              name: 'group_photo.jpg'
+            },
+            relationships: {
+              imageable: {
+                links: {
+                  self: '/pictures/3/relationships/imageable',
+                  related: '/pictures/3/imageable'
+                },
+                data: nil
+              }
+            }
+          }
+
+        ],
+        :included => [
+          {
+            id: '1',
+            type: 'products',
+            links: {
+              self: '/products/1'
+            },
+            attributes: {
+              name: 'Enterprise Gizmo'
+            },
+            relationships: {
+              picture: {
+                links: {
+                  self: '/products/1/relationships/picture',
+                  related: '/products/1/picture',
+                },
+                data: {
+                  type: 'pictures',
+                  id: '1'
+                }
+              }
+            }
+          },
+          {
+            id: '1',
+            type: 'documents',
+            links: {
+              self: '/documents/1'
+            },
+            attributes: {
+              name: 'Company Brochure'
+            },
+            relationships: {
+              pictures: {
+                links: {
+                  self: '/documents/1/relationships/pictures',
+                  related: '/documents/1/pictures'
+                }
+              }
+            }
+          }
+        ]
+      },
+      serialized_data
+    )
+  end
+
+  def test_polymorphic_get_related_resource
+    get '/pictures/1/imageable'
+    serialized_data = JSON.parse(response.body)
+      assert_hash_equals(
+      {
+        data: {
+          id: '1',
+          type: 'products',
+          links: {
+            self: 'http://www.example.com/products/1'
+          },
+          attributes: {
+            name: 'Enterprise Gizmo'
+          },
+          relationships: {
+            picture: {
+              links: {
+                self: 'http://www.example.com/products/1/relationships/picture',
+                related: 'http://www.example.com/products/1/picture'
+              },
+              data: {
+                type: 'pictures',
+                id: '1'
+              }
+            }
+          }
+        }
+      },
+      serialized_data
+    )
+  end
+
+
+  def test_polymorphic_create_relationship
+    picture = Picture.find(3)
+    original_imageable = picture.imageable
+    assert_nil original_imageable
+
+    patch "/pictures/#{picture.id}/relationships/imageable",
+          {
+            association: 'imageable',
+            data: {
+              type: 'documents',
+              id: '1'
+            }
+          }.to_json,
+          {
+            'Content-Type' => JSONAPI::MEDIA_TYPE
+          }
+    assert_response :no_content
+    picture = Picture.find(3)
+    assert_equal 'Document', picture.imageable.class.to_s
+
+    # restore data
+    picture.imageable = original_imageable
+    picture.save
+  end
+
+  def test_polymorphic_update_relationship
+    picture = Picture.find(1)
+    original_imageable = picture.imageable
+    assert_not_equal 'Document', picture.imageable.class.to_s
+
+    patch "/pictures/#{picture.id}/relationships/imageable",
+          {
+            association: 'imageable',
+            data: {
+              type: 'documents',
+              id: '1'
+            }
+          }.to_json,
+          {
+            'Content-Type' => JSONAPI::MEDIA_TYPE
+          }
+    assert_response :no_content
+    picture = Picture.find(1)
+    assert_equal 'Document', picture.imageable.class.to_s
+
+    # restore data
+    picture.imageable = original_imageable
+    picture.save
+  end
+
+  def test_polymorphic_delete_relationship
+    picture = Picture.find(1)
+    original_imageable = picture.imageable
+    assert original_imageable
+
+    delete "/pictures/#{picture.id}/relationships/imageable",
+           {
+             association: 'imageable'
+           }.to_json,
+           {
+             'Content-Type' => JSONAPI::MEDIA_TYPE
+           }
+    assert_response :no_content
+    picture = Picture.find(1)
+    assert_nil picture.imageable
+
+    # restore data
+    picture.imageable = original_imageable
+    picture.save
+  end
+end

--- a/test/unit/serializer/polymorphic_serializer_test.rb
+++ b/test/unit/serializer/polymorphic_serializer_test.rb
@@ -175,6 +175,34 @@ class PolymorphismTest < ActionDispatch::IntegrationTest
     )
   end
 
+  def test_create_resource_with_polymorphic_relationship
+    document = Document.find(1)
+    post "/pictures/",
+      {
+        data: {
+          type: "pictures",
+          attributes: {
+            name: "hello.jpg"
+          },
+          relationships: {
+            imageable: {
+              data: {
+                type: "documents",
+                id: document.id.to_s
+              }
+            }
+          }
+        }
+      }.to_json,
+      {
+        'Content-Type' => JSONAPI::MEDIA_TYPE
+      }
+    assert_equal response.status, 201
+    picture = Picture.find(json_response["data"]["id"])
+    assert_not_nil picture.imageable, "imageable should be present"
+  ensure
+    picture.destroy
+  end
 
   def test_polymorphic_create_relationship
     picture = Picture.find(3)

--- a/test/unit/serializer/serializer_test.rb
+++ b/test/unit/serializer/serializer_test.rb
@@ -254,6 +254,12 @@ class SerializerTest < ActionDispatch::IntegrationTest
                  related: "/people/1/hairCut"
                },
                data: nil
+             },
+             vehicles: {
+               links: {
+                 self: "/people/1/relationships/vehicles",
+                 related: "/people/1/vehicles"
+               }
              }
             }
           }
@@ -356,6 +362,12 @@ class SerializerTest < ActionDispatch::IntegrationTest
                   related: '/people/1/hairCut'
                 },
                 data: nil
+              },
+              vehicles: {
+                links: {
+                  self: "/people/1/relationships/vehicles",
+                  related: "/people/1/vehicles"
+                }
               }
             }
           }
@@ -611,7 +623,13 @@ class SerializerTest < ActionDispatch::IntegrationTest
                 related: "/people/2/hairCut"
               },
               data: nil
-            }
+            },
+            vehicles: {
+              links: {
+                self: "/people/2/relationships/vehicles",
+                related: "/people/2/vehicles"
+              }
+            },
           }
         },
         included: [


### PR DESCRIPTION
This simply adds to PR https://github.com/cerebris/jsonapi-resources/pull/255 from @ggordon. I added support for creating resources with a polymorphic `has_one`. I don't like the code, but I wanted to change as little as possible for now since I need this feature ASAP. We should refactor to handle the creation of all `has_one` relationships the same way (whether or not they're polymorphic), but I think that we can merge prior to that since we'll have good test coverage and the public API feels right.
