### PR TITLE
relation_name: choose the relation based on the context

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,9 @@ The association methods support the following options:
  * `foreign_key` - the method on the resource used to fetch the related resource. Defaults to `<resource_name>_id` for 
     has_one and `<resource_name>_ids` for has_many relationships.
  * `acts_as_set` - allows the entire set of related records to be replaced in one operation. Defaults to false if not set.
-
+ * `relation_name` - the name of the relation to use on the model. A lambda may be provided which allows conditional 
+    selection of the relation based on the context.
+    
 Examples:
 
 ```ruby
@@ -261,6 +263,24 @@ class ExpenseEntryResource < JSONAPI::Resource
 
   has_one :currency, class_name: 'Currency', foreign_key: 'currency_code'
   has_one :employee
+end
+```
+
+```ruby
+class BookResource < JSONAPI::Resource
+
+  # Only book_admins may see unapproved comments for a book. Using a lambda to select the correct relation on the model
+  has_many :book_comments, relation_name: -> (options = {}) {
+    context = options[:context]
+    current_user = context ? context[:current_user] : nil
+
+    unless current_user && current_user.book_admin
+      :approved_book_comments
+    else
+      :book_comments
+    end
+  }
+  ...
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -269,7 +269,8 @@ end
 ```ruby
 class BookResource < JSONAPI::Resource
 
