### PR TITLE
Configure exception class whitelist to be reraised by operations processors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ end
 ```ruby
 class BookResource < JSONAPI::Resource
 
-  # Only book_admins may see unapproved comments for a book. Using 
+  # Only book_admins may see unapproved comments for a book. Using
   # a lambda to select the correct relation on the model
   has_many :book_comments, relation_name: -> (options = {}) {
     context = options[:context]
@@ -1240,6 +1240,14 @@ JSONAPI.configure do |config|
   config.top_level_meta_record_count_key = :record_count
 
   config.use_text_errors = false
+
+  # List of classes that should not be rescued by the operations processor.
+  # For example, if you use Pundit for authorization, you might
+  # raise a Pundit::NotAuthorizedError at some point during operations
+  # processing. If you want to use Rails' `rescue_from` macro to
+  # catch this error and render a 403 status code, you should add
+  # the `Pundit::NotAuthorizedError` to the `exception_class_whitelist`.
+  self.exception_class_whitelist = []
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -1247,7 +1247,7 @@ JSONAPI.configure do |config|
   # processing. If you want to use Rails' `rescue_from` macro to
   # catch this error and render a 403 status code, you should add
   # the `Pundit::NotAuthorizedError` to the `exception_class_whitelist`.
-  self.exception_class_whitelist = []
+  config.exception_class_whitelist = []
 end
 ```
 

--- a/lib/jsonapi/active_record_operations_processor.rb
+++ b/lib/jsonapi/active_record_operations_processor.rb
@@ -29,8 +29,12 @@ class ActiveRecordOperationsProcessor < JSONAPI::OperationsProcessor
     raise e
 
   rescue => e
-    internal_server_error = JSONAPI::Exceptions::InternalServerError.new(e)
-    Rails.logger.error { "Internal Server Error: #{e.message} #{e.backtrace.join("\n")}" }
-    return JSONAPI::ErrorsOperationResult.new(internal_server_error.errors[0].code, internal_server_error.errors)
+    if JSONAPI.configuration.exception_class_whitelist.include?(e.class)
+      raise e
+    else
+      internal_server_error = JSONAPI::Exceptions::InternalServerError.new(e)
+      Rails.logger.error { "Internal Server Error: #{e.message} #{e.backtrace.join("\n")}" }
+      return JSONAPI::ErrorsOperationResult.new(internal_server_error.errors[0].code, internal_server_error.errors)
+    end
   end
 end

--- a/lib/jsonapi/configuration.rb
+++ b/lib/jsonapi/configuration.rb
@@ -16,7 +16,8 @@ module JSONAPI
                 :use_text_errors,
                 :top_level_links_include_pagination,
                 :top_level_meta_include_record_count,
-                :top_level_meta_record_count_key
+                :top_level_meta_record_count_key,
+                :exception_class_whitelist
 
     def initialize
       #:underscored_key, :camelized_key, :dasherized_key, or custom
@@ -45,6 +46,14 @@ module JSONAPI
       self.top_level_meta_record_count_key = :record_count
 
       self.use_text_errors = false
+
+      # List of classes that should not be rescued by the operations processor.
+      # For example, if you use Pundit for authorization, you might
+      # raise a Pundit::NotAuthorizedError at some point during operations
+      # processing. If you want to use Rails' `rescue_from` macro to
+      # catch this error and render a 403 status code, you should add
+      # the `Pundit::NotAuthorizedError` to the `exception_class_whitelist`.
+      self.exception_class_whitelist = []
     end
 
     def json_key_format=(format)
@@ -77,6 +86,8 @@ module JSONAPI
     attr_writer :top_level_meta_include_record_count
 
     attr_writer :top_level_meta_record_count_key
+
+    attr_writer :exception_class_whitelist
   end
 
   class << self

--- a/lib/jsonapi/operations_processor.rb
+++ b/lib/jsonapi/operations_processor.rb
@@ -89,9 +89,13 @@ module JSONAPI
 
     rescue => e
       # :nocov:
-      internal_server_error = JSONAPI::Exceptions::InternalServerError.new(e)
-      Rails.logger.error { "Internal Server Error: #{e.message} #{e.backtrace.join("\n")}" }
-      return JSONAPI::ErrorsOperationResult.new(internal_server_error.errors[0].code, internal_server_error.errors)
+      if JSONAPI.configuration.exception_class_whitelist.include?(e.class)
+        raise e
+      else
+        internal_server_error = JSONAPI::Exceptions::InternalServerError.new(e)
+        Rails.logger.error { "Internal Server Error: #{e.message} #{e.backtrace.join("\n")}" }
+        return JSONAPI::ErrorsOperationResult.new(internal_server_error.errors[0].code, internal_server_error.errors)
+      end
       # :nocov:
     end
   end

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -11,6 +11,22 @@ class PostsControllerTest < ActionController::TestCase
     assert json_response['data'].is_a?(Array)
   end
 
+  def test_exception_class_whitelist
+    original_config = JSONAPI.configuration.dup
+    JSONAPI.configuration.operations_processor = :error_raising
+    # test that the operations processor rescues the error when it
+    # has not been added to the exception_class_whitelist
+    get :index
+    assert_response 500
+    # test that the operations processor does not rescue the error when it
+    # has been added to the exception_class_whitelist
+    JSONAPI.configuration.exception_class_whitelist << PostsController::SpecialError
+    get :index
+    assert_response 403
+  ensure
+    JSONAPI.configuration = original_config
+  end
+
   def test_index_filter_with_empty_result
     get :index, {filter: {title: 'post that does not exist'}}
     assert_response :success

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,6 +12,7 @@ end
 
 require 'rails/all'
 require 'rails/test_help'
+require 'minitest/mock'
 require 'jsonapi-resources'
 
 require File.expand_path('../helpers/value_matchers', __FILE__)
@@ -260,4 +261,3 @@ class TitleValueFormatter < JSONAPI::ValueFormatter
     end
   end
 end
-


### PR DESCRIPTION
For example, if you use Pundit for authorization, you might
raise a `Pundit::NotAuthorizedError` at some point during operations
processing. If you want to use Rails' `rescue_from` macro to
catch this error and render a 403 status code, you should add
the `Pundit::NotAuthorizedError` to the `exception_class_whitelist`.

`JSONAPI.configuration.exception_class_whitelist = [Pundit::NotAuthorizedError]`
