### PR TITLE
Use source for errors instead of path

### DIFF
--- a/lib/jsonapi/error.rb
+++ b/lib/jsonapi/error.rb
@@ -1,6 +1,6 @@
 module JSONAPI
   class Error
-    attr_accessor :title, :detail, :id, :href, :code, :path, :links, :status
+    attr_accessor :title, :detail, :id, :href, :code, :source, :links, :status
 
     def initialize(options = {})
       @title          = options[:title]
@@ -12,7 +12,7 @@ module JSONAPI
                         else
                           options[:code]
                         end
-      @path           = options[:path]
+      @source         = options[:source]
       @links          = options[:links]
       @status         = options[:status]
     end

--- a/lib/jsonapi/exceptions.rb
+++ b/lib/jsonapi/exceptions.rb
@@ -312,7 +312,7 @@ module JSONAPI
                                  status: :unprocessable_entity,
                                  title: "#{format_key(element[0])} - #{message}",
                                  detail: message,
-                                 source: "/#{element[0]}")
+                                 source: { pointer: "/#{element[0]}" })
             end
           )
         end

--- a/lib/jsonapi/exceptions.rb
+++ b/lib/jsonapi/exceptions.rb
@@ -294,9 +294,10 @@ module JSONAPI
     end
 
     class ValidationErrors < Error
-      attr_accessor :messages
-      def initialize(messages)
+      attr_accessor :messages, :resource_associations
+      def initialize(messages, resource_associations)
         @messages = messages
+        @resource_associations = resource_associations
         @key_formatter = JSONAPI.configuration.key_formatter
       end
 
@@ -312,9 +313,19 @@ module JSONAPI
                                  status: :unprocessable_entity,
                                  title: "#{format_key(element[0])} - #{message}",
                                  detail: message,
-                                 source: { pointer: "/#{element[0]}" })
+                                 source: { pointer: pointer(element[0]) })
             end
           )
+        end
+      end
+
+      private
+
+      def pointer(attr_or_association_name)
+        if resource_associations.key?(attr_or_association_name)
+          "/data/relationships/#{attr_or_association_name}"
+        else
+          "/data/attributes/#{attr_or_association_name}"
         end
       end
     end

--- a/lib/jsonapi/exceptions.rb
+++ b/lib/jsonapi/exceptions.rb
@@ -295,9 +295,9 @@ module JSONAPI
 
     class ValidationErrors < Error
       attr_accessor :messages, :resource_associations
-      def initialize(messages, resource_associations)
-        @messages = messages
-        @resource_associations = resource_associations
+      def initialize(resource)
+        @messages = resource.model.errors.messages
+        @resource_associations = resource.class._associations.keys
         @key_formatter = JSONAPI.configuration.key_formatter
       end
 
@@ -322,7 +322,7 @@ module JSONAPI
       private
 
       def pointer(attr_or_association_name)
-        if resource_associations.key?(attr_or_association_name)
+        if resource_associations.include?(attr_or_association_name)
           "/data/relationships/#{attr_or_association_name}"
         else
           "/data/attributes/#{attr_or_association_name}"

--- a/lib/jsonapi/exceptions.rb
+++ b/lib/jsonapi/exceptions.rb
@@ -307,9 +307,9 @@ module JSONAPI
       end
 
       def errors
-        error_messages.map do |attr_key, messages|
+        error_messages.flat_map do |attr_key, messages|
           messages.map { |message| json_api_error(attr_key, message) }
-        end.flatten
+        end
       end
 
       private

--- a/lib/jsonapi/exceptions.rb
+++ b/lib/jsonapi/exceptions.rb
@@ -312,7 +312,7 @@ module JSONAPI
                                  status: :unprocessable_entity,
                                  title: "#{format_key(element[0])} - #{message}",
                                  detail: message,
-                                 path: "/#{element[0]}")
+                                 source: "/#{element[0]}")
             end
           )
         end