-  # Only book_admins may see unapproved comments for a book. Using a lambda to select the correct relation on the model
+  # Only book_admins may see unapproved comments for a book. Using 
+  # a lambda to select the correct relation on the model
   has_many :book_comments, relation_name: -> (options = {}) {
     context = options[:context]
     current_user = context ? context[:current_user] : nil

--- a/lib/jsonapi/acts_as_resource_controller.rb
+++ b/lib/jsonapi/acts_as_resource_controller.rb
@@ -6,7 +6,7 @@ module JSONAPI
 
     included do
       before_filter :ensure_correct_media_type, only: [:create, :update, :create_association, :update_association]
-      before_filter :setup_request
+      append_before_filter :setup_request
       after_filter :setup_response
     end
 

--- a/lib/jsonapi/association.rb
+++ b/lib/jsonapi/association.rb
@@ -33,7 +33,7 @@ module JSONAPI
     class HasOne < Association
       def initialize(name, options={})
         super
-        @class_name = options.fetch(:class_name, name.to_s.capitalize)
+        @class_name = options.fetch(:class_name, name.to_s.camelize)
         @type = class_name.underscore.pluralize.to_sym
         @foreign_key ||= @key.nil? ? "#{name}_id".to_sym : @key
       end
@@ -42,7 +42,7 @@ module JSONAPI
     class HasMany < Association
       def initialize(name, options={})
         super
-        @class_name = options.fetch(:class_name, name.to_s.capitalize.singularize)
+        @class_name = options.fetch(:class_name, name.to_s.camelize.singularize)
         @type = class_name.underscore.pluralize.to_sym
         @foreign_key  ||= @key.nil? ? "#{name.to_s.singularize}_ids".to_sym : @key
       end

--- a/lib/jsonapi/association.rb
+++ b/lib/jsonapi/association.rb
@@ -7,11 +7,15 @@ module JSONAPI
       @options             = options
       @acts_as_set         = options.fetch(:acts_as_set, false) == true
       @foreign_key         = options[:foreign_key ] ? options[:foreign_key ].to_sym : nil
-      @module_path         = options[:module_path] || ''
+      @module_path         = options.fetch(:module_path, '')
     end
 
     def primary_key
-      @primary_key ||= Resource.resource_for(@module_path + @name)._primary_key
+      @primary_key ||= resource_klass._primary_key
+    end
+
+    def resource_klass
+      @resource_klass ||= Resource.resource_for(@module_path + @class_name)
     end
 
     class HasOne < Association

--- a/lib/jsonapi/association.rb
+++ b/lib/jsonapi/association.rb
@@ -8,6 +8,7 @@ module JSONAPI
       @acts_as_set         = options.fetch(:acts_as_set, false) == true
       @foreign_key         = options[:foreign_key ] ? options[:foreign_key ].to_sym : nil
       @module_path         = options.fetch(:module_path, '')
+      @relation_name       = options.fetch(:relation_name, @name)
     end
 
     def primary_key
@@ -16,6 +17,17 @@ module JSONAPI
 
     def resource_klass
       @resource_klass ||= Resource.resource_for(@module_path + @class_name)
+    end
+
+    def relation_name(options = {})
+      case @relation_name
+        when Symbol
+          @relation_name
+        when String
+          @relation_name.to_sym
+        when Proc
+          @relation_name.call(options)
+      end
     end
 
     class HasOne < Association

--- a/lib/jsonapi/association.rb
+++ b/lib/jsonapi/association.rb
@@ -22,7 +22,9 @@ module JSONAPI
     def relation_name(options = {})
       case @relation_name
         when Symbol
+          # :nocov:
           @relation_name
+          # :nocov:
         when String
           @relation_name.to_sym
         when Proc

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -432,7 +432,7 @@ module JSONAPI
         end
 
         if required_includes.any?
-          records = apply_includes(records, include_directives: IncludeDirectives.new(required_includes), options: options)
+          records = apply_includes(records, options.merge(include_directives: IncludeDirectives.new(required_includes)))
         end
 
         records

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -641,7 +641,7 @@ module JSONAPI
           end unless method_defined?(associated_records_method_name)
 
           if @_associations[attr].is_a?(JSONAPI::Association::HasOne)
-            define_method attr do
+            define_method attr do |options = {}|
               resource_klass = self.class._associations[attr].resource_klass
               if resource_klass
                 associated_model = public_send(associated_records_method_name)

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -555,7 +555,7 @@ module JSONAPI
       def _resource_name_from_type(type)
         class_name = @@resource_types[type]
         if class_name.nil?
-          class_name = "#{type.to_s.singularize}_resource".camelize
+          class_name = "#{type.to_s.underscore.singularize}_resource".camelize
           @@resource_types[type] = class_name
         end
         return class_name

--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -21,7 +21,6 @@ module JSONAPI
       @include_directives = options[:include_directives]
       @key_formatter = options.fetch(:key_formatter, JSONAPI.configuration.key_formatter)
       @route_formatter = options.fetch(:route_formatter, JSONAPI.configuration.route_formatter)
-      # @paginator = options[:paginator]
       @base_url = options.fetch(:base_url, '')
     end
 

--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -21,6 +21,7 @@ module JSONAPI
       @include_directives = options[:include_directives]
       @key_formatter = options.fetch(:key_formatter, JSONAPI.configuration.key_formatter)
       @route_formatter = options.fetch(:route_formatter, JSONAPI.configuration.route_formatter)
+      # @paginator = options[:paginator]
       @base_url = options.fetch(:base_url, '')
     end
 

--- a/lib/jsonapi/response_document.rb
+++ b/lib/jsonapi/response_document.rb
@@ -50,7 +50,7 @@ module JSONAPI
       @operation_results.results.each do |result|
         meta.merge!(result.meta)
 
-        if JSONAPI.configuration.top_level_meta_include_record_count
+        if JSONAPI.configuration.top_level_meta_include_record_count && result.respond_to?(:record_count)
           meta[JSONAPI.configuration.top_level_meta_record_count_key] = result.record_count
         end
       end

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -2449,35 +2449,26 @@ class Api::V2::BooksControllerTest < ActionController::TestCase
     $test_user = Person.find(5)
     Api::V2::BookResource.paginator :none
 
-    count_queries do
-      get :index, {filter: {id: '0,1,2,3,4'}, include: 'book-comments'}
-    end
+    get :index, {filter: {id: '0,1,2,3,4'}, include: 'book-comments'}
     assert_response :success
     assert_equal 5, json_response['data'].size
     assert_equal 'Book 0', json_response['data'][0]['attributes']['title']
     assert_equal 255, json_response['included'].size
     assert_equal 51, json_response['data'][0]['relationships']['book-comments']['data'].size
-    assert_query_count(2)
   end
 
   def test_books_filter_by_book_comment_id_limited_user
     $test_user = Person.find(1)
-    count_queries do
-      get :index, {filter: {book_comments: '0,52' }}
-    end
+    get :index, {filter: {book_comments: '0,52' }}
     assert_response :success
     assert_equal 1, json_response['data'].size
-    assert_query_count(1)
   end
 
   def test_books_filter_by_book_comment_id_admin_user
     $test_user = Person.find(5)
-    count_queries do
-      get :index, {filter: {book_comments: '0,52' }}
-    end
+    get :index, {filter: {book_comments: '0,52' }}
     assert_response :success
     assert_equal 2, json_response['data'].size
-    assert_query_count(1)
   end
 end
 

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -114,7 +114,10 @@ class PostsControllerTest < ActionController::TestCase
   end
 
   def test_filter_association_single
-    get :index, {filter: {tags: '5,1'}}
+    count_queries do
+      get :index, {filter: {tags: '5,1'}}
+    end
+    assert_query_count(1)
     assert_response :success
     assert_equal 3, json_response['data'].size
     assert_match /New post/, response.body
@@ -123,7 +126,10 @@ class PostsControllerTest < ActionController::TestCase
   end
 
   def test_filter_associations_multiple
-    get :index, {filter: {tags: '5,1', comments: '3'}}
+    count_queries do
+      get :index, {filter: {tags: '5,1', comments: '3'}}
+    end
+    assert_query_count(1)
     assert_response :success
     assert_equal 1, json_response['data'].size
     assert_match /JR Solves your serialization woes!/, response.body
@@ -2452,6 +2458,26 @@ class Api::V2::BooksControllerTest < ActionController::TestCase
     assert_equal 255, json_response['included'].size
     assert_equal 51, json_response['data'][0]['relationships']['book-comments']['data'].size
     assert_query_count(2)
+  end
+
+  def test_books_filter_by_book_comment_id_limited_user
+    $test_user = Person.find(1)
+    count_queries do
+      get :index, {filter: {book_comments: '0,52' }}
+    end
+    assert_response :success
+    assert_equal 1, json_response['data'].size
+    assert_query_count(1)
+  end
+
+  def test_books_filter_by_book_comment_id_admin_user
+    $test_user = Person.find(5)
+    count_queries do
+      get :index, {filter: {book_comments: '0,52' }}
+    end
+    assert_response :success
+    assert_equal 2, json_response['data'].size
+    assert_query_count(1)
   end
 end
 

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -54,19 +54,19 @@ class PostsControllerTest < ActionController::TestCase
   end
 
   def test_index_include_one_level_query_count
-    query_count = count_queries do
+    count_queries do
       get :index, {include: 'author'}
     end
     assert_response :success
-    assert_equal 2, query_count
+    assert_query_count(2)
   end
 
   def test_index_include_two_levels_query_count
-    query_count = count_queries do
+    count_queries do
       get :index, {include: 'author,author.comments'}
     end
     assert_response :success
-    assert_equal 3, query_count
+    assert_query_count(3)
   end
 
   def test_index_filter_by_ids_and_fields
@@ -2179,25 +2179,25 @@ class Api::V2::BooksControllerTest < ActionController::TestCase
   def test_books_offset_pagination_no_params_includes_query_count_one_level
     Api::V2::BookResource.paginator :offset
 
-    query_count = count_queries do
+    count_queries do
       get :index, {include: 'book-comments'}
     end
     assert_response :success
     assert_equal 10, json_response['data'].size
     assert_equal 'Book 0', json_response['data'][0]['attributes']['title']
-    assert_equal 3, query_count
+    assert_query_count(3)
   end
 
   def test_books_offset_pagination_no_params_includes_query_count_two_levels
     Api::V2::BookResource.paginator :offset
 
-    query_count = count_queries do
+    count_queries do
       get :index, {include: 'book-comments,book-comments.author'}
     end
     assert_response :success
     assert_equal 10, json_response['data'].size
     assert_equal 'Book 0', json_response['data'][0]['attributes']['title']
-    assert_equal 4, query_count
+    assert_query_count(4)
   end
 
   def test_books_offset_pagination
@@ -2320,19 +2320,19 @@ class Api::V2::BooksControllerTest < ActionController::TestCase
   def test_books_included_paged
     Api::V2::BookResource.paginator :offset
 
-    query_count = count_queries do
+    count_queries do
       get :index, {filter: {id: '0'}, include: 'book-comments'}
     end
     assert_response :success
     assert_equal 1, json_response['data'].size
     assert_equal 'Book 0', json_response['data'][0]['attributes']['title']
-    assert_equal 3, query_count
+    assert_query_count(3)
   end
 
   def test_books_banned_non_book_admin
     $test_user = Person.find(1)
     Api::V2::BookResource.paginator :offset
-    query_count = count_queries do
+    count_queries do
       JSONAPI.configuration.top_level_meta_include_record_count = true
       get :index, {page: {offset: 50, limit: 12}}
       JSONAPI.configuration.top_level_meta_include_record_count = false
@@ -2341,6 +2341,7 @@ class Api::V2::BooksControllerTest < ActionController::TestCase
     assert_equal 12, json_response['data'].size
     assert_equal 'Book 50', json_response['data'][0]['attributes']['title']
     assert_equal 901, json_response['meta']['record-count']
+    assert_query_count(4)
   end
 
   def test_books_banned_admin
@@ -2360,7 +2361,7 @@ class Api::V2::BooksControllerTest < ActionController::TestCase
   def test_books_not_banned_admin
     $test_user = Person.find(5)
     Api::V2::BookResource.paginator :offset
-    query_count = count_queries do
+    count_queries do
       JSONAPI.configuration.top_level_meta_include_record_count = true
       get :index, {page: {offset: 50, limit: 12}, filter: {banned: 'false'}}
       JSONAPI.configuration.top_level_meta_include_record_count = false
@@ -2369,12 +2370,13 @@ class Api::V2::BooksControllerTest < ActionController::TestCase
     assert_equal 12, json_response['data'].size
     assert_equal 'Book 50', json_response['data'][0]['attributes']['title']
     assert_equal 901, json_response['meta']['record-count']
+    assert_query_count(2)
   end
 
   def test_books_banned_non_book_admin
     $test_user = Person.find(1)
     Api::V2::BookResource.paginator :offset
-    query_count = count_queries do
+    count_queries do
       JSONAPI.configuration.top_level_meta_include_record_count = true
       get :index, {page: {offset: 590, limit: 20}}
       JSONAPI.configuration.top_level_meta_include_record_count = false
@@ -2383,13 +2385,14 @@ class Api::V2::BooksControllerTest < ActionController::TestCase
     assert_equal 20, json_response['data'].size
     assert_equal 'Book 590', json_response['data'][0]['attributes']['title']
     assert_equal 901, json_response['meta']['record-count']
+    assert_query_count(2)
   end
 
   def test_books_included_exclude_unapproved
     $test_user = Person.find(1)
     Api::V2::BookResource.paginator :none
 
-    query_count = count_queries do
+    count_queries do
       get :index, {filter: {id: '0,1,2,3,4'}, include: 'book-comments'}
     end
     assert_response :success
@@ -2397,7 +2400,7 @@ class Api::V2::BooksControllerTest < ActionController::TestCase
     assert_equal 'Book 0', json_response['data'][0]['attributes']['title']
     assert_equal 130, json_response['included'].size
     assert_equal 26, json_response['data'][0]['relationships']['book-comments']['data'].size
-    assert_equal 3, query_count
+    assert_query_count(3)
   end
 end
 
@@ -2409,12 +2412,12 @@ class Api::V2::BookCommentsControllerTest < ActionController::TestCase
 
   def test_book_comments_exclude_unapproved
     $test_user = Person.find(1)
-    query_count = count_queries do
+    count_queries do
       get :index
     end
     assert_response :success
     assert_equal 130, json_response['data'].size
-    assert_equal 1, query_count
+    assert_query_count(1)
   end
 end
 

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -803,7 +803,6 @@ module Api
       filters :writer
     end
 
-    # AuthorResource = AuthorResource.dup
     PersonResource = PersonResource.dup
     CommentResource = CommentResource.dup
     TagResource = TagResource.dup
@@ -824,7 +823,6 @@ end
 module Api
   module V2
     PreferencesResource = PreferencesResource.dup
-    # AuthorResource = AuthorResource.dup
     PersonResource = PersonResource.dup
     PostResource = PostResource.dup
 

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -841,7 +841,6 @@ module Api
           :book_comments
         end
       }
