### PR TITLE
Resource linkage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1277,6 +1277,11 @@ JSONAPI.configure do |config|
   # catch this error and render a 403 status code, you should add
   # the `Pundit::NotAuthorizedError` to the `exception_class_whitelist`.
   config.exception_class_whitelist = []
+  
+  # Resource Linkage
+  # Controls the serialization of resource linkage for non compound documents
+  # NOTE: always_include_has_many_linkage_data is not currently implemented
+  config.always_include_has_one_linkage_data = false  
 end
 ```
 

--- a/lib/jsonapi/configuration.rb
+++ b/lib/jsonapi/configuration.rb
@@ -17,7 +17,9 @@ module JSONAPI
                 :top_level_links_include_pagination,
                 :top_level_meta_include_record_count,
                 :top_level_meta_record_count_key,
-                :exception_class_whitelist
+                :exception_class_whitelist,
+                :always_include_to_one_linkage_data,
+                :always_include_to_many_linkage_data
 
     def initialize
       #:underscored_key, :camelized_key, :dasherized_key, or custom
@@ -54,6 +56,12 @@ module JSONAPI
       # catch this error and render a 403 status code, you should add
       # the `Pundit::NotAuthorizedError` to the `exception_class_whitelist`.
       self.exception_class_whitelist = []
+
+      # Resource Linkage
+      # Controls the serialization of resource linkage for non compound documents
+      # NOTE: always_include_to_many_linkage_data is not currently implemented
+      self.always_include_to_one_linkage_data = false
+      self.always_include_to_many_linkage_data = false
     end
 
     def json_key_format=(format)
@@ -88,6 +96,10 @@ module JSONAPI
     attr_writer :top_level_meta_record_count_key
 
     attr_writer :exception_class_whitelist
+
+    attr_writer :always_include_to_one_linkage_data
+
+    attr_writer :always_include_to_many_linkage_data
   end
 
   class << self

--- a/lib/jsonapi/relationship.rb
+++ b/lib/jsonapi/relationship.rb
@@ -1,7 +1,7 @@
 module JSONAPI
   class Relationship
     attr_reader :acts_as_set, :foreign_key, :type, :options, :name,
-                :class_name, :polymorphic
+                :class_name, :polymorphic, :always_include_linkage_data
 
     def initialize(name, options = {})
       @name = name.to_s
@@ -11,6 +11,7 @@ module JSONAPI
       @module_path = options[:module_path] || ''
       @relation_name = options.fetch(:relation_name, @name)
       @polymorphic = options.fetch(:polymorphic, false) == true
+      @always_include_linkage_data = options.fetch(:always_include_linkage_data, false) == true
     end
 
     alias_method :polymorphic?, :polymorphic

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -653,7 +653,7 @@ module JSONAPI
       def check_reserved_attribute_name(name)
         # Allow :id since it can be used to specify the format. Since it is a method on the base Resource
         # an attribute method won't be created for it.
-        if [:type, :href, :links].include?(name.to_sym)
+        if [:type, :href, :links, :model].include?(name.to_sym)
           warn "[NAME COLLISION] `#{name}` is a reserved key in #{@@resource_types[_type]}."
         end
       end

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -275,7 +275,6 @@ class PostsControllerTest < ActionController::TestCase
     assert_response :success
     assert json_response['data'].is_a?(Hash)
     assert_nil json_response['data']['attributes']
-    assert_equal '1', json_response['data']['relationships']['author']['data']['id']
   end
 
   def test_show_single_with_fields_string
@@ -326,7 +325,6 @@ class PostsControllerTest < ActionController::TestCase
 
     assert_response :created
     assert json_response['data'].is_a?(Hash)
-    assert_equal '3', json_response['data']['relationships']['author']['data']['id']
     assert_equal 'JR is Great', json_response['data']['attributes']['title']
     assert_equal 'JSONAPIResources is the greatest thing since unsliced bread.', json_response['data']['attributes']['body']
   end
@@ -431,7 +429,7 @@ class PostsControllerTest < ActionController::TestCase
     assert_response :created
     assert json_response['data'].is_a?(Array)
     assert_equal json_response['data'].size, 2
-    assert_equal json_response['data'][0]['relationships']['author']['data']['id'], '3'
+    assert_nil json_response['data'][0]['relationships']['author']['data']
     assert_match /JR is Great/, response.body
     assert_match /Ember is Great/, response.body
   end
