### PR TITLE
fix validation error message attribute format

### DIFF
--- a/lib/jsonapi/exceptions.rb
+++ b/lib/jsonapi/exceptions.rb
@@ -323,10 +323,11 @@ module JSONAPI
       end
 
       def pointer(attr_or_relationship_name)
+        formatted_attr_or_relationship_name = format_key(attr_or_relationship_name)
         if resource_relationships.include?(attr_or_relationship_name)
-          "/data/relationships/#{attr_or_relationship_name}"
+          "/data/relationships/#{formatted_attr_or_relationship_name}"
         else
-          "/data/attributes/#{attr_or_relationship_name}"
+          "/data/attributes/#{formatted_attr_or_relationship_name}"
         end
       end
     end

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -289,6 +289,7 @@ class Preferences < ActiveRecord::Base
 end
 
 class Fact < ActiveRecord::Base
+  validates :spouse_name, :bio, presence: true
 end
 
 class Like < ActiveRecord::Base


### PR DESCRIPTION
The attributes needs to be properly formatted in validation messages as well (discovered it when using Ember Data server side validation messages), this PR fixes the problem. 
