### PR TITLE
update to support non-standard primary key has many relationships

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -596,7 +596,7 @@ module JSONAPI
       end
 
       def _as_parent_key
-        @_as_parent_key ||= "#{_type.to_s.singularize}_#{_primary_key}"
+        @_as_parent_key ||= "#{_type.to_s.singularize}_id"
       end
 
       def _allowed_filters

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -744,7 +744,7 @@ module JSONAPI
 
               sort_criteria =  options.fetch(:sort_criteria, {})
               unless sort_criteria.nil? || sort_criteria.empty?
-                order_options = self.class.construct_order_options(sort_criteria)
+                order_options = relationship.resource_klass.construct_order_options(sort_criteria)
                 records = resource_klass.apply_sort(records, order_options)
               end
 

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -2645,7 +2645,7 @@ class Api::V1::MoonsControllerTest < ActionController::TestCase
                                   id: "1",
                                   type: "moons",
                                   links: {self: "http://test.host/moons/1"},
-                                  attributes: {name: "Titan", "description": "Best known of the Saturn moons."},
+                                  attributes: {name: "Titan", description: "Best known of the Saturn moons."},
                                   relationships: {
                                     planet: {links: {self: "http://test.host/moons/1/relationships/planet", related: "http://test.host/moons/1/planet"}},
                                     craters: {links: {self: "http://test.host/moons/1/relationships/craters", related: "http://test.host/moons/1/craters"}}}
@@ -2673,15 +2673,15 @@ class Api::V1::CratersControllerTest < ActionController::TestCase
                         data: [
                           {id:"A4D3",
                            type:"craters",
-                           links:{"self":"http://test.host/craters/A4D3"},
-                           attributes:{"code":"A4D3", "description":"Small crater"},
-                           relationships:{"moon":{"links":{"self":"http://test.host/craters/A4D3/relationships/moon", "related":"http://test.host/craters/A4D3/moon"}}}
+                           links:{self: "http://test.host/craters/A4D3"},
+                           attributes:{code: "A4D3", description: "Small crater"},
+                           relationships:{"moon": {links: {self: "http://test.host/craters/A4D3/relationships/moon", related: "http://test.host/craters/A4D3/moon"}}}
                           },
-                          {id:"S56D",
-                           type:"craters",
-                           links:{"self":"http://test.host/craters/S56D"},
-                           attributes:{"code":"S56D", "description":"Very large crater"},
-                           relationships:{"moon":{"links":{"self":"http://test.host/craters/S56D/relationships/moon", "related":"http://test.host/craters/S56D/moon"}}}
+                          {id: "S56D",
+                           type: "craters",
+                           links:{self: "http://test.host/craters/S56D"},
+                           attributes:{code: "S56D", description: "Very large crater"},
+                           relationships:{moon: {links: {self: "http://test.host/craters/S56D/relationships/moon", related: "http://test.host/craters/S56D/moon"}}}
                           }
                         ]
                       }

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -2675,7 +2675,7 @@ class Api::V1::CratersControllerTest < ActionController::TestCase
                            type:"craters",
                            links:{self: "http://test.host/craters/A4D3"},
                            attributes:{code: "A4D3", description: "Small crater"},