@@ -561,7 +559,8 @@ class PostsControllerTest < ActionController::TestCase
                author: {data: {type: 'people', id: '3'}},
                tags: {data: [{type: 'tags', id: 3}, {type: 'tags', id: 4}]}
              }
-           }
+           },
+           include: 'author'
          }
 
     assert_response :created
@@ -585,7 +584,8 @@ class PostsControllerTest < ActionController::TestCase
                author: {data: {type: 'people', id: '3'}},
                tags: {data: [{type: 'tags', id: 3}, {type: 'tags', id: 4}]}
              }
-           }
+           },
+           include: 'author'
          }
 
     assert_response :created
@@ -639,7 +639,7 @@ class PostsControllerTest < ActionController::TestCase
               tags: {data: [{type: 'tags', id: 3}, {type: 'tags', id: 4}]}
             }
           },
-          include: 'tags'
+          include: 'tags,author,section'
         }
 
     assert_response :success
@@ -709,7 +709,7 @@ class PostsControllerTest < ActionController::TestCase
               tags: []
             }
           },
-          include: 'tags'
+          include: 'tags,author,section'
         }
 
     assert_response :success
@@ -1246,15 +1246,11 @@ class PostsControllerTest < ActionController::TestCase
 
     assert_response :success
     assert_equal json_response['data'].size, 2
-    assert_equal json_response['data'][0]['relationships']['author']['data']['id'], '3'
-    assert_equal json_response['data'][0]['relationships']['section']['data']['id'], javascript.id.to_s
     assert_equal json_response['data'][0]['attributes']['title'], 'A great new Post QWERTY'
     assert_equal json_response['data'][0]['attributes']['body'], 'AAAA'
     assert matches_array?([{'type' => 'tags', 'id' => '3'}, {'type' => 'tags', 'id' => '4'}],
                           json_response['data'][0]['relationships']['tags']['data'])
 
-    assert_equal json_response['data'][1]['relationships']['author']['data']['id'], '3'
-    assert_equal json_response['data'][1]['relationships']['section']['data']['id'], javascript.id.to_s
     assert_equal json_response['data'][1]['attributes']['title'], 'A great new Post ASDFG'
     assert_equal json_response['data'][1]['attributes']['body'], 'Not First!!!!'
     assert matches_array?([{'type' => 'tags', 'id' => '3'}, {'type' => 'tags', 'id' => '4'}],
@@ -1601,7 +1597,7 @@ class ExpenseEntriesControllerTest < ActionController::TestCase
                iso_currency: {data: {type: 'iso_currencies', id: 'USD'}}
              }
            },
-           include: 'iso_currency',
+           include: 'iso_currency,employee',
            fields: {expense_entries: 'id,transaction_date,iso_currency,cost,employee'}
          }
 
@@ -1632,7 +1628,7 @@ class ExpenseEntriesControllerTest < ActionController::TestCase
                isoCurrency: {data: {type: 'iso_currencies', id: 'USD'}}
              }
            },
-           include: 'isoCurrency',
+           include: 'isoCurrency,employee',
            fields: {expenseEntries: 'id,transactionDate,isoCurrency,cost,employee'}
          }
 
@@ -1663,7 +1659,7 @@ class ExpenseEntriesControllerTest < ActionController::TestCase
                'iso-currency' => {data: {type: 'iso_currencies', id: 'USD'}}
              }
            },
-           include: 'iso-currency',
+           include: 'iso-currency,employee',
            fields: {'expense-entries' => 'id,transaction-date,iso-currency,cost,employee'}
          }
 
