### PR TITLE
Enable exception superclasses to be whitelisted.

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ The relationship methods (`relationship`, `has_one`, and `has_many`) support the
 
 `to_one` relationships support the additional option:
  * `foreign_key_on` - defaults to `:self`. To indicate that the foreign key is on the related resource specify `:related`.
- 
+
 Examples:
 
 ```ruby
@@ -338,7 +338,7 @@ class ContactResource < JSONAPI::Resource
 end
 ```
 
-Then a request could pass in a filter for example `http://example.com/contacts?filter[name_last]=Smith` and the system 
+Then a request could pass in a filter for example `http://example.com/contacts?filter[name_last]=Smith` and the system
 will find all people where the last name exactly matches Smith.
 
 ##### Default Filters
@@ -1276,8 +1276,9 @@ JSONAPI.configure do |config|
   # processing. If you want to use Rails' `rescue_from` macro to
   # catch this error and render a 403 status code, you should add
   # the `Pundit::NotAuthorizedError` to the `exception_class_whitelist`.
+  # Subclasses of the whitelisted classes will also be whitelisted.
   config.exception_class_whitelist = []
-  
+
   # Resource Linkage
   # Controls the serialization of resource linkage for non compound documents
   # NOTE: always_include_has_many_linkage_data is not currently implemented

--- a/lib/jsonapi/active_record_operations_processor.rb
+++ b/lib/jsonapi/active_record_operations_processor.rb
@@ -29,7 +29,7 @@ class ActiveRecordOperationsProcessor < JSONAPI::OperationsProcessor
     raise e
 
   rescue => e
-    if JSONAPI.configuration.exception_class_whitelist.include?(e.class)
+    if JSONAPI.configuration.exception_class_whitelist.any? { |k| e.class.ancestors.include?(k) }
       raise e
     else
       internal_server_error = JSONAPI::Exceptions::InternalServerError.new(e)

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -429,7 +429,7 @@ class ErrorRaisingOperationsProcessor < ActiveRecordOperationsProcessor
   def process_operation(operation)
     mock_operation = Minitest::Mock.new
     mock_operation.expect(:apply, true) do
-      raise PostsController::SpecialError
+      raise PostsController::SubSpecialError
     end
     super(mock_operation)
   end
@@ -445,6 +445,7 @@ end
 class PostsController < ActionController::Base
   include JSONAPI::ActsAsResourceController
   class SpecialError < StandardError; end
+  class SubSpecialError < PostsController::SpecialError; end
 
   # This is used to test that classes that are whitelisted are reraised by
   # the operations processor.


### PR DESCRIPTION
This makes it easy to reraise any type of exception (or groups of exception classes). I needed this for integration with a application monitoring service.