-                           relationships:{"moon": {links: {self: "http://test.host/craters/A4D3/relationships/moon", related: "http://test.host/craters/A4D3/moon"}}}
+                           relationships:{moon: {links: {self: "http://test.host/craters/A4D3/relationships/moon", related: "http://test.host/craters/A4D3/moon"}}}
                           },
                           {id: "S56D",
                            type: "craters",

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -2633,28 +2633,65 @@ class Api::V1::PlanetsControllerTest < ActionController::TestCase
     assert_response :unprocessable_entity
     assert_match /Save failed or was cancelled/, json_response['errors'][0]['detail']
   end
+end
 
-  class Api::V1::CratersControllerTest < ActionController::TestCase
-    def test_get_related_resources
-      get :get_related_resources, {moon_id: '1', relationship: 'craters', source: "api/v1/moons"}
+class Api::V1::MoonsControllerTest < ActionController::TestCase
+   def test_get_related_resource
+      get :get_related_resource, {crater_id: 'S56D', relationship: 'moon', source: "api/v1/craters"}
       assert_response :success
       assert_hash_equals json_response,
-                        {
-                          data: [
-                            {id:"A4D3",
-                             type:"craters",
-                             links:{"self":"http://test.host/craters/A4D3"},
-                             attributes:{"code":"A4D3", "description":"Small crater"},
-                             relationships:{"moon":{"links":{"self":"http://test.host/craters/A4D3/relationships/moon", "related":"http://test.host/craters/A4D3/moon"}}}
-                            },
-                            {id:"S56D",
-                             type:"craters",
-                             links:{"self":"http://test.host/craters/S56D"},
-                             attributes:{"code":"S56D", "description":"Very large crater"},
-                             relationships:{"moon":{"links":{"self":"http://test.host/craters/S56D/relationships/moon", "related":"http://test.host/craters/S56D/moon"}}}
-                            }
-                          ]
-                        }
-    end
+                              {
+                                data: {
+                                  id: "1",
+                                  type: "moons",
+                                  links: {self: "http://test.host/moons/1"},
+                                  attributes: {name: "Titan", "description": "Best known of the Saturn moons."},
+                                  relationships: {
+                                    planet: {links: {self: "http://test.host/moons/1/relationships/planet", related: "http://test.host/moons/1/planet"}},
+                                    craters: {links: {self: "http://test.host/moons/1/relationships/craters", related: "http://test.host/moons/1/craters"}}}
+                                  }
+                                }
+
+   end
+end
+
+class Api::V1::CratersControllerTest < ActionController::TestCase
+  def test_show_single
+    get :show, {id: 'S56D'}
+    assert_response :success
+    assert json_response['data'].is_a?(Hash)
+    assert_equal 'S56D', json_response['data']['attributes']['code']
+    assert_equal 'Very large crater', json_response['data']['attributes']['description']
+    assert_nil json_response['included']
+  end
+
+  def test_get_related_resources
+    get :get_related_resources, {moon_id: '1', relationship: 'craters', source: "api/v1/moons"}
+    assert_response :success
+    assert_hash_equals json_response,
+                      {
+                        data: [
+                          {id:"A4D3",
+                           type:"craters",
+                           links:{"self":"http://test.host/craters/A4D3"},
+                           attributes:{"code":"A4D3", "description":"Small crater"},
+                           relationships:{"moon":{"links":{"self":"http://test.host/craters/A4D3/relationships/moon", "related":"http://test.host/craters/A4D3/moon"}}}
+                          },
+                          {id:"S56D",
+                           type:"craters",
+                           links:{"self":"http://test.host/craters/S56D"},
+                           attributes:{"code":"S56D", "description":"Very large crater"},
+                           relationships:{"moon":{"links":{"self":"http://test.host/craters/S56D/relationships/moon", "related":"http://test.host/craters/S56D/moon"}}}
+                          }
+                        ]
+                      }
+  end
+
+  def test_show_relationship
+    get :show_relationship, {crater_id: 'S56D', relationship: 'moon'}
+
+    assert_response :success
+    assert_equal "moons", json_response['data']['type']
+    assert_equal "1", json_response['data']['id']
   end
 end

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -2633,4 +2633,28 @@ class Api::V1::PlanetsControllerTest < ActionController::TestCase
     assert_response :unprocessable_entity
     assert_match /Save failed or was cancelled/, json_response['errors'][0]['detail']
   end
+
+  class Api::V1::CratersControllerTest < ActionController::TestCase
+    def test_get_related_resources
+      get :get_related_resources, {moon_id: '1', relationship: 'craters', source: "api/v1/moons"}
+      assert_response :success
+      assert_hash_equals json_response,
+                        {
+                          data: [
+                            {id:"A4D3",
+                             type:"craters",
+                             links:{"self":"http://test.host/craters/A4D3"},
+                             attributes:{"code":"A4D3", "description":"Small crater"},
+                             relationships:{"moon":{"links":{"self":"http://test.host/craters/A4D3/relationships/moon", "related":"http://test.host/craters/A4D3/moon"}}}
+                            },
+                            {id:"S56D",
+                             type:"craters",
+                             links:{"self":"http://test.host/craters/S56D"},
+                             attributes:{"code":"S56D", "description":"Very large crater"},
+                             relationships:{"moon":{"links":{"self":"http://test.host/craters/S56D/relationships/moon", "related":"http://test.host/craters/S56D/moon"}}}
+                            }
+                          ]
+                        }
+    end
+  end
 end

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -886,6 +886,10 @@ class CraterResource < JSONAPI::Resource
   attribute :description
 
   has_one :moon
+
+  def self.verify_key(key, context = nil)
+    key && String(key)
+  end
 end
 
 class PreferencesResource < JSONAPI::Resource

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -92,6 +92,12 @@ ActiveRecord::Schema.define do
     t.integer :planet_id
   end
 
+  create_table :craters, id: false, force: true do |t|
+    t.string  :code
+    t.string  :description
+    t.integer :moon_id
+  end
+
   create_table :preferences, force: true do |t|
     t.integer :person_id
     t.boolean :advanced_mode, default: false
@@ -281,6 +287,14 @@ end
 
 class Moon < ActiveRecord::Base
   belongs_to :planet
+
+  has_many :craters
+end
+
+class Crater < ActiveRecord::Base
+  self.primary_key = :code
+
+  belongs_to :moon
 end
 
 class Preferences < ActiveRecord::Base
@@ -360,7 +374,7 @@ class BreedData
   end
 end
 
-class CustomerOrder < ActiveRecord::Base
+class Customer < ActiveRecord::Base
   has_many :purchase_orders
 end
 
@@ -522,6 +536,9 @@ module Api
     end
 
     class MoonsController < JSONAPI::ResourceController
+    end
+
+    class CratersController < JSONAPI::ResourceController
     end
 
     class LikesController < JSONAPI::ResourceController
@@ -861,6 +878,14 @@ class MoonResource < JSONAPI::Resource
   attribute :description
 
   has_one :planet
+  has_many :craters
+end
+
+class CraterResource < JSONAPI::Resource
+  attribute :code
+  attribute :description
+
+  has_one :moon
 end
 
 class PreferencesResource < JSONAPI::Resource
@@ -952,6 +977,7 @@ module Api
     PlanetResource = PlanetResource.dup
     PlanetTypeResource = PlanetTypeResource.dup
     MoonResource = MoonResource.dup
+    CraterResource = CraterResource.dup
     PreferencesResource = PreferencesResource.dup
     EmployeeResource = EmployeeResource.dup
     FriendResource = FriendResource.dup
@@ -1226,6 +1252,8 @@ saturn = Planet.create(name: 'Satern',
                        description: 'Saturn is the sixth planet from the Sun and the second largest planet in the Solar System, after Jupiter.',
                        planet_type_id: planetoid.id)
 titan = Moon.create(name:'Titan', description: 'Best known of the Saturn moons.', planet_id: saturn.id)
+crater1 = Crater.create(code:'S56D', description: 'Very large crater', moon_id: titan.id)
+crater2 = Crater.create(code:'A4D3', description: 'Small crater', moon_id: titan.id)
 makemake = Planet.create(name: 'Makemake', description: 'A small planetoid in the Kuiperbelt.', planet_type_id: planetoid.id)
 uranus = Planet.create(name: 'Uranus', description: 'Insert adolescent jokes here.', planet_type_id: gas_giant.id)
 jupiter = Planet.create(name: 'Jupiter', description: 'A gas giant.', planet_type_id: gas_giant.id)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -110,6 +110,7 @@ TestApp.routes.draw do
   jsonapi_resources :planets
   jsonapi_resources :planet_types
   jsonapi_resources :moons
+  jsonapi_resources :craters
   jsonapi_resources :preferences
   jsonapi_resources :facts
   jsonapi_resources :categories
@@ -130,6 +131,7 @@ TestApp.routes.draw do
       jsonapi_resources :planets
       jsonapi_resources :planet_types
       jsonapi_resources :moons
+      jsonapi_resources :craters
       jsonapi_resources :preferences
       jsonapi_resources :likes
     end


### PR DESCRIPTION
Fixes: https://github.com/cerebris/jsonapi-resources/issues/332

This PR fixes some issues when you have a model that specifies a non-standard primary key. See test/fixtures/active_record.rb for an example model.

The first commit fixes the get_related_resources where the order by cause of the sql query was using the wrong primary key.

The second commit resolve an issue where the code is incorrectly looking for a param postfixed with the primary key of the parent model (`_as_parent_key`) but the router generates routes that always end in _id. 
