### PR TITLE
Adds abstract option

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ end
 Resources that are not backed by a model (purely used as base classes for other resources) should be declared as 
 abstract.
 
+Because abstract resources do not expect to be backed by a model, they won't attempt to discover the model class
+or any of its relationships.
 
 ```ruby
 class BaseResource < JSONAPI::Resource

--- a/README.md
+++ b/README.md
@@ -54,6 +54,23 @@ class ContactResource < JSONAPI::Resource
 end
 ```
 
+##### Abstract Resources
+
+Resources that are not backed by a model (purely used as base classes for other resources) should be declared as 
+abstract.
+
+
+```ruby
+class BaseResource < JSONAPI::Resource
+  abstract
+  
+  has_one :creator
+end
+
+class ContactResource < BaseResource
+end
+```
+
 #### Attributes
 
 Any of a resource's attributes that are accessible must be explicitly declared. Single attributes can be declared using

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -648,7 +648,11 @@ module Api
 end
 
 ### RESOURCES
-class PersonResource < JSONAPI::Resource
+class BaseResource < JSONAPI::Resource
+  abstract
+end
+
+class PersonResource < BaseResource
   attributes :id, :name, :email
   attribute :date_joined, format: :date_with_timezone
 

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -11,6 +11,10 @@ end
 class NoMatchResource < JSONAPI::Resource
 end
 
+class NoMatchAbstractResource < JSONAPI::Resource
+  abstract
+end
+
 class CatResource < JSONAPI::Resource
   attribute :id
   attribute :name
@@ -55,12 +59,25 @@ class ResourceTest < ActiveSupport::TestCase
     assert_equal(PostResource._model_class, Post)
   end
 
+  def test_base_resource_abstract
+    assert BaseResource._abstract
+  end
+
+  def test_derived_not_abstract
+    assert PersonResource < BaseResource
+    refute PersonResource._abstract
+  end
+
   def test_nil_model_class
-    error = assert_raises(NameError) { NoMatchResource._model_class }
-    assert_equal(
-      error.message,
-      "model could not be found for NoMatchResource"
-    )
+    assert_output nil, "[MODEL NOT FOUND] Model could not be found for NoMatchResource. If this a base Resource declare it as abstract.\n" do
+      assert_nil NoMatchResource._model_class
+    end
+  end
+
+  def test_nil_abstract_model_class
+    assert_output nil, '' do
+      assert_nil NoMatchAbstractResource._model_class
+    end
   end
 
   def test_model_alternate


### PR DESCRIPTION
Change exception to a warning in _model_class if called for a non abstract resource.

This modifies the behavior discussed in #321