-      has_many :approved_book_comments, class_name: "BookComments"
 
       filters :banned
 
@@ -911,7 +910,9 @@ module Api
                 records.where(approved_comments(value[0] == 'true'))
               end
             else
+              #:nocov:
               return super(records, filter, value)
+            #:nocov:
           end
         end
 

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -842,7 +842,7 @@ module Api
         end
       }
 
-      filters :banned
+      filters :banned, :book_comments
 
       class << self
         def apply_filter(records, filter, value, options)

--- a/test/fixtures/book_comments.yml
+++ b/test/fixtures/book_comments.yml
@@ -6,6 +6,7 @@ book_<%= book_num %>_comment_<%= comment_num %>:
   body: This is comment <%= comment_num %> on book <%= book_num %>.
   author_id: 1
   book_id: <%= book_num %>
+  approved: <%= comment_num.even? %>
   <% comment_id = comment_id + 1 %>
   <% end %>
 <% end %>

--- a/test/fixtures/book_comments.yml
+++ b/test/fixtures/book_comments.yml
@@ -4,7 +4,7 @@
 book_<%= book_num %>_comment_<%= comment_num %>:
   id: <%= comment_id %>
   body: This is comment <%= comment_num %> on book <%= book_num %>.
-  author_id: 1
+  author_id: <%= book_num.even? ? comment_id % 2 : (comment_id % 2) + 2 %>
   book_id: <%= book_num %>
   approved: <%= comment_num.even? %>
   <% comment_id = comment_id + 1 %>

