### PR TITLE
Add belongs_to association

### DIFF
--- a/README.md
+++ b/README.md
@@ -1248,6 +1248,11 @@ JSONAPI.configure do |config|
   # catch this error and render a 403 status code, you should add
   # the `Pundit::NotAuthorizedError` to the `exception_class_whitelist`.
   config.exception_class_whitelist = []
+  
+  # Resource Linkage
+  # Controls the serialization of resource linkage for non compound documents
+  # NOTE: force_has_many_resource_linkage is not currently implemented
+  config.force_has_one_resource_linkage = false  
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ end
 
 #### Associations
 
-Related resources need to be specified in the resource. These are declared with the `has_one` and the `has_many` methods.
+Related resources need to be specified in the resource. These are declared with the `belongs_to`, `has_one`, and the `has_many` methods.
 
 Here's a simple example where a post has a single author and an author can have many posts:
 
@@ -222,7 +222,7 @@ Here's a simple example where a post has a single author and an author can have 
 class PostResource < JSONAPI::Resource
   attribute :title, :body
 
-  has_one :author
+  belongs_to :author
 end
 ```
 
@@ -243,7 +243,7 @@ The association methods support the following options:
  * `class_name` - a string specifying the underlying class for the related resource
  * `foreign_key` - the method on the resource used to fetch the related resource. Defaults to `<resource_name>_id` for has_one and `<resource_name>_ids` for has_many relationships.
  * `acts_as_set` - allows the entire set of related records to be replaced in one operation. Defaults to false if not set.
- * `polymorphic` - set to true to identify associations that are polymorphic.
+ * `polymorphic` - set to true to identify associations that are polymorphic. Note: not supported by `has_one`
  * `relation_name` - the name of the relation to use on the model. A lambda may be provided which allows conditional selection of the relation based on the context.
 
 Examples:
@@ -251,21 +251,21 @@ Examples:
 ```ruby
 class CommentResource < JSONAPI::Resource
   attributes :body
-  has_one :post
-  has_one :author, class_name: 'Person'
+  belongs_to :post
+  belongs_to :author, class_name: 'Person'
   has_many :tags, acts_as_set: true
 end
 
 class ExpenseEntryResource < JSONAPI::Resource
   attributes :cost, :transaction_date
 
-  has_one :currency, class_name: 'Currency', foreign_key: 'currency_code'
-  has_one :employee
+  belongs_to :currency, class_name: 'Currency', foreign_key: 'currency_code'
+  belongs_to :employee
 end
 
 class TagResource < JSONAPI::Resource
   attributes :name
-  has_one :taggable, polymorphic: true
+  has_many :taggable, polymorphic: true
 end
 ```
 
@@ -322,8 +322,8 @@ For example:
 ```ruby
  class CommentResource < JSONAPI::Resource
   attributes :body, :status
-  has_one :post
-  has_one :author
+  belongs_to :post
+  belongs_to :author
 
   filter :status, default: 'published,pending'
 end
@@ -360,7 +360,7 @@ When you create a relationship, a method is created to fetch record(s) for that 
 
 ```ruby
 class PostResource < JSONAPI::Resource
-  has_one :author
+  belongs_to :author
   has_many :comments
 
   # def record_for_author(options = {})
@@ -675,8 +675,8 @@ class PostResource < JSONAPI::Resource
   attribute :body
   attribute :subject
 
-  has_one :author, class_name: 'Person'
-  has_one :section
+  belongs_to :author, class_name: 'Person'
+  belongs_to :section
   has_many :tags, acts_as_set: true
   has_many :comments, acts_as_set: false
   def subject
@@ -698,8 +698,8 @@ module Api
       attribute :body
       attribute :subject
 
-      has_one :writer, foreign_key: 'author_id'
-      has_one :section
+      belongs_to :writer, foreign_key: 'author_id'
+      belongs_to :section
       has_many :comments, acts_as_set: false
 
       def subject
@@ -1039,7 +1039,7 @@ A single additional route was created to allow you GET the phone numbers through
 
 ###### `jsonapi_related_resource`
 
-Like `jsonapi_related_resources`, but for has_one related resources.
+Like `jsonapi_related_resources`, but for `has_one` or `belongs_to` related resources.
 
 ```ruby
 Rails.application.routes.draw do

--- a/lib/jsonapi/association.rb
+++ b/lib/jsonapi/association.rb
@@ -1,7 +1,7 @@
 module JSONAPI
   class Association
     attr_reader :acts_as_set, :foreign_key, :type, :options, :name,
-                :class_name, :polymorphic
+                :class_name, :polymorphic, :force_resource_linkage
 
     def initialize(name, options = {})
       @name = name.to_s
@@ -11,6 +11,7 @@ module JSONAPI
       @module_path = options[:module_path] || ''
       @relation_name = options.fetch(:relation_name, @name)
       @polymorphic = options.fetch(:polymorphic, false) == true
+      @force_resource_linkage = options.fetch(:force_resource_linkage, false) == true
     end
 
     alias_method :polymorphic?, :polymorphic

--- a/lib/jsonapi/association.rb
+++ b/lib/jsonapi/association.rb
@@ -49,6 +49,16 @@ module JSONAPI
     class HasOne < Association
       def initialize(name, options = {})
         super
+        @polymorphic = false
+        @class_name = options.fetch(:class_name, name.to_s.camelize)
+        @type = class_name.underscore.pluralize.to_sym
+        @foreign_key ||= "#{name}_id".to_sym
+      end
+    end
+
+    class BelongsTo < Association
+      def initialize(name, options = {})
+        super
         @class_name = options.fetch(:class_name, name.to_s.camelize)
         @type = class_name.underscore.pluralize.to_sym
         @foreign_key ||= "#{name}_id".to_sym

--- a/lib/jsonapi/configuration.rb
+++ b/lib/jsonapi/configuration.rb
@@ -17,7 +17,9 @@ module JSONAPI
                 :top_level_links_include_pagination,
                 :top_level_meta_include_record_count,
                 :top_level_meta_record_count_key,
-                :exception_class_whitelist
+                :exception_class_whitelist,
+                :force_has_one_resource_linkage,
+                :force_has_many_resource_linkage
 
     def initialize
       #:underscored_key, :camelized_key, :dasherized_key, or custom
@@ -54,6 +56,12 @@ module JSONAPI
       # catch this error and render a 403 status code, you should add
       # the `Pundit::NotAuthorizedError` to the `exception_class_whitelist`.
       self.exception_class_whitelist = []
+
+      # Resource Linkage
+      # Controls the serialization of resource linkage for non compound documents
+      # NOTE: force_has_many_resource_linkage is not currently implemented
+      self.force_has_one_resource_linkage = false
+      self.force_has_many_resource_linkage = false
     end
 
     def json_key_format=(format)