--- a/lib/jsonapi/exceptions.rb
+++ b/lib/jsonapi/exceptions.rb
@@ -370,7 +370,7 @@ module JSONAPI
       def initialize(page, value, msg = nil)
         @page = page
         @value = value
-        @msg = msg.nil? ? "#{value} is not a valid value for #{page} page parameter." : msg
+        @msg = msg || "#{value} is not a valid value for #{page} page parameter."
       end
 
       def errors

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -138,7 +138,10 @@ module JSONAPI
     # ```
     def _save
       unless @model.valid?
-        fail JSONAPI::Exceptions::ValidationErrors.new(@model.errors.messages)
+        fail JSONAPI::Exceptions::ValidationErrors.new(
+          @model.errors.messages,
+          self.class._associations
+        )
       end
 
       if defined? @model.save

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -138,10 +138,7 @@ module JSONAPI
     # ```
     def _save
       unless @model.valid?
-        fail JSONAPI::Exceptions::ValidationErrors.new(
-          @model.errors.messages,
-          self.class._associations
-        )
+        fail JSONAPI::Exceptions::ValidationErrors.new(self)
       end
 
       if defined? @model.save

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -391,11 +391,11 @@ class PostsControllerTest < ActionController::TestCase
 
     assert_response :unprocessable_entity
 
-    assert_equal "/author", json_response['errors'][0]['path']
+    assert_equal "/author", json_response['errors'][0]['source']
     assert_equal "can't be blank", json_response['errors'][0]['detail']
     assert_equal "author - can't be blank", json_response['errors'][0]['title']
 
-    assert_equal "/title", json_response['errors'][1]['path']
+    assert_equal "/title", json_response['errors'][1]['source']
     assert_equal "is too long (maximum is 35 characters)", json_response['errors'][1]['detail']
     assert_equal "title - is too long (maximum is 35 characters)", json_response['errors'][1]['title']
   end

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -391,11 +391,11 @@ class PostsControllerTest < ActionController::TestCase
 
     assert_response :unprocessable_entity
 
-    assert_equal "/author", json_response['errors'][0]['source']
+    assert_equal "/author", json_response['errors'][0]['source']['pointer']
     assert_equal "can't be blank", json_response['errors'][0]['detail']
     assert_equal "author - can't be blank", json_response['errors'][0]['title']
 
-    assert_equal "/title", json_response['errors'][1]['source']
+    assert_equal "/title", json_response['errors'][1]['source']['pointer']
     assert_equal "is too long (maximum is 35 characters)", json_response['errors'][1]['detail']
     assert_equal "title - is too long (maximum is 35 characters)", json_response['errors'][1]['title']
   end

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -391,11 +391,11 @@ class PostsControllerTest < ActionController::TestCase
 
     assert_response :unprocessable_entity
 
-    assert_equal "/author", json_response['errors'][0]['source']['pointer']
+    assert_equal "/data/relationships/author", json_response['errors'][0]['source']['pointer']
     assert_equal "can't be blank", json_response['errors'][0]['detail']
     assert_equal "author - can't be blank", json_response['errors'][0]['title']
 
-    assert_equal "/title", json_response['errors'][1]['source']['pointer']
+    assert_equal "/data/attributes/title", json_response['errors'][1]['source']['pointer']
     assert_equal "is too long (maximum is 35 characters)", json_response['errors'][1]['detail']
     assert_equal "title - is too long (maximum is 35 characters)", json_response['errors'][1]['title']
   end


### PR DESCRIPTION
The JSON API format specifies using a `source` key to reference the source
of the error in Error Objects (http://jsonapi.org/format/#error-objects).

Currently the key `path` is being used.

At the moment we are also getting a `path` that looks like: e.g. `/email` for an attribute `email`

The JSON API format specifies:

> `pointer`: a JSON Pointer [RFC6901] to the associated entity in the request document [e.g. "/data" for a primary data object, or "/data/attributes/title" for a specific attribute].

Should we update to specify that it is an attribute like: `/data/attributes/email`?

also I wasn't clear if we should also have `pointer` specified, to make it clear it is a JSON Pointer instead of a parameter as a string.