--- a/test/fixtures/books.yml
+++ b/test/fixtures/books.yml
@@ -3,4 +3,5 @@ book_<%= book_num %>:
   id: <%= book_num %>
   title: Book <%= book_num %>
   isbn: 12345-<%= book_num %>-6789
+  banned: <%= book_num > 600 && book_num < 700 %>
 <% end %>

--- a/test/fixtures/people.yml
+++ b/test/fixtures/people.yml
@@ -22,3 +22,10 @@ d:
   name: Tag Crazy Author
   email: taggy@xyz.fake
   date_joined: <%= DateTime.parse('2013-11-30 4:20:00 UTC +00:00') %>
+
+e:
+  id: 5
+  name: Wilma Librarian
+  email: lib@xyz.fake
+  date_joined: <%= DateTime.parse('2013-11-30 4:20:00 UTC +00:00') %>
+  book_admin: true

--- a/test/helpers/assertions.rb
+++ b/test/helpers/assertions.rb
@@ -1,8 +1,13 @@
 module Helpers
-  module HashHelpers
+  module Assertions
     def assert_hash_equals(exp, act, msg = nil)
       msg = message(msg, '') { diff exp, act }
       assert(matches_hash?(exp, act, {exact: true}), msg)
+    end
+
+    def assert_array_equals(exp, act, msg = nil)
+      msg = message(msg, '') { diff exp, act }
+      assert(matches_array?(exp, act, {exact: true}), msg)
     end
   end
 end