@@ -88,6 +96,10 @@ module JSONAPI
     attr_writer :top_level_meta_record_count_key
 
     attr_writer :exception_class_whitelist
+
+    attr_writer :force_has_one_resource_linkage
+
+    attr_writer :force_has_many_resource_linkage
   end
 
   class << self

--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -393,7 +393,7 @@ module JSONAPI
           value.each do |link_key, link_value|
             param = unformat_key(link_key)
             association = @resource_klass._association(param)
-            if association.is_a?(JSONAPI::Association::HasOne)
+            if association.is_a?(JSONAPI::Association::HasOne) || association.is_a?(JSONAPI::Association::BelongsTo)
               if link_value.nil?
                 linkage = nil
               else
@@ -520,7 +520,7 @@ module JSONAPI
 
     def parse_update_association_operation(data, association_type, parent_key)
       association = resource_klass._association(association_type)
-      if association.is_a?(JSONAPI::Association::HasOne)
+      if association.is_a?(JSONAPI::Association::HasOne) || association.is_a?(JSONAPI::Association::BelongsTo)
         if association.polymorphic?
           object_params = { relationships: { format_key(association.name) => { data: data } } }
           verified_param_set = parse_params(object_params, updatable_fields)

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -638,7 +638,7 @@ module JSONAPI
       def check_reserved_attribute_name(name)
         # Allow :id since it can be used to specify the format. Since it is a method on the base Resource
         # an attribute method won't be created for it.
-        if [:type, :href, :links].include?(name.to_sym)
+        if [:type, :href, :links, :model].include?(name.to_sym)
           warn "[NAME COLLISION] `#{name}` is a reserved key in #{@@resource_types[_type]}."
         end
       end

--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -83,18 +83,18 @@ module JSONAPI
       if source.respond_to?(:to_ary)
         source.each do |resource|
           id = resource.id
-          if already_serialized?(@primary_class_name, id)
+          if already_serialized?(resource.class._type, id)
             set_primary(@primary_class_name, id)
           end
 
-          add_included_object(@primary_class_name, id, object_hash(resource,  include_directives), true)
+          add_included_object(id, object_hash(resource,  include_directives), true)
         end
       else
         return {} if source.nil?
 
         resource = source
         id = resource.id
-        add_included_object(@primary_class_name, id, object_hash(source,  include_directives), true)
+        add_included_object(id, object_hash(source,  include_directives), true)
       end
     end
 
@@ -161,8 +161,6 @@ module JSONAPI
             hash[format_key(name)] = link_object(source, association, include_linkage)
           end
 
-          type = association.type
-
           # If the object has been serialized once it will be in the related objects list,
           # but it's possible all children won't have been captured. So we must still go
           # through the associations.
@@ -171,10 +169,9 @@ module JSONAPI
               resource = source.send(name)
               if resource
                 id = resource.id
-                type = association.type_for_source(source)
-                associations_only = already_serialized?(type, id)
+                associations_only = already_serialized?(resource.class._type, id)
                 if include_linkage && !associations_only
-                  add_included_object(type, id, object_hash(resource, ia))
+                  add_included_object(id, object_hash(resource, ia))
                 elsif include_linked_children || associations_only
                   relationship_data(resource, ia)
                 end
@@ -183,9 +180,9 @@ module JSONAPI
               resources = source.send(name)
               resources.each do |resource|
                 id = resource.id
-                associations_only = already_serialized?(type, id)
+                associations_only = already_serialized?(resource.class._type, id)
                 if include_linkage && !associations_only
-                  add_included_object(type, id, object_hash(resource, ia))
+                  add_included_object(id, object_hash(resource, ia))
                 elsif include_linked_children || associations_only
                   relationship_data(resource, ia)
                 end
@@ -255,13 +252,13 @@ module JSONAPI
       linkage
     end
 
-    def link_object_has_one(source, association)
+    def link_object_has_one(source, association, include_linkage)
       include_linkage = include_linkage | @force_has_one_resource_linkage | association.force_resource_linkage
       link_object_hash = {}
       link_object_hash[:links] = {}
       link_object_hash[:links][:self] = self_link(source, association)
       link_object_hash[:links][:related] = related_link(source, association)
-      link_object_hash[:data] = has_one_linkage(source, association)
+      link_object_hash[:data] = has_one_linkage(source, association) if include_linkage
       link_object_hash
     end
 
@@ -312,12 +309,13 @@ module JSONAPI
     end
 
     # Collects the hashes for all objects processed by the serializer
-    def add_included_object(type, id, object_hash, primary = false)
-      type = format_key(type)
+    def add_included_object(id, object_hash, primary = false)
+      type = object_hash['type']
 
       @included_objects[type] = {} unless @included_objects.key?(type)
 
       if already_serialized?(type, id)
+        @included_objects[type][id][:object_hash].merge!(object_hash)
         set_primary(type, id) if primary
       else
         @included_objects[type].store(id, primary: primary, object_hash: object_hash)

--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -54,9 +54,10 @@ module JSONAPI
     end
 
     def serialize_to_links_hash(source, requested_association)
-      if requested_association.is_a?(JSONAPI::Association::HasOne)
+      case requested_association
+      when JSONAPI::Association::HasOne, JSONAPI::Association::BelongsTo
         data = has_one_linkage(source, requested_association)
-      else
+      when JSONAPI::Association::HasMany
         data = has_many_linkage(source, requested_association)
       end
 
@@ -165,7 +166,8 @@ module JSONAPI
           # but it's possible all children won't have been captured. So we must still go
           # through the associations.
           if include_linkage || include_linked_children
-            if association.is_a?(JSONAPI::Association::HasOne)
+            case association
+            when JSONAPI::Association::HasOne, JSONAPI::Association::BelongsTo
               resource = source.send(name)
               if resource
                 id = resource.id
@@ -176,7 +178,7 @@ module JSONAPI
                   relationship_data(resource, ia)
                 end
               end
-            elsif association.is_a?(JSONAPI::Association::HasMany)
+            when JSONAPI::Association::HasMany
               resources = source.send(name)
               resources.each do |resource|
                 id = resource.id
@@ -274,9 +276,10 @@ module JSONAPI
     end
 
     def link_object(source, association, include_linkage)
-      if association.is_a?(JSONAPI::Association::HasOne)
+      case association
+      when JSONAPI::Association::HasOne, JSONAPI::Association::BelongsTo
         link_object_has_one(source, association, include_linkage)
-      elsif association.is_a?(JSONAPI::Association::HasMany)
+      when JSONAPI::Association::HasMany
         link_object_has_many(source, association, include_linkage)
       end
     end

