### PR TITLE
Remove the permit check for params other than id on a remove request.

### DIFF
--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -604,7 +604,7 @@ module JSONAPI
     end
 
     def parse_remove_operation(params)
-      keys = parse_key_array(params.permit(:id)[:id])
+      keys = parse_key_array(params.require(:id))
 
       keys.each do |key|
         @operations.push JSONAPI::RemoveResourceOperation.new(
@@ -613,8 +613,6 @@ module JSONAPI
           resource_id: key
         )
       end
-    rescue ActionController::UnpermittedParameters => e
-      @errors.concat(JSONAPI::Exceptions::ParametersNotAllowed.new(e.params).errors)
     rescue JSONAPI::Exceptions::Error => e
       @errors.concat(e.errors)
     end

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -1427,13 +1427,6 @@ class PostsControllerTest < ActionController::TestCase
     assert_equal initial_count, Post.count
   end
 
-  def test_delete_extra_param
-    initial_count = Post.count
-    delete :destroy, {id: '4', asdfg: 'aaaa'}
-    assert_response :bad_request
-    assert_equal initial_count, Post.count
-  end
-
   def test_show_to_one_relationship
     get :show_relationship, {post_id: '1', relationship: 'author'}
     assert_response :success


### PR DESCRIPTION
Does not currently take any action to store these params, though I think we should do this soon.

Fixes #334