--- a/test/integration/requests/request_test.rb
+++ b/test/integration/requests/request_test.rb
@@ -4,6 +4,7 @@ class RequestTest < ActionDispatch::IntegrationTest
   def setup
     JSONAPI.configuration.json_key_format = :underscored_key
     JSONAPI.configuration.route_format = :underscored_route
+    $test_user = Person.find(1)
   end
 
   def after_teardown
@@ -337,7 +338,7 @@ class RequestTest < ActionDispatch::IntegrationTest
     Api::V2::BookResource.paginator :none
     get '/api/v2/books'
     assert_equal 200, status
-    assert_equal 1000, json_response['data'].size
+    assert_equal 901, json_response['data'].size
   end
 
   def test_pagination_offset_style
@@ -385,7 +386,7 @@ class RequestTest < ActionDispatch::IntegrationTest
     get '/api/v2/books/1/book_comments?page[limit]=10'
     assert_equal 200, status
     assert_equal 10, json_response['data'].size
-    assert_equal 'This is comment 9 on book 1.', json_response['data'][9]['attributes']['body']
+    assert_equal 'This is comment 18 on book 1.', json_response['data'][9]['attributes']['body']
   end
 
   def test_pagination_related_resources_data_includes
@@ -394,7 +395,7 @@ class RequestTest < ActionDispatch::IntegrationTest
     get '/api/v2/books/1/book_comments?page[limit]=10&include=author,book'
     assert_equal 200, status
     assert_equal 10, json_response['data'].size