--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -22,6 +22,8 @@ module JSONAPI
       @key_formatter = options.fetch(:key_formatter, JSONAPI.configuration.key_formatter)
       @route_formatter = options.fetch(:route_formatter, JSONAPI.configuration.route_formatter)
       @base_url = options.fetch(:base_url, '')
+      @force_has_one_resource_linkage = options.fetch(:force_has_one_resource_linkage, JSONAPI.configuration.force_has_one_resource_linkage)
+      @force_has_many_resource_linkage = options.fetch(:force_has_many_resource_linkage, JSONAPI.configuration.force_has_many_resource_linkage)
     end
 
     # Converts a single resource, or an array of resources to a hash, conforming to the JSONAPI structure
@@ -254,6 +256,7 @@ module JSONAPI
     end
 
     def link_object_has_one(source, association)
+      include_linkage = include_linkage | @force_has_one_resource_linkage | association.force_resource_linkage
       link_object_hash = {}
       link_object_hash[:links] = {}
       link_object_hash[:links][:self] = self_link(source, association)
@@ -263,6 +266,8 @@ module JSONAPI
     end
 
     def link_object_has_many(source, association, include_linkage)
+      # TODO:
+      # include_linkage = include_linkage | @force_has_one_resource_linkage | association.force_resource_linkage
       link_object_hash = {}
       link_object_hash[:links] = {}
       link_object_hash[:links][:self] = self_link(source, association)
@@ -271,9 +276,9 @@ module JSONAPI
       link_object_hash
     end
 
-    def link_object(source, association, include_linkage = false)
+    def link_object(source, association, include_linkage)
       if association.is_a?(JSONAPI::Association::HasOne)
-        link_object_has_one(source, association)
+        link_object_has_one(source, association, include_linkage)
       elsif association.is_a?(JSONAPI::Association::HasMany)
         link_object_has_many(source, association, include_linkage)
       end

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -275,7 +275,6 @@ class PostsControllerTest < ActionController::TestCase
     assert_response :success
     assert json_response['data'].is_a?(Hash)
     assert_nil json_response['data']['attributes']
-    assert_equal '1', json_response['data']['relationships']['author']['data']['id']
   end
 
   def test_show_single_with_fields_string
@@ -326,7 +325,6 @@ class PostsControllerTest < ActionController::TestCase
 
     assert_response :created
     assert json_response['data'].is_a?(Hash)
-    assert_equal '3', json_response['data']['relationships']['author']['data']['id']
     assert_equal 'JR is Great', json_response['data']['attributes']['title']
     assert_equal 'JSONAPIResources is the greatest thing since unsliced bread.', json_response['data']['attributes']['body']
   end
@@ -431,7 +429,7 @@ class PostsControllerTest < ActionController::TestCase
     assert_response :created
     assert json_response['data'].is_a?(Array)
     assert_equal json_response['data'].size, 2
-    assert_equal json_response['data'][0]['relationships']['author']['data']['id'], '3'
+    assert_nil json_response['data'][0]['relationships']['author']['data']
     assert_match /JR is Great/, response.body
     assert_match /Ember is Great/, response.body
   end
@@ -561,7 +559,8 @@ class PostsControllerTest < ActionController::TestCase
                author: {data: {type: 'people', id: '3'}},
                tags: {data: [{type: 'tags', id: 3}, {type: 'tags', id: 4}]}
              }
-           }
+           },
+           include: 'author'
          }
 
     assert_response :created
@@ -585,7 +584,8 @@ class PostsControllerTest < ActionController::TestCase
                author: {data: {type: 'people', id: '3'}},
                tags: {data: [{type: 'tags', id: 3}, {type: 'tags', id: 4}]}
              }
-           }
+           },
+           include: 'author'
          }
 
     assert_response :created
@@ -639,7 +639,7 @@ class PostsControllerTest < ActionController::TestCase
               tags: {data: [{type: 'tags', id: 3}, {type: 'tags', id: 4}]}
             }
           },
-          include: 'tags'
+          include: 'tags,author,section'
         }
 
     assert_response :success
@@ -709,7 +709,7 @@ class PostsControllerTest < ActionController::TestCase
               tags: []
             }
           },
-          include: 'tags'
+          include: 'tags,author,section'
         }
 
     assert_response :success
@@ -1246,15 +1246,11 @@ class PostsControllerTest < ActionController::TestCase
 
     assert_response :success
     assert_equal json_response['data'].size, 2
-    assert_equal json_response['data'][0]['relationships']['author']['data']['id'], '3'
-    assert_equal json_response['data'][0]['relationships']['section']['data']['id'], javascript.id.to_s
     assert_equal json_response['data'][0]['attributes']['title'], 'A great new Post QWERTY'
     assert_equal json_response['data'][0]['attributes']['body'], 'AAAA'
     assert matches_array?([{'type' => 'tags', 'id' => '3'}, {'type' => 'tags', 'id' => '4'}],
                           json_response['data'][0]['relationships']['tags']['data'])
 
-    assert_equal json_response['data'][1]['relationships']['author']['data']['id'], '3'
-    assert_equal json_response['data'][1]['relationships']['section']['data']['id'], javascript.id.to_s
     assert_equal json_response['data'][1]['attributes']['title'], 'A great new Post ASDFG'
     assert_equal json_response['data'][1]['attributes']['body'], 'Not First!!!!'
     assert matches_array?([{'type' => 'tags', 'id' => '3'}, {'type' => 'tags', 'id' => '4'}],
@@ -1601,7 +1597,7 @@ class ExpenseEntriesControllerTest < ActionController::TestCase
                iso_currency: {data: {type: 'iso_currencies', id: 'USD'}}
              }
            },
-           include: 'iso_currency',
+           include: 'iso_currency,employee',
            fields: {expense_entries: 'id,transaction_date,iso_currency,cost,employee'}
          }
 
@@ -1632,7 +1628,7 @@ class ExpenseEntriesControllerTest < ActionController::TestCase
                isoCurrency: {data: {type: 'iso_currencies', id: 'USD'}}
              }
            },
-           include: 'isoCurrency',
+           include: 'isoCurrency,employee',
            fields: {expenseEntries: 'id,transactionDate,isoCurrency,cost,employee'}
          }
 
@@ -1663,7 +1659,7 @@ class ExpenseEntriesControllerTest < ActionController::TestCase
                'iso-currency' => {data: {type: 'iso_currencies', id: 'USD'}}
              }
            },
-           include: 'iso-currency',
+           include: 'iso-currency,employee',
            fields: {'expense-entries' => 'id,transaction-date,iso-currency,cost,employee'}
          }
 
