### PR TITLE
fix singleton resource update action to not require id

### DIFF
--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -104,7 +104,7 @@ module JSONAPI
     def setup_update_action(params)
       parse_fields(params[:fields])
       parse_include_directives(params[:include])
-      parse_replace_operation(params.require(:data), params.require(:id))
+      parse_replace_operation(params.require(:data), params[:id])
     end
 
     def setup_destroy_action(params)
@@ -563,7 +563,7 @@ module JSONAPI
       end
     end
 
-    def parse_single_replace_operation(data, keys)
+    def parse_single_replace_operation(data, keys, id_key_presence_check_required: true)
       fail JSONAPI::Exceptions::MissingKey.new if data[:id].nil?
 
       type = data[:type]
@@ -572,7 +572,7 @@ module JSONAPI
       end
 
       key = data[:id]
-      unless keys.include?(key)
+      if id_key_presence_check_required && !keys.include?(key)
         fail JSONAPI::Exceptions::KeyNotIncludedInURL.new(key)
       end
 
@@ -596,7 +596,8 @@ module JSONAPI
           parse_single_replace_operation(object_params, keys)
         end
       else
-        parse_single_replace_operation(data, [keys])
+        parse_single_replace_operation(data, [keys],
+                                       id_key_presence_check_required: keys.present?)
       end
 
     rescue JSONAPI::Exceptions::Error => e

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -2101,6 +2101,18 @@ class Api::V2::PreferencesControllerTest < ActionController::TestCase
     get :show
     assert_response :success
   end
+
+  def test_update_singleton_resource_without_id
+    set_content_type_header!
+    patch :update,
+      data: {
+        id: "1",
+        type: "preferences",
+        attributes: {
+        }
+      }
+    assert_response :success
+  end
 end
 
 class Api::V1::PostsControllerTest < ActionController::TestCase


### PR DESCRIPTION
The singleton resource doesn't have `id` part in URL for update actions, so I think there's no need to check for its' presence and do any comparison with the `id` from the `data` in that case, for normal resources (non-singleton) the `id` is required on URL level anyway, so I think it's safe and shouldn't cause any regression.
