### PR TITLE
fix parse_sort_criteria when sort is empty

### DIFF
--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -234,7 +234,7 @@ module JSONAPI
     end
 
     def parse_sort_criteria(sort_criteria)
-      return unless sort_criteria
+      return unless sort_criteria.present?
 
       @sort_criteria = CSV.parse_line(URI.unescape(sort_criteria)).collect do |sort|
         if sort.start_with?('-')

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -205,6 +205,12 @@ class PostsControllerTest < ActionController::TestCase
     assert_equal 3, json_response['data'].size
   end
 
+  def test_sorting_blank
+    get :index, {sort: ''}
+
+    assert_response :success
+  end
+
   def test_sorting_asc
     get :index, {sort: 'title'}
 


### PR DESCRIPTION
fix #270 
