### PR TITLE
Use NameError exception when model can not be resolved.

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -623,7 +623,7 @@ module JSONAPI
       def _model_class
         return @model if @model
         @model = _model_name.to_s.safe_constantize
-        fail "model could not be found for #{self.name}" if @model.nil?
+        fail NameError, "model could not be found for #{self.name}" if @model.nil?
         @model
       end
 

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -56,7 +56,7 @@ class ResourceTest < ActiveSupport::TestCase
   end
 
   def test_nil_model_class
-    error = assert_raises(StandardError) { NoMatchResource._model_class }
+    error = assert_raises(NameError) { NoMatchResource._model_class }
     assert_equal(
       error.message,
       "model could not be found for NoMatchResource"


### PR DESCRIPTION
  Odd, but `fail`ing without the exception type didn't always raise the same type of error. Tests passed on Travis, but not locally.
