### PR TITLE
Adds feature that the resource interrogates the model for the primary key.

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,10 +178,10 @@ updating the attribute. See the [Value Formatters](#value-formatters) section fo
 
 #### Primary Key
 
-Resources are always represented using a key of `id`. If the underlying model does not use `id` as the primary key you
-can use the `primary_key` method to tell the resource which field on the model to use as the primary key. Note: this
-doesn't have to be the actual primary key of the model. For example you may wish to use integers internally and a
-different scheme publicly.
+Resources are always represented using a key of `id`. The resource will interrogate the model to find the primary key.
+If the underlying model does not use `id` as the primary key _and_ does not support the `primary_key` method you
+must use the `primary_key` method to tell the resource which field on the model to use as the primary key. **Note:**
+this _must_ be the actual primary key of the model.
 
 By default only integer values are allowed for primary key. To change this behavior you can override
 `verify_key` class method:

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -577,7 +577,7 @@ module JSONAPI
       end
 
       def _primary_key
-        @_primary_key ||= :id
+        @_primary_key ||= _model_class.respond_to?(:primary_key) ? _model_class.primary_key : :id
       end
 
       def _as_parent_key

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -673,6 +673,9 @@ class PostResource < JSONAPI::Resource
   has_many :tags, acts_as_set: true
   has_many :comments, acts_as_set: false
 
+  # Not needed - just for testing
+  primary_key :id
+
   before_save do
     msg = "Before save"
   end
@@ -763,7 +766,6 @@ class HairCutResource < JSONAPI::Resource
 end
 
 class IsoCurrencyResource < JSONAPI::Resource
-  primary_key :code
   attributes :name, :country_name, :minor_unit
 
   filter :country_name


### PR DESCRIPTION
Should clear up up some self inflicted confusion regarding the primary keys. Changes the readme and adds code to get the primary key from the model, if possible.

Fixes #291 
