### PR TITLE
Pass `context` into `records_for` through options

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -669,7 +669,8 @@ module JSONAPI
           end unless method_defined?("#{foreign_key}=")
 
           define_method associated_records_method_name do |options = {}|
-            relation_name = association.relation_name(options.merge({context: @context}))
+            options = options.merge({context: @context})
+            relation_name = association.relation_name(options)
             records_for(relation_name, options)
           end unless method_defined?(associated_records_method_name)
 


### PR DESCRIPTION
I wasn't getting the context in the options hash when overriding the `records_for` method.
I'm not sure if this is the right way to fix it, please let me know if it's ok.
Thanks!