@@ -1948,18 +1944,13 @@ class PeopleControllerTest < ActionController::TestCase
              links: {
                self: 'http://test.host/people/1/relationships/preferences',
                related: 'http://test.host/people/1/preferences'
-             },
-             data: {
-               type: 'preferences',
-               id: '1'
              }
            },
            "hair-cut" => {
              "links" => {
                "self" => "http://test.host/people/1/relationships/hair_cut",
                "related" => "http://test.host/people/1/hair_cut"
-             },
-             "data" => nil
+             }
            },
            vehicles: {
              links: {
@@ -2160,7 +2151,6 @@ class Api::V1::PostsControllerTest < ActionController::TestCase
 
     assert_response :created
     assert json_response['data'].is_a?(Hash)
-    assert_equal '3', json_response['data']['relationships']['writer']['data']['id']
     assert_equal 'JR - now with Namespacing', json_response['data']['attributes']['title']
     assert_equal 'JSONAPIResources is the greatest thing since unsliced bread now that it has namespaced resources.',
                  json_response['data']['attributes']['body']

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -195,6 +195,11 @@ ActiveRecord::Schema.define do
 
   create_table :vehicles, force: true do |t|
     t.string :type
+    t.string :make
+    t.string :vehicle_model
+    t.string :length_at_water_line
+    t.string :drive_layout
+    t.string :serial_number
     t.integer :person_id
   end
 end
@@ -644,12 +649,15 @@ end
 
 class VehicleResource < JSONAPI::Resource
   has_one :person
+  attributes :make, :vehicle_model, :serial_number
 end
 
 class CarResource < VehicleResource
+  attributes :drive_layout
 end
 
 class BoatResource < VehicleResource
+  attributes :length_at_water_line
 end
 
 class CommentResource < JSONAPI::Resource
@@ -893,7 +901,7 @@ end
 
 class ProductResource < JSONAPI::Resource
   attribute :name
-  has_one :picture
+  has_one :picture, always_include_linkage_data: true
 
   def picture_id
     model.picture.id

--- a/test/fixtures/vehicles.yml
+++ b/test/fixtures/vehicles.yml
@@ -1,8 +1,16 @@
-car:
+Miata:
   id: 1
   type: Car
+  make: Mazda
+  vehicle_model: Miata MX5
+  drive_layout: Front Engine RWD
+  serial_number: 32432adfsfdysua
   person_id: 1
-boat:
+Launch20:
   id: 2
   type: Boat
+  make: Chris-Craft
+  vehicle_model: Launch 20
+  length_at_water_line: 15.5ft
+  serial_number: 434253JJJSD
   person_id: 1

--- a/test/unit/serializer/polymorphic_serializer_test.rb
+++ b/test/unit/serializer/polymorphic_serializer_test.rb
@@ -23,7 +23,7 @@ class PolymorphismTest < ActionDispatch::IntegrationTest
     assert imageable.polymorphic?
   end
 
-  def test_polymorphic_to_many_serialization
+  def test_sti_polymorphic_to_many_serialization
     serialized_data = JSONAPI::ResourceSerializer.new(
       PersonResource,
       include: %w(vehicles)
@@ -31,94 +31,93 @@ class PolymorphismTest < ActionDispatch::IntegrationTest
 
     assert_hash_equals(
       {
-        :data => {
-          "id" => "1",
-          "type" => "people",
-          "links" => {
-            :self => "/people/1"
+        data: {
+          id: '1',
+          type: 'people',
+          links: {
+            self: '/people/1'
           },
-          "attributes" => {
-            "name" => "Joe Author",
-            "email" => "joe@xyz.fake",
-            "dateJoined" => "2013-08-07 16:25:00 -0400"
+          attributes: {
+            name: 'Joe Author',
+            email: 'joe@xyz.fake',
+            dateJoined: '2013-08-07 16:25:00 -0400'
           },
-          "relationships" => {
-            "comments" => {
-              :links => {
-                :self => "/people/1/relationships/comments",
-                :related => "/people/1/comments"
+          relationships: {
+            comments: {
+              links: {
+                self: '/people/1/relationships/comments',
+                related: '/people/1/comments'
               }
             },
-            "posts" => {
-              :links => {
-                :self => "/people/1/relationships/posts",
-                :related => "/people/1/posts"
+            posts: {
+              links: {
+                self: '/people/1/relationships/posts',
+                related: '/people/1/posts'
               }
             },
-            "vehicles" => {
-              :links => {
-                :self => "/people/1/relationships/vehicles",
-                :related => "/people/1/vehicles"
+            vehicles: {
+              links: {
+                self: '/people/1/relationships/vehicles',
+                related: '/people/1/vehicles'
               },
               :data => [
-                { :type => "cars", :id=> "1" },
-                { :type => "boats", :id=>"2" }
+                { type: 'cars', id: '1' },
+                { type: 'boats', id: '2' }
               ]
             },
-            "preferences" => {
-              :links => {
-                :self => "/people/1/relationships/preferences",
-                :related => "/people/1/preferences"
-              },
-              :data => {
-                :type => "preferences",
-                :id=>"1"
+            preferences: {
+              links: {
+                self: '/people/1/relationships/preferences',
+                related: '/people/1/preferences'
               }
             },
-            "hairCut" => {
-              :links => {
-                :self => "/people/1/relationships/hairCut",
-                :related => "/people/1/hairCut"
-              },
-              :data => nil
+            hairCut: {
+              links: {
+                self: '/people/1/relationships/hairCut',
+                related: '/people/1/hairCut'
+              }
             }
           }
         },
-        :included => [
+        included: [
           {
-            "id" => "1",
-            "type" => "cars",
-            "links" => {
-              :self => "/cars/1"
+            id: '1',
+            type: 'cars',
+            links: {
+              self: '/cars/1'
             },
-            "relationships" => {
-              "person" => {
-                :links => {
-                  :self => "/cars/1/relationships/person",
-                  :related => "/cars/1/person"
-                },
-                :data => {
-                  :type => "people",
-                  :id => "1"
+            attributes: {
+              make: 'Mazda',
+              vehicleModel: 'Miata MX5',
+              driveLayout: 'Front Engine RWD',
+              serialNumber: '32432adfsfdysua'
+            },
+            relationships: {
+              person: {
+                links: {
+                  self: '/cars/1/relationships/person',
+                  related: '/cars/1/person'
                 }
               }
             }
           },
           {
-            "id" => "2",
-            "type" => "boats",
-            "links" => {
-              :self => "/boats/2"
+            id: '2',
+            type: 'boats',
+            links: {
+              self: '/boats/2'
             },
-            "relationships" => {
-              "person" => {
-                :links => {
-                  :self => "/boats/2/relationships/person",
-                  :related => "/boats/2/person"
-                },
-                :data => {
-                  :type => "people",
-                  :id => "1"
+            attributes: {
+              make: 'Chris-Craft',
+              vehicleModel: 'Launch 20',
+              lengthAtWaterLine: '15.5ft',
+              serialNumber: '434253JJJSD'
+            },
+            relationships: {
+              person: {
+                links: {
+                  self: '/boats/2/relationships/person',
+                  related: '/boats/2/person'
                 }
               }
             }

--- a/test/unit/serializer/serializer_test.rb
+++ b/test/unit/serializer/serializer_test.rb
@@ -11,9 +11,11 @@ class SerializerTest < ActionDispatch::IntegrationTest
 
     JSONAPI.configuration.json_key_format = :camelized_key
     JSONAPI.configuration.route_format = :camelized_route
+    JSONAPI.configuration.always_include_to_one_linkage_data = false
   end
 
   def after_teardown
+    JSONAPI.configuration.always_include_to_one_linkage_data = false
     JSONAPI.configuration.json_key_format = :underscored_key
   end
 
@@ -42,17 +44,12 @@ class SerializerTest < ActionDispatch::IntegrationTest
               links: {
                 self: 'http://example.com/posts/1/relationships/section',
                 related: 'http://example.com/posts/1/section'
-              },
-              data: nil
+              }
             },
             author: {
               links: {
                 self: 'http://example.com/posts/1/relationships/author',
                 related: 'http://example.com/posts/1/author'
-              },
-              data: {
-                type: 'people',
-                id: '1'
               }
             },
             tags: {
@@ -102,17 +99,12 @@ class SerializerTest < ActionDispatch::IntegrationTest
               links:{
                 self: 'http://example.com/api/v1/posts/1/relationships/section',
                 related: 'http://example.com/api/v1/posts/1/section'
-              },
-              data: nil
+              }
             },
             writer: {
               links:{
                 self: 'http://example.com/api/v1/posts/1/relationships/writer',
                 related: 'http://example.com/api/v1/posts/1/writer'
-              },
-              data: {
-                type: 'writers',
-                id: '1'
               }
             },
             comments: {
@@ -148,10 +140,6 @@ class SerializerTest < ActionDispatch::IntegrationTest
               links: {
                 self: '/posts/1/relationships/author',
                 related: '/posts/1/author'
-              },
-              data: {
-                type: 'people',
-                id: '1'
               }
             }
           }
@@ -186,8 +174,7 @@ class SerializerTest < ActionDispatch::IntegrationTest
               links: {
                 self: '/posts/1/relationships/section',
                 related: '/posts/1/section'
-              },
-              data: nil
+              }
             },
             author: {
               links: {
@@ -242,18 +229,13 @@ class SerializerTest < ActionDispatch::IntegrationTest
                links: {
                  self: '/people/1/relationships/preferences',
                  related: '/people/1/preferences'
-               },
-               data: {
-                 type: 'preferences',
-                 id: '1'
                }
              },
              hairCut: {
                links: {
                  self: "/people/1/relationships/hairCut",
                  related: "/people/1/hairCut"
-               },
-               data: nil
+               }
              },
              vehicles: {
                links: {
@@ -294,8 +276,7 @@ class SerializerTest < ActionDispatch::IntegrationTest
               links: {
                 self: '/posts/1/relationships/section',
                 related: '/posts/1/section'
-              },
-              data: nil
+              }
             },
             author: {
               links: {
@@ -350,18 +331,13 @@ class SerializerTest < ActionDispatch::IntegrationTest
                 links: {
                   self: '/people/1/relationships/preferences',
                   related: '/people/1/preferences'
-                },
-                data: {
-                  type: 'preferences',
-                  id: '1'
                 }
               },
               hair_cut: {
                 links: {
                   self: '/people/1/relationships/hairCut',
                   related: '/people/1/hairCut'
-                },
-                data: nil
+                }
               },
               vehicles: {
                 links: {
@@ -397,17 +373,12 @@ class SerializerTest < ActionDispatch::IntegrationTest
               links: {
                 self: '/posts/1/relationships/section',
                 related: '/posts/1/section'
-              },
-              data: nil
+              }
             },
             author: {
               links: {
                 self: '/posts/1/relationships/author',
               related: '/posts/1/author'
-              },
-              data: {
-                type: 'people',
-                id: '1'
               }
             },
             tags: {
@@ -497,20 +468,12 @@ class SerializerTest < ActionDispatch::IntegrationTest
                   links: {
                     self: '/comments/1/relationships/author',
                     related: '/comments/1/author'
-                  },
-                  data: {
-                    type: 'people',
-                    id: '1'
                   }
                 },
                 post: {
                   links: {
                     self: '/comments/1/relationships/post',
                     related: '/comments/1/post'
-                  },
-                  data: {
-                    type: 'posts',
-                    id: '1'
                   }
                 },
                 tags: {
@@ -539,20 +502,12 @@ class SerializerTest < ActionDispatch::IntegrationTest
                   links: {
                     self: '/comments/2/relationships/author',
                     related: '/comments/2/author'
-                  },
-                  data: {
-                    type: 'people',
-                    id: '2'
                   }
                 },
                 post: {
                   links: {
                     self: '/comments/2/relationships/post',
                     related: '/comments/2/post'
-                  },
-                  data: {
-                    type: 'posts',
-                    id: '1'
                   }
                 },
                 tags: {
@@ -614,15 +569,13 @@ class SerializerTest < ActionDispatch::IntegrationTest
               links: {
                 self: "/people/2/relationships/preferences",
                 related: "/people/2/preferences"
-              },
-              data: nil
+              }
             },
             hairCut: {
               links: {
                 self: "/people/2/relationships/hairCut",
                 related: "/people/2/hairCut"
-              },
-              data: nil
+              }
             },
             vehicles: {
               links: {
@@ -647,20 +600,12 @@ class SerializerTest < ActionDispatch::IntegrationTest
                 links: {
                   self: '/comments/2/relationships/author',
                   related: '/comments/2/author'
-                },
-                data: {
-                  type: 'people',
-                  id: '2'
                 }
               },
               post: {
                 links: {
                   self: '/comments/2/relationships/post',
                   related: '/comments/2/post'
-                },
-                data: {
-                  type: 'posts',
-                  id: '1'
                 }
               },
               tags: {
@@ -685,20 +630,12 @@ class SerializerTest < ActionDispatch::IntegrationTest
                 links: {
                   self: '/comments/3/relationships/author',
                   related: '/comments/3/author'
-                },
-                data: {
-                  type: 'people',
-                  id: '2'
                 }
               },
               post: {
                 links: {
                   self: '/comments/3/relationships/post',
                   related: '/comments/3/post'
-                },
-                data: {
-                  type: 'posts',
-                  id: '2'
                 }
               },
               tags: {
@@ -715,12 +652,14 @@ class SerializerTest < ActionDispatch::IntegrationTest
     )
   end
 
-  def test_serializer_array_of_resources
+  def test_serializer_array_of_resources_always_include_to_one_linkage_data
 
     posts = []
     Post.find(1, 2).each do |post|
       posts.push PostResource.new(post)
     end
+
+    JSONAPI.configuration.always_include_to_one_linkage_data = true
 
     assert_hash_equals(
       {
@@ -1025,6 +964,282 @@ class SerializerTest < ActionDispatch::IntegrationTest
       JSONAPI::ResourceSerializer.new(PostResource,
                                       include: ['comments', 'comments.tags']).serialize_to_hash(posts)
     )
+    JSONAPI.configuration.always_include_to_one_linkage_data = false
+  end
+
+  def test_serializer_array_of_resources
+
+    posts = []
+    Post.find(1, 2).each do |post|
+      posts.push PostResource.new(post)
+    end
+
+    assert_hash_equals(
+      {
+        data: [
+          {
+            type: 'posts',
+            id: '1',
+            attributes: {
+              title: 'New post',
+              body: 'A body!!!',
+              subject: 'New post'
+            },
+            links: {
+              self: '/posts/1'
+            },
+            relationships: {
+              section: {
+                links: {
+                  self: '/posts/1/relationships/section',
+                  related: '/posts/1/section'
+                }
+              },
+              author: {
+                links: {
+                  self: '/posts/1/relationships/author',
+                  related: '/posts/1/author'
+                }
+              },
+              tags: {
+                links: {
+                  self: '/posts/1/relationships/tags',
+                  related: '/posts/1/tags'
+                }
+              },
+              comments: {
+                links: {
+                  self: '/posts/1/relationships/comments',
+                  related: '/posts/1/comments'
+                },
+                data: [
+                  {type: 'comments', id: '1'},
+                  {type: 'comments', id: '2'}
+                ]
+              }
+            }
+          },
+          {
+            type: 'posts',
+            id: '2',
+            attributes: {
+              title: 'JR Solves your serialization woes!',
+              body: 'Use JR',
+              subject: 'JR Solves your serialization woes!'
+            },
+            links: {
+              self: '/posts/2'
+            },
+            relationships: {
+              section: {
+                links: {
+                  self: '/posts/2/relationships/section',
+                  related: '/posts/2/section'
+                }
+              },
+              author: {
+                links: {
+                  self: '/posts/2/relationships/author',
+                  related: '/posts/2/author'
+                }
+              },
+              tags: {
+                links: {
+                  self: '/posts/2/relationships/tags',
+                  related: '/posts/2/tags'
+                }
+              },
+              comments: {
+                links: {
+                  self: '/posts/2/relationships/comments',
+                  related: '/posts/2/comments'
+                },
+                data: [
+                  {type: 'comments', id: '3'}
+                ]
+              }
+            }
+          }
+        ],
+        included: [
+          {
+            type: 'tags',
+            id: '1',
+            attributes: {
+              name: 'short'
+            },
+            links: {
+              self: '/tags/1'
+            },
+            relationships: {
+              posts: {
+                links: {
+                  self: '/tags/1/relationships/posts',
+                  related: '/tags/1/posts'
+                }
+              }
+            }
+          },
+          {
+            type: 'tags',
+            id: '2',
+            attributes: {
+              name: 'whiny'
+            },
+            links: {
+              self: '/tags/2'
+            },
+            relationships: {
+              posts: {
+                links: {
+                  self: '/tags/2/relationships/posts',
+                  related: '/tags/2/posts'
+                }
+              }
+            }
+          },
+          {
+            type: 'tags',
+            id: '4',
+            attributes: {
+              name: 'happy'
+            },
+            links: {
+              self: '/tags/4'
+            },
+            relationships: {
+              posts: {
+                links: {
+                  self: '/tags/4/relationships/posts',
+                  related: '/tags/4/posts'
+                }
+              }
+            }
+          },
+          {
+            type: 'tags',
+            id: '5',
+            attributes: {
+              name: 'JR'
+            },
+            links: {
+              self: '/tags/5'
+            },
+            relationships: {
+              posts: {
+                links: {
+                  self: '/tags/5/relationships/posts',
+                  related: '/tags/5/posts'
+                }
+              }
+            }
+          },
+          {
+            type: 'comments',
+            id: '1',
+            attributes: {
+              body: 'what a dumb post'
+            },
+            links: {
+              self: '/comments/1'
+            },
+            relationships: {
+              author: {
+                links: {
+                  self: '/comments/1/relationships/author',
+                  related: '/comments/1/author'
+                }
+              },
+              post: {
+                links: {
+                  self: '/comments/1/relationships/post',
+                  related: '/comments/1/post'
+                }
+              },
+              tags: {
+                links: {
+                  self: '/comments/1/relationships/tags',
+                  related: '/comments/1/tags'
+                },
+                data: [
+                  {type: 'tags', id: '1'},
+                  {type: 'tags', id: '2'}
+                ]
+              }
+            }
+          },
+          {
+            type: 'comments',
+            id: '2',
+            attributes: {
+              body: 'i liked it'
+            },
+            links: {
+              self: '/comments/2'
+            },
+            relationships: {
+              author: {
+                links: {
+                  self: '/comments/2/relationships/author',
+                  related: '/comments/2/author'
+                }
+              },
+              post: {
+                links: {
+                  self: '/comments/2/relationships/post',
+                  related: '/comments/2/post'
+                }
+              },
+              tags: {
+                links: {
+                  self: '/comments/2/relationships/tags',
+                  related: '/comments/2/tags'
+                },
+                data: [
+                  {type: 'tags', id: '4'},
+                  {type: 'tags', id: '1'}
+                ]
+              }
+            }
+          },
+          {
+            type: 'comments',
+            id: '3',
+            attributes: {
+              body: 'Thanks man. Great post. But what is JR?'
+            },
+            links: {
+              self: '/comments/3'
+            },
+            relationships: {
+              author: {
+                links: {
+                  self: '/comments/3/relationships/author',
+                  related: '/comments/3/author'
+                }
+              },
+              post: {
+                links: {
+                  self: '/comments/3/relationships/post',
+                  related: '/comments/3/post'
+                }
+              },
+              tags: {
+                links: {
+                  self: '/comments/3/relationships/tags',
+                  related: '/comments/3/tags'
+                },
+                data: [
+                  {type: 'tags', id: '5'}
+                ]
+              }
+            }
+          }
+        ]
+      },
+      JSONAPI::ResourceSerializer.new(PostResource,
+                                      include: ['comments', 'comments.tags']).serialize_to_hash(posts)
+    )
   end
 
   def test_serializer_array_of_resources_limited_fields
@@ -1141,10 +1356,6 @@ class SerializerTest < ActionDispatch::IntegrationTest
                 links: {
                   self: '/comments/1/relationships/post',
                   related: '/comments/1/post'
-                },
-                data: {
-                  type: 'posts',
-                  id: '1'
                 }
               }
             }
@@ -1163,10 +1374,6 @@ class SerializerTest < ActionDispatch::IntegrationTest
                 links: {
                   self: '/comments/2/relationships/post',
                   related: '/comments/2/post'
-                },
-                data: {
-                  type: 'posts',
-                  id: '1'
                 }
               }
             }
@@ -1185,10 +1392,6 @@ class SerializerTest < ActionDispatch::IntegrationTest
                 links: {
                   self: '/comments/3/relationships/post',
                   related: '/comments/3/post'
-                },
-                data: {
-                  type: 'posts',
-                  id: '2'
                 }
               }
             }
@@ -1300,8 +1503,7 @@ class SerializerTest < ActionDispatch::IntegrationTest
               links: {
                 self: '/planets/8/relationships/planetType',
                 related: '/planets/8/planetType'
-              },
-              data: nil
+              }
             },
             tags: {
               links: {
@@ -1436,8 +1638,7 @@ class SerializerTest < ActionDispatch::IntegrationTest
               links: {
                 self: '/preferences/1/relationships/author',
                 related: '/preferences/1/author'
-              },
-              data: nil
+              }
             },
             friends: {
               links: {


### PR DESCRIPTION
Adds option for outputting resource linkage outside of a compound document. Can be global configuration setting, or an a per association basis.

Exposed and fixes issues with single table inheritance polymorphism.

Fixes #299