@@ -1948,18 +1944,13 @@ class PeopleControllerTest < ActionController::TestCase
              links: {
                self: 'http://test.host/people/1/relationships/preferences',
                related: 'http://test.host/people/1/preferences'
-             },
-             data: {
-               type: 'preferences',
-               id: '1'
              }
            },
            "hair-cut" => {
              "links" => {
                "self" => "http://test.host/people/1/relationships/hair_cut",
                "related" => "http://test.host/people/1/hair_cut"
-             },
-             "data" => nil
+             }
            },
            vehicles: {
              links: {
@@ -2160,7 +2151,6 @@ class Api::V1::PostsControllerTest < ActionController::TestCase
 
     assert_response :created
     assert json_response['data'].is_a?(Hash)
-    assert_equal '3', json_response['data']['relationships']['writer']['data']['id']
     assert_equal 'JR - now with Namespacing', json_response['data']['attributes']['title']
     assert_equal 'JSONAPIResources is the greatest thing since unsliced bread now that it has namespaced resources.',
                  json_response['data']['attributes']['body']

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -881,7 +881,7 @@ end
 
 class ProductResource < JSONAPI::Resource
   attribute :name
-  has_one :picture
+  has_one :picture, force_resource_linkage: true
 
   def picture_id
     model.picture.id

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -190,6 +190,11 @@ ActiveRecord::Schema.define do
 
   create_table :vehicles, force: true do |t|
     t.string :type
+    t.string :make
+    t.string :vehicle_model
+    t.string :length_at_water_line
+    t.string :drive_layout
+    t.string :serial_number
     t.integer :person_id
   end
 end
@@ -634,12 +639,15 @@ end
 
 class VehicleResource < JSONAPI::Resource
   has_one :person
+  attributes :make, :vehicle_model, :serial_number
 end
 
 class CarResource < VehicleResource
+  attributes :drive_layout
 end
 
 class BoatResource < VehicleResource
+  attributes :length_at_water_line
 end
 
 class CommentResource < JSONAPI::Resource

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -18,6 +18,11 @@ ActiveRecord::Schema.define do
     t.timestamps null: false
   end
 
+  create_table :author_details, force: true do |t|
+    t.integer :person_id
+    t.string  :author_stuff
+  end
+
   create_table :posts, force: true do |t|
     t.string     :title
     t.text       :body
@@ -207,10 +212,15 @@ class Person < ActiveRecord::Base
   has_many :vehicles
   belongs_to :preferences
   belongs_to :hair_cut
+  has_one :author_detail
 
   ### Validations
   validates :name, presence: true
   validates :date_joined, presence: true
+end
+
+class AuthorDetail < ActiveRecord::Base
+  belongs_to :author, class_name: 'Person', foreign_key: 'person_id'
 end
 
 class Post < ActiveRecord::Base
@@ -620,7 +630,7 @@ class PersonResource < JSONAPI::Resource
   has_many :vehicles, polymorphic: true
 
   has_one :preferences
-  has_one :hair_cut
+  belongs_to :hair_cut
 
   filter :name
 
@@ -638,7 +648,7 @@ class PersonResource < JSONAPI::Resource
 end
 
 class VehicleResource < JSONAPI::Resource
-  has_one :person
+  belongs_to :person
   attributes :make, :vehicle_model, :serial_number
 end
 
@@ -652,8 +662,8 @@ end
 
 class CommentResource < JSONAPI::Resource
   attributes :body
-  has_one :post
-  has_one :author, class_name: 'Person'
+  belongs_to :post
+  belongs_to :author, class_name: 'Person'
   has_many :tags
 
   filters :body
@@ -676,8 +686,8 @@ class PostResource < JSONAPI::Resource
   attribute :body
   attribute :subject
 
-  has_one :author, class_name: 'Person'
-  has_one :section
+  belongs_to :author, class_name: 'Person'
+  belongs_to :section
   has_many :tags, acts_as_set: true
   has_many :comments, acts_as_set: false
 
@@ -785,8 +795,8 @@ class ExpenseEntryResource < JSONAPI::Resource
   attributes :cost
   attribute :transaction_date, format: :date
 
-  has_one :iso_currency, foreign_key: 'currency_code'
-  has_one :employee, class_name: 'Person'
+  belongs_to :iso_currency, foreign_key: 'currency_code'
+  belongs_to :employee, class_name: 'Person'
 end
 
 class EmployeeResource < JSONAPI::Resource
@@ -827,7 +837,7 @@ class PlanetResource < JSONAPI::Resource
   attribute :description
 
   has_many :moons
-  has_one :planet_type
+  belongs_to :planet_type
 
   has_many :tags, acts_as_set: true
 end
@@ -847,13 +857,13 @@ class MoonResource < JSONAPI::Resource
   attribute :name
   attribute :description
 
-  has_one :planet
+  belongs_to :planet
 end
 
 class PreferencesResource < JSONAPI::Resource
   attribute :advanced_mode
 
-  has_one :author, foreign_key: :person_id, class_name: 'Person'
+  belongs_to :author, foreign_key: :person_id, class_name: 'Person'
   has_many :friends, class_name: 'Person'
 
   def self.find_by_key(key, options = {})
@@ -879,7 +889,7 @@ end
 
 class PictureResource < JSONAPI::Resource
   attribute :name
-  has_one :imageable, polymorphic: true
+  belongs_to :imageable, polymorphic: true
 end
 
 class DocumentResource < JSONAPI::Resource
@@ -918,8 +928,8 @@ module Api
       attribute :body
       attribute :subject
 
-      has_one :writer, foreign_key: 'author_id'
-      has_one :section
+      belongs_to :writer, foreign_key: 'author_id'
+      belongs_to :section
       has_many :comments, acts_as_set: false
 
       def subject
@@ -1013,8 +1023,8 @@ module Api
     class BookCommentResource < JSONAPI::Resource
       attributes :body, :approved
 
-      has_one :book
-      has_one :author, class_name: 'Person'
+      belongs_to :book
+      belongs_to :author, class_name: 'Person'
 
       filters :approved, :book
 
@@ -1089,6 +1099,7 @@ module Api
       attributes :name, :email
       model_name 'Person'
       has_many :posts
+      has_one :author_detail
 
       filter :name
 
@@ -1106,6 +1117,10 @@ module Api
       def fetchable_fields
         super - [:email]
       end
+    end
+
+    class AuthorDetailResource < JSONAPI::Resource
+      attributes :author_stuff
     end
 
     PersonResource = PersonResource.dup
@@ -1138,7 +1153,7 @@ module Api
       attribute :tax
       attribute :total
 
-      has_one :customer
+      belongs_to :customer
       has_many :line_items
       has_many :order_flags, acts_as_set: true
     end
@@ -1154,7 +1169,7 @@ module Api
       attribute :quantity
       attribute :item_cost
 
-      has_one :purchase_order
+      belongs_to :purchase_order
     end
   end
 

--- a/test/fixtures/author_details.yml
+++ b/test/fixtures/author_details.yml
@@ -1,0 +1,9 @@
+a:
+  id: 1
+  person_id: 1
+  author_stuff: blah blah
+
+b:
+  id: 2
+  person_id: 2
+  author_stuff: blah blah blah

--- a/test/fixtures/vehicles.yml
+++ b/test/fixtures/vehicles.yml
@@ -1,8 +1,16 @@
-car:
+Miata:
   id: 1
   type: Car
+  make: Mazda
+  vehicle_model: Miata MX5
+  drive_layout: Front Engine RWD
+  serial_number: 32432adfsfdysua
   person_id: 1
-boat:
+Launch20:
   id: 2
   type: Boat
+  make: Chris-Craft
+  vehicle_model: Launch 20
+  length_at_water_line: 15.5ft
+  serial_number: 434253JJJSD
   person_id: 1

--- a/test/unit/serializer/polymorphic_serializer_test.rb
+++ b/test/unit/serializer/polymorphic_serializer_test.rb
@@ -31,93 +31,93 @@ class PolymorphismTest < ActionDispatch::IntegrationTest
 
     assert_hash_equals(
       {
-        :data => {
-          'id' => '1',
-          'type' => 'people',
-          'links' => {
-            :self => '/people/1'
+        data: {
+          id: '1',
+          type: 'people',
+          links: {
+            self: '/people/1'
           },
-          'attributes' => {
-            'name' => 'Joe Author',
-            'email' => 'joe@xyz.fake',
-            'dateJoined' => '2013-08-07 16:25:00 -0400'
+          attributes: {
+            name: 'Joe Author',
+            email: 'joe@xyz.fake',
+            dateJoined: '2013-08-07 16:25:00 -0400'
           },
-          'relationships' => {
-            'comments' => {
-              :links => {
-                :self => '/people/1/relationships/comments',
-                :related => '/people/1/comments'
+          relationships: {
+            comments: {
+              links: {
+                self: '/people/1/relationships/comments',
+                related: '/people/1/comments'
               }
             },
-            'posts' => {
-              :links => {
-                :self => '/people/1/relationships/posts',
-                :related => '/people/1/posts'
+            posts: {
+              links: {
+                self: '/people/1/relationships/posts',
+                related: '/people/1/posts'
               }
             },
-            'vehicles' => {
-              :links => {
-                :self => '/people/1/relationships/vehicles',
-                :related => '/people/1/vehicles'
+            vehicles: {
+              links: {
+                self: '/people/1/relationships/vehicles',
+                related: '/people/1/vehicles'
               },
               :data => [
-                { :type => 'cars', :id=> '1' },
-                { :type => 'boats', :id=>'2' }
+                { type: 'cars', id: '1' },
+                { type: 'boats', id: '2' }
               ]
             },
-            'preferences' => {
-              :links => {
-                :self => '/people/1/relationships/preferences',
-                :related => '/people/1/preferences'
+            preferences: {
+              links: {
+                self: '/people/1/relationships/preferences',
+                related: '/people/1/preferences'
               }
             },
-            'hairCut' => {
-              :links => {
-                :self => '/people/1/relationships/hairCut',
-                :related => '/people/1/hairCut'
+            hairCut: {
+              links: {
+                self: '/people/1/relationships/hairCut',
+                related: '/people/1/hairCut'
               }
             }
           }
         },
         included: [
           {
-            'id': '1',
-            'type' => 'cars',
-            'links' => {
-              :self => '/cars/1'
+            id: '1',
+            type: 'cars',
+            links: {
+              self: '/cars/1'
             },
-            'attributes': {
-              'make': 'Mazda',
-              'vehicleModel': 'Miata MX5',
-              'driveLayout': 'Front Engine RWD',
-              'serialNumber': '32432adfsfdysua'
+            attributes: {
+              make: 'Mazda',
+              vehicleModel: 'Miata MX5',
+              driveLayout: 'Front Engine RWD',
+              serialNumber: '32432adfsfdysua'
             },
-            'relationships' => {
-              'person' => {
-                :links => {
-                  :self => '/cars/1/relationships/person',
-                  :related => '/cars/1/person'
+            relationships: {
+              person: {
+                links: {
+                  self: '/cars/1/relationships/person',
+                  related: '/cars/1/person'
                 }
               }
             }
           },
           {
-            'id' => '2',
-            'type' => 'boats',
-            'links' => {
-              :self => '/boats/2'
+            id: '2',
+            type: 'boats',
+            links: {
+              self: '/boats/2'
             },
-            'attributes': {
-              'make': 'Chris-Craft',
-              'vehicleModel': 'Launch 20',
-              'lengthAtWaterLine': '15.5ft',
-              'serialNumber': '434253JJJSD'
+            attributes: {
+              make: 'Chris-Craft',
+              vehicleModel: 'Launch 20',
+              lengthAtWaterLine: '15.5ft',
+              serialNumber: '434253JJJSD'
             },
-            'relationships' => {
-              'person' => {
-                :links => {
-                  :self => '/boats/2/relationships/person',
-                  :related => '/boats/2/person'
+            relationships: {
+              person: {
+                links: {
+                  self: '/boats/2/relationships/person',
+                  related: '/boats/2/person'
                 }
               }
             }

--- a/test/unit/serializer/polymorphic_serializer_test.rb
+++ b/test/unit/serializer/polymorphic_serializer_test.rb
@@ -23,7 +23,7 @@ class PolymorphismTest < ActionDispatch::IntegrationTest
     assert imageable.polymorphic?
   end
 
-  def test_polymorphic_has_many_serialization
+  def test_sti_polymorphic_has_many_serialization
     serialized_data = JSONAPI::ResourceSerializer.new(
       PersonResource,
       include: %w(vehicles)
@@ -32,93 +32,92 @@ class PolymorphismTest < ActionDispatch::IntegrationTest
     assert_hash_equals(
       {
         :data => {
-          "id" => "1",
-          "type" => "people",
-          "links" => {
-            :self => "/people/1"
+          'id' => '1',
+          'type' => 'people',
+          'links' => {
+            :self => '/people/1'
           },
-          "attributes" => {
-            "name" => "Joe Author",
-            "email" => "joe@xyz.fake",
-            "dateJoined" => "2013-08-07 16:25:00 -0400"
+          'attributes' => {
+            'name' => 'Joe Author',
+            'email' => 'joe@xyz.fake',
+            'dateJoined' => '2013-08-07 16:25:00 -0400'
           },
-          "relationships" => {
-            "comments" => {
+          'relationships' => {
+            'comments' => {
               :links => {
-                :self => "/people/1/relationships/comments",
-                :related => "/people/1/comments"
+                :self => '/people/1/relationships/comments',
+                :related => '/people/1/comments'
               }
             },
-            "posts" => {
+            'posts' => {
               :links => {
-                :self => "/people/1/relationships/posts",
-                :related => "/people/1/posts"
+                :self => '/people/1/relationships/posts',
+                :related => '/people/1/posts'
               }
             },
-            "vehicles" => {
+            'vehicles' => {
               :links => {
-                :self => "/people/1/relationships/vehicles",
-                :related => "/people/1/vehicles"
+                :self => '/people/1/relationships/vehicles',
+                :related => '/people/1/vehicles'
               },
               :data => [
-                { :type => "cars", :id=> "1" },
-                { :type => "boats", :id=>"2" }
+                { :type => 'cars', :id=> '1' },
+                { :type => 'boats', :id=>'2' }
               ]
             },
-            "preferences" => {
+            'preferences' => {
               :links => {
-                :self => "/people/1/relationships/preferences",
-                :related => "/people/1/preferences"
-              },
-              :data => {
-                :type => "preferences",
-                :id=>"1"
+                :self => '/people/1/relationships/preferences',
+                :related => '/people/1/preferences'
               }
             },
-            "hairCut" => {
+            'hairCut' => {
               :links => {
-                :self => "/people/1/relationships/hairCut",
-                :related => "/people/1/hairCut"
-              },
-              :data => nil
+                :self => '/people/1/relationships/hairCut',
+                :related => '/people/1/hairCut'
+              }
             }
           }
         },
-        :included => [
+        included: [
           {
-            "id" => "1",
-            "type" => "cars",
-            "links" => {
-              :self => "/cars/1"
+            'id': '1',
+            'type' => 'cars',
+            'links' => {
+              :self => '/cars/1'
             },
-            "relationships" => {
-              "person" => {
+            'attributes': {
+              'make': 'Mazda',
+              'vehicleModel': 'Miata MX5',
+              'driveLayout': 'Front Engine RWD',
+              'serialNumber': '32432adfsfdysua'
+            },
+            'relationships' => {
+              'person' => {
                 :links => {
-                  :self => "/cars/1/relationships/person",
-                  :related => "/cars/1/person"
-                },
-                :data => {
-                  :type => "people",
-                  :id => "1"
+                  :self => '/cars/1/relationships/person',
+                  :related => '/cars/1/person'
                 }
               }
             }
           },
           {
-            "id" => "2",
-            "type" => "boats",
-            "links" => {
-              :self => "/boats/2"
+            'id' => '2',
+            'type' => 'boats',
+            'links' => {
+              :self => '/boats/2'
             },
-            "relationships" => {
-              "person" => {
+            'attributes': {
+              'make': 'Chris-Craft',
+              'vehicleModel': 'Launch 20',
+              'lengthAtWaterLine': '15.5ft',
+              'serialNumber': '434253JJJSD'
+            },
+            'relationships' => {
+              'person' => {
                 :links => {
-                  :self => "/boats/2/relationships/person",
-                  :related => "/boats/2/person"
-                },
-                :data => {
-                  :type => "people",
-                  :id => "1"
+                  :self => '/boats/2/relationships/person',
+                  :related => '/boats/2/person'
                 }
               }
             }

--- a/test/unit/serializer/serializer_test.rb
+++ b/test/unit/serializer/serializer_test.rb
@@ -11,9 +11,11 @@ class SerializerTest < ActionDispatch::IntegrationTest
 
     JSONAPI.configuration.json_key_format = :camelized_key
     JSONAPI.configuration.route_format = :camelized_route
+    JSONAPI.configuration.force_has_one_resource_linkage = false
   end
 
   def after_teardown
+    JSONAPI.configuration.force_has_one_resource_linkage = false
     JSONAPI.configuration.json_key_format = :underscored_key
   end
 
@@ -42,17 +44,12 @@ class SerializerTest < ActionDispatch::IntegrationTest
               links: {
                 self: 'http://example.com/posts/1/relationships/section',
                 related: 'http://example.com/posts/1/section'
-              },
-              data: nil
+              }
             },
             author: {
               links: {
                 self: 'http://example.com/posts/1/relationships/author',
                 related: 'http://example.com/posts/1/author'
-              },
-              data: {
-                type: 'people',
-                id: '1'
               }
             },
             tags: {
@@ -102,17 +99,12 @@ class SerializerTest < ActionDispatch::IntegrationTest
               links:{
                 self: 'http://example.com/api/v1/posts/1/relationships/section',
                 related: 'http://example.com/api/v1/posts/1/section'
-              },
-              data: nil
+              }
             },
             writer: {
               links:{
                 self: 'http://example.com/api/v1/posts/1/relationships/writer',
                 related: 'http://example.com/api/v1/posts/1/writer'
-              },
-              data: {
-                type: 'writers',
-                id: '1'
               }
             },
             comments: {
@@ -148,10 +140,6 @@ class SerializerTest < ActionDispatch::IntegrationTest
               links: {
                 self: '/posts/1/relationships/author',
                 related: '/posts/1/author'
-              },
-              data: {
-                type: 'people',
-                id: '1'
               }
             }
           }
@@ -186,8 +174,7 @@ class SerializerTest < ActionDispatch::IntegrationTest
               links: {
                 self: '/posts/1/relationships/section',
                 related: '/posts/1/section'
-              },
-              data: nil
+              }
             },
             author: {
               links: {
@@ -242,18 +229,13 @@ class SerializerTest < ActionDispatch::IntegrationTest
                links: {
                  self: '/people/1/relationships/preferences',
                  related: '/people/1/preferences'
-               },
-               data: {
-                 type: 'preferences',
-                 id: '1'
                }
              },
              hairCut: {
                links: {
                  self: "/people/1/relationships/hairCut",
                  related: "/people/1/hairCut"
-               },
-               data: nil
+               }
              },
              vehicles: {
                links: {
@@ -294,8 +276,7 @@ class SerializerTest < ActionDispatch::IntegrationTest
               links: {
                 self: '/posts/1/relationships/section',
                 related: '/posts/1/section'
-              },
-              data: nil
+              }
             },
             author: {
               links: {
@@ -350,18 +331,13 @@ class SerializerTest < ActionDispatch::IntegrationTest
                 links: {
                   self: '/people/1/relationships/preferences',
                   related: '/people/1/preferences'
-                },
-                data: {
-                  type: 'preferences',
-                  id: '1'
                 }
               },
               hair_cut: {
                 links: {
                   self: '/people/1/relationships/hairCut',
                   related: '/people/1/hairCut'
-                },
-                data: nil
+                }
               },
               vehicles: {
                 links: {
@@ -397,17 +373,12 @@ class SerializerTest < ActionDispatch::IntegrationTest
               links: {
                 self: '/posts/1/relationships/section',
                 related: '/posts/1/section'
-              },
-              data: nil
+              }
             },
             author: {
               links: {
                 self: '/posts/1/relationships/author',
               related: '/posts/1/author'
-              },
-              data: {
-                type: 'people',
-                id: '1'
               }
             },
             tags: {
@@ -497,20 +468,12 @@ class SerializerTest < ActionDispatch::IntegrationTest
                   links: {
                     self: '/comments/1/relationships/author',
                     related: '/comments/1/author'
-                  },
-                  data: {
-                    type: 'people',
-                    id: '1'
                   }
                 },
                 post: {
                   links: {
                     self: '/comments/1/relationships/post',
                     related: '/comments/1/post'
-                  },
-                  data: {
-                    type: 'posts',
-                    id: '1'
                   }
                 },
                 tags: {
@@ -539,20 +502,12 @@ class SerializerTest < ActionDispatch::IntegrationTest
                   links: {
                     self: '/comments/2/relationships/author',
                     related: '/comments/2/author'
-                  },
-                  data: {
-                    type: 'people',
-                    id: '2'
                   }
                 },
                 post: {
                   links: {
                     self: '/comments/2/relationships/post',
                     related: '/comments/2/post'
-                  },
-                  data: {
-                    type: 'posts',
-                    id: '1'
                   }
                 },
                 tags: {
@@ -614,15 +569,13 @@ class SerializerTest < ActionDispatch::IntegrationTest
               links: {
                 self: "/people/2/relationships/preferences",
                 related: "/people/2/preferences"
-              },
-              data: nil
+              }
             },
             hairCut: {
               links: {
                 self: "/people/2/relationships/hairCut",
                 related: "/people/2/hairCut"
-              },
-              data: nil
+              }
             },
             vehicles: {
               links: {
@@ -647,20 +600,12 @@ class SerializerTest < ActionDispatch::IntegrationTest
                 links: {
                   self: '/comments/2/relationships/author',
                   related: '/comments/2/author'
-                },
-                data: {
-                  type: 'people',
-                  id: '2'
                 }
               },
               post: {
                 links: {
                   self: '/comments/2/relationships/post',
                   related: '/comments/2/post'
-                },
-                data: {
-                  type: 'posts',
-                  id: '1'
                 }
               },
               tags: {
@@ -685,20 +630,12 @@ class SerializerTest < ActionDispatch::IntegrationTest
                 links: {
                   self: '/comments/3/relationships/author',
                   related: '/comments/3/author'
-                },
-                data: {
-                  type: 'people',
-                  id: '2'
                 }
               },
               post: {
                 links: {
                   self: '/comments/3/relationships/post',
                   related: '/comments/3/post'
-                },
-                data: {
-                  type: 'posts',
-                  id: '2'
                 }
               },
               tags: {
@@ -715,12 +652,14 @@ class SerializerTest < ActionDispatch::IntegrationTest
     )
   end
 
-  def test_serializer_array_of_resources
+  def test_serializer_array_of_resources_force_has_one_relationship_data
 
     posts = []
     Post.find(1, 2).each do |post|
       posts.push PostResource.new(post)
     end
+
+    JSONAPI.configuration.force_has_one_resource_linkage = true
 
     assert_hash_equals(
       {
@@ -1025,6 +964,282 @@ class SerializerTest < ActionDispatch::IntegrationTest
       JSONAPI::ResourceSerializer.new(PostResource,
                                       include: ['comments', 'comments.tags']).serialize_to_hash(posts)
     )
+    JSONAPI.configuration.force_has_one_resource_linkage = false
+  end
+
+  def test_serializer_array_of_resources
+
+    posts = []
+    Post.find(1, 2).each do |post|
+      posts.push PostResource.new(post)
+    end
+
+    assert_hash_equals(
+      {
+        data: [
+          {
+            type: 'posts',
+            id: '1',
+            attributes: {
+              title: 'New post',
+              body: 'A body!!!',
+              subject: 'New post'
+            },
+            links: {
+              self: '/posts/1'
+            },
+            relationships: {
+              section: {
+                links: {
+                  self: '/posts/1/relationships/section',
+                  related: '/posts/1/section'
+                }
+              },
+              author: {
+                links: {
+                  self: '/posts/1/relationships/author',
+                  related: '/posts/1/author'
+                }
+              },
+              tags: {
+                links: {
+                  self: '/posts/1/relationships/tags',
+                  related: '/posts/1/tags'
+                }
+              },
+              comments: {
+                links: {
+                  self: '/posts/1/relationships/comments',
+                  related: '/posts/1/comments'
+                },
+                data: [
+                  {type: 'comments', id: '1'},
+                  {type: 'comments', id: '2'}
+                ]
+              }
+            }
+          },
+          {
+            type: 'posts',
+            id: '2',
+            attributes: {
+              title: 'JR Solves your serialization woes!',
+              body: 'Use JR',
+              subject: 'JR Solves your serialization woes!'
+            },
+            links: {
+              self: '/posts/2'
+            },
+            relationships: {
+              section: {
+                links: {
+                  self: '/posts/2/relationships/section',
+                  related: '/posts/2/section'
+                }
+              },
+              author: {
+                links: {
+                  self: '/posts/2/relationships/author',
+                  related: '/posts/2/author'
+                }
+              },
+              tags: {
+                links: {
+                  self: '/posts/2/relationships/tags',
+                  related: '/posts/2/tags'
+                }
+              },
+              comments: {
+                links: {
+                  self: '/posts/2/relationships/comments',
+                  related: '/posts/2/comments'
+                },
+                data: [
+                  {type: 'comments', id: '3'}
+                ]
+              }
+            }
+          }
+        ],
+        included: [
+          {
+            type: 'tags',
+            id: '1',
+            attributes: {
+              name: 'short'
+            },
+            links: {
+              self: '/tags/1'
+            },
+            relationships: {
+              posts: {
+                links: {
+                  self: '/tags/1/relationships/posts',
+                  related: '/tags/1/posts'
+                }
+              }
+            }
+          },
+          {
+            type: 'tags',
+            id: '2',
+            attributes: {
+              name: 'whiny'
+            },
+            links: {
+              self: '/tags/2'
+            },
+            relationships: {
+              posts: {
+                links: {
+                  self: '/tags/2/relationships/posts',
+                  related: '/tags/2/posts'
+                }
+              }
+            }
+          },
+          {
+            type: 'tags',
+            id: '4',
+            attributes: {
+              name: 'happy'
+            },
+            links: {
+              self: '/tags/4'
+            },
+            relationships: {
+              posts: {
+                links: {
+                  self: '/tags/4/relationships/posts',
+                  related: '/tags/4/posts'
+                }
+              }
+            }
+          },
+          {
+            type: 'tags',
+            id: '5',
+            attributes: {
+              name: 'JR'
+            },
+            links: {
+              self: '/tags/5'
+            },
+            relationships: {
+              posts: {
+                links: {
+                  self: '/tags/5/relationships/posts',
+                  related: '/tags/5/posts'
+                }
+              }
+            }
+          },
+          {
+            type: 'comments',
+            id: '1',
+            attributes: {
+              body: 'what a dumb post'
+            },
+            links: {
+              self: '/comments/1'
+            },
+            relationships: {
+              author: {
+                links: {
+                  self: '/comments/1/relationships/author',
+                  related: '/comments/1/author'
+                }
+              },
+              post: {
+                links: {
+                  self: '/comments/1/relationships/post',
+                  related: '/comments/1/post'
+                }
+              },
+              tags: {
+                links: {
+                  self: '/comments/1/relationships/tags',
+                  related: '/comments/1/tags'
+                },
+                data: [
+                  {type: 'tags', id: '1'},
+                  {type: 'tags', id: '2'}
+                ]
+              }
+            }
+          },
+          {
+            type: 'comments',
+            id: '2',
+            attributes: {
+              body: 'i liked it'
+            },
+            links: {
+              self: '/comments/2'
+            },
+            relationships: {
+              author: {
+                links: {
+                  self: '/comments/2/relationships/author',
+                  related: '/comments/2/author'
+                }
+              },
+              post: {
+                links: {
+                  self: '/comments/2/relationships/post',
+                  related: '/comments/2/post'
+                }
+              },
+              tags: {
+                links: {
+                  self: '/comments/2/relationships/tags',
+                  related: '/comments/2/tags'
+                },
+                data: [
+                  {type: 'tags', id: '4'},
+                  {type: 'tags', id: '1'}
+                ]
+              }
+            }
+          },
+          {
+            type: 'comments',
+            id: '3',
+            attributes: {
+              body: 'Thanks man. Great post. But what is JR?'
+            },
+            links: {
+              self: '/comments/3'
+            },
+            relationships: {
+              author: {
+                links: {
+                  self: '/comments/3/relationships/author',
+                  related: '/comments/3/author'
+                }
+              },
+              post: {
+                links: {
+                  self: '/comments/3/relationships/post',
+                  related: '/comments/3/post'
+                }
+              },
+              tags: {
+                links: {
+                  self: '/comments/3/relationships/tags',
+                  related: '/comments/3/tags'
+                },
+                data: [
+                  {type: 'tags', id: '5'}
+                ]
+              }
+            }
+          }
+        ]
+      },
+      JSONAPI::ResourceSerializer.new(PostResource,
+                                      include: ['comments', 'comments.tags']).serialize_to_hash(posts)
+    )
   end
 
   def test_serializer_array_of_resources_limited_fields
@@ -1141,10 +1356,6 @@ class SerializerTest < ActionDispatch::IntegrationTest
                 links: {
                   self: '/comments/1/relationships/post',
                   related: '/comments/1/post'
-                },
-                data: {
-                  type: 'posts',
-                  id: '1'
                 }
               }
             }
@@ -1163,10 +1374,6 @@ class SerializerTest < ActionDispatch::IntegrationTest
                 links: {
                   self: '/comments/2/relationships/post',
                   related: '/comments/2/post'
-                },
-                data: {
-                  type: 'posts',
-                  id: '1'
                 }
               }
             }
@@ -1185,10 +1392,6 @@ class SerializerTest < ActionDispatch::IntegrationTest
                 links: {
                   self: '/comments/3/relationships/post',
                   related: '/comments/3/post'
-                },
-                data: {
-                  type: 'posts',
-                  id: '2'
                 }
               }
             }
@@ -1300,8 +1503,7 @@ class SerializerTest < ActionDispatch::IntegrationTest
               links: {
                 self: '/planets/8/relationships/planetType',
                 related: '/planets/8/planetType'
-              },
-              data: nil
+              }
             },
             tags: {
               links: {
@@ -1436,8 +1638,7 @@ class SerializerTest < ActionDispatch::IntegrationTest
               links: {
                 self: '/preferences/1/relationships/author',
                 related: '/preferences/1/author'
-              },
-              data: nil
+              }
             },
             friends: {
               links: {

--- a/test/unit/serializer/serializer_test.rb
+++ b/test/unit/serializer/serializer_test.rb
@@ -1682,4 +1682,54 @@ class SerializerTest < ActionDispatch::IntegrationTest
       JSONAPI::ResourceSerializer.new(FactResource).serialize_to_hash(facts)
     )
   end
+
+  def test_serializer_has_one
+    serialized = JSONAPI::ResourceSerializer.new(
+      Api::V5::AuthorResource,
+      include: ['author_detail']
+    ).serialize_to_hash(Api::V5::AuthorResource.new(Person.find(1)))
+
+    assert_hash_equals(
+      {
+        data: {
+          type: 'authors',
+          id: '1',
+          attributes: {
+            name: 'Joe Author',
+          },
+          links: {
+            self: '/api/v5/authors/1'
+          },
+          relationships: {
+            posts: {
+              links: {
+                self: '/api/v5/authors/1/relationships/posts',
+                related: '/api/v5/authors/1/posts'
+              }
+            },
+            authorDetail: {
+              links: {
+                self: '/api/v5/authors/1/relationships/authorDetail',
+                related: '/api/v5/authors/1/authorDetail'
+              },
+              data: {type: 'authorDetails', id: '1'}
+            }
+          }
+        },
+        included: [
+          {
+            type: 'authorDetails',
+            id: '1',
+            attributes: {
+              authorStuff: 'blah blah'
+            },
+            links: {
+              self: '/api/v5/authorDetails/1'
+            }
+          }
+        ]
+      },
+      serialized
+    )
+  end
 end


### PR DESCRIPTION
Splits the existing has_one association into has_one and belongs_to associations. These mirror the ActiveModel associations. This will be a breaking change as most existing has_one associations are likely to really be belongs_to associations. Users will need to edit their existing resources.

Fixes #300

Also note that this branch is based on #304.
