### PR TITLE
Prefer public_send to collaborating objects

### DIFF
--- a/lib/jsonapi/link_builder.rb
+++ b/lib/jsonapi/link_builder.rb
@@ -58,7 +58,7 @@ module JSONAPI
 
     def engine_path_from_resource_class(klass)
       path_name = engine_resources_path_name_from_class(klass)
-      engine_name.routes.url_helpers.send(path_name)
+      engine_name.routes.url_helpers.public_send(path_name)
     end
 
     def engine_primary_resources_path
@@ -71,7 +71,7 @@ module JSONAPI
 
     def engine_resource_path(source)
       resource_path_name = engine_resource_path_name_from_source(source)
-      engine_name.routes.url_helpers.send(resource_path_name, source.id)
+      engine_name.routes.url_helpers.public_send(resource_path_name, source.id)
     end
 
     def engine_resource_path_name_from_source(source)

--- a/lib/jsonapi/operation.rb
+++ b/lib/jsonapi/operation.rb
@@ -126,7 +126,7 @@ module JSONAPI
     def apply
       source_resource = @source_klass.find_by_key(@source_id, context: @context)
 
-      related_resource = source_resource.send(@association_type)
+      related_resource = source_resource.public_send(@association_type)
 
       return JSONAPI::ResourceOperationResult.new(:ok, related_resource)
 
@@ -152,7 +152,7 @@ module JSONAPI
     def apply
       source_resource = @source_klass.find_by_key(@source_id, context: @context)
 
-      related_resource = source_resource.send(@association_type,
+      related_resource = source_resource.public_send(@association_type,
                                               filters:  @filters,
                                               sort_criteria: @sort_criteria,
                                               paginator: @paginator)

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -28,7 +28,7 @@ module JSONAPI
     end
 
     def id
-      model.send(self.class._primary_key)
+      model.public_send(self.class._primary_key)
     end
 
     def is_new?
@@ -112,7 +112,7 @@ module JSONAPI
     # Override this on a resource to customize how the associated records
     # are fetched for a model. Particularly helpful for authorization.
     def records_for(association_name, _options = {})
-      model.send association_name
+      model.public_send association_name
     end
 
     private
@@ -166,9 +166,9 @@ module JSONAPI
         related_resource = association.resource_klass.find_by_key(association_key_value, context: @context)
 
         # TODO: Add option to skip relations that already exist instead of returning an error?
-        relation = @model.send(association.type).where(association.primary_key => association_key_value).first
+        relation = @model.public_send(association.type).where(association.primary_key => association_key_value).first
         if relation.nil?
-          @model.send(association.type) << related_resource.model
+          @model.public_send(association.type) << related_resource.model
         else
           fail JSONAPI::Exceptions::HasManyRelationExists.new(association_key_value)
         end
@@ -198,8 +198,8 @@ module JSONAPI
     def _replace_polymorphic_has_one_link(association_type, key_value, key_type)
       association = self.class._associations[association_type.to_sym]
 
-      model.send("#{association.foreign_key}=", key_value)
-      model.send("#{association.polymorphic_type}=", key_type.to_s.classify)
+      model.public_send("#{association.foreign_key}=", key_value)
+      model.public_send("#{association.polymorphic_type}=", key_type.to_s.classify)
 
       @save_needed = true
 
@@ -209,7 +209,7 @@ module JSONAPI
     def _remove_has_many_link(association_type, key)
       association = self.class._associations[association_type]
 
-      @model.send(association.type).delete(key)
+      @model.public_send(association.type).delete(key)
 
       :completed
     end
@@ -314,11 +314,11 @@ module JSONAPI
         @_attributes ||= {}
         @_attributes[attr] = options
         define_method attr do
-          @model.send(attr)
+          @model.public_send(attr)
         end unless method_defined?(attr)
 
         define_method "#{attr}=" do |value|
-          @model.send "#{attr}=", value
+          @model.public_send "#{attr}=", value
         end unless method_defined?("#{attr}=")
       end
 
@@ -696,7 +696,7 @@ module JSONAPI
             define_method foreign_key do
               records = public_send(associated_records_method_name)
               return records.collect do |record|
-                record.send(association.resource_klass._primary_key)
+                record.public_send(association.resource_klass._primary_key)
               end
             end unless method_defined?(foreign_key)
             define_method attr do |options = {}|

--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -132,7 +132,7 @@ module JSONAPI
       fields.each_with_object({}) do |name, hash|
         format = source.class._attribute_options(name)[:format]
         unless name == :id
-          hash[format_key(name)] = format_value(source.send(name), format)
+          hash[format_key(name)] = format_value(source.public_send(name), format)
         end
       end
     end
@@ -167,7 +167,7 @@ module JSONAPI
           # through the associations.
           if include_linkage || include_linked_children
             if association.is_a?(JSONAPI::Association::HasOne)
-              resource = source.send(name)
+              resource = source.public_send(name)
               if resource
                 id = resource.id
                 type = association.type_for_source(source)
@@ -179,7 +179,7 @@ module JSONAPI
                 end
               end
             elsif association.is_a?(JSONAPI::Association::HasMany)
-              resources = source.send(name)
+              resources = source.public_send(name)
               resources.each do |resource|
                 id = resource.id
                 associations_only = already_serialized?(type, id)
@@ -267,18 +267,18 @@ module JSONAPI
     # Extracts the foreign key value for a has_one association.
     def foreign_key_value(source, association)
       foreign_key = association.foreign_key
-      value = source.send(foreign_key)
+      value = source.public_send(foreign_key)
       IdValueFormatter.format(value)
     end
 
     def foreign_key_types_and_values(source, association)
       if association.is_a?(JSONAPI::Association::HasMany)
         if association.polymorphic?
-          source.model.send(association.name).pluck(:type, :id).map do |type, id|
+          source.model.public_send(association.name).pluck(:type, :id).map do |type, id|
             [type.pluralize, IdValueFormatter.format(id)]
           end
         else
-          source.send(association.foreign_key).map do |value|
+          source.public_send(association.foreign_key).map do |value|
             [association.type, IdValueFormatter.format(value)]
           end
         end


### PR DESCRIPTION
### Background

While upgrading to a recent release, we noticed due to failing tests that the resource object was accessing a private interface on our model. We traced this back to the `send` calls. The fix for our code was to specify a `:relation_name` option so that the appropriate interface is accessed. It would be nice for the relation object to complain earlier about the missing interface which was working by chance only because we had a private method matching the message it sent.
### Note

We've chosen to keep some of the `send` calls sent to the object itself. We did note that the jsonapi-resources test suite still passed even when changing these calls to `public_send`. However, we didn't feel confident enough in our knowledge of these calls to make the change here.