-    assert_equal 'This is comment 9 on book 1.', json_response['data'][9]['attributes']['body']
+    assert_equal 'This is comment 18 on book 1.', json_response['data'][9]['attributes']['body']
   end
 
   def test_flow_self

--- a/test/integration/requests/request_test.rb
+++ b/test/integration/requests/request_test.rb
@@ -398,6 +398,16 @@ class RequestTest < ActionDispatch::IntegrationTest
     assert_equal 'This is comment 18 on book 1.', json_response['data'][9]['attributes']['body']
   end
 
+  # def test_pagination_related_resources_data_includes
+  #   Api::V2::BookResource.paginator :none
+  #   Api::V2::BookCommentResource.paginator :none
+  #   get '/api/v2/books?filter[]'
+  #   assert_equal 200, status
+  #   assert_equal 10, json_response['data'].size
+  #   assert_equal 'This is comment 18 on book 1.', json_response['data'][9]['attributes']['body']
+  # end
+
+
   def test_flow_self
     get '/posts'
     assert_equal 200, status

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,7 +15,7 @@ require 'rails/test_help'
 require 'jsonapi-resources'
 
 require File.expand_path('../helpers/value_matchers', __FILE__)
-require File.expand_path('../helpers/hash_helpers', __FILE__)
+require File.expand_path('../helpers/assertions', __FILE__)
 require File.expand_path('../helpers/functional_helpers', __FILE__)
 
 Rails.env = 'test'
@@ -200,7 +200,7 @@ end
 Minitest::Test = MiniTest::Unit::TestCase unless defined?(Minitest::Test)
 
 class Minitest::Test
-  include Helpers::HashHelpers
+  include Helpers::Assertions
   include Helpers::ValueMatchers
   include Helpers::FunctionalHelpers
 end

--- a/test/unit/serializer/include_directives_test.rb
+++ b/test/unit/serializer/include_directives_test.rb
@@ -105,4 +105,9 @@ class IncludeDirectivesTest < ActiveSupport::TestCase
       },
       directives)
   end
+
+  def test_three_levels_include_full_model_includes
+    directives = JSONAPI::IncludeDirectives.new(['posts.comments.tags'])
+    assert_array_equals([{:posts=>[{:comments=>[:tags]}]}], directives.model_includes)
+  end
 end


### PR DESCRIPTION
Adds `relation_name` to associations to allow conditional use of the correct relation on the model for an association.

Fixed some issues where retrieving the related ids were not eager loading and were not being filtered appropriately.

Expanded query count tests to ensure we are eager loading correctly.
