### PR TITLE
Fix camel case scope converting inside link_builder

### DIFF
--- a/lib/jsonapi/link_builder.rb
+++ b/lib/jsonapi/link_builder.rb
@@ -77,7 +77,7 @@ module JSONAPI
 
     def engine_resource_path_name_from_source(source)
       scopes         = module_scopes_from_class(source.class)[1..-1]
-      base_path_name = scopes.map { |scope| scope.downcase }.join("_")
+      base_path_name = scopes.map { |scope| scope.underscore }.join("_")
       end_path_name  = source.class._type.to_s.singularize
       "#{ base_path_name }_#{ end_path_name }_path"
     end
@@ -88,7 +88,7 @@ module JSONAPI
 
     def engine_resources_path_name_from_class(klass)
       scopes         = module_scopes_from_class(klass)[1..-1]
-      base_path_name = scopes.map { |scope| scope.downcase }.join("_")
+      base_path_name = scopes.map { |scope| scope.underscore }.join("_")
       end_path_name  = klass._type.to_s
       "#{ base_path_name }_#{ end_path_name }_path"
     end
@@ -101,7 +101,7 @@ module JSONAPI
       scopes = module_scopes_from_class(klass)
 
       unless scopes.empty?
-        "/#{ scopes.map(&:downcase).join('/') }/"
+        "/#{ scopes.map(&:underscore).join('/') }/"
       else
         "/"
       end

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -1233,8 +1233,22 @@ module Api
   end
 end
 
+module AdminApi
+  module V1
+    class PersonResource < JSONAPI::Resource
+    end
+  end
+end
+
 module MyEngine
   module Api
+    module V1
+      class PersonResource < JSONAPI::Resource
+      end
+    end
+  end
+
+  module AdminApi
     module V1
       class PersonResource < JSONAPI::Resource
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -208,11 +208,23 @@ TestApp.routes.draw do
     end
   end
 
+  namespace :admin_api do
+    namespace :v1 do
+      jsonapi_resources :people
+    end
+  end
+
   mount MyEngine::Engine => "/boomshaka", as: :my_engine
 end
 
 MyEngine::Engine.routes.draw do
   namespace :api do
+    namespace :v1 do
+      jsonapi_resources :people
+    end
+  end
+
+  namespace :admin_api do
     namespace :v1 do
       jsonapi_resources :people
     end

--- a/test/unit/serializer/link_builder_test.rb
+++ b/test/unit/serializer/link_builder_test.rb
@@ -63,6 +63,22 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
     assert_equal expected_link, builder.self_link(source)
   end
 
+  def test_self_link_with_engine_app_and_camel_case_scope
+    primary_resource_klass = MyEngine::AdminApi::V1::PersonResource
+
+    config = {
+      base_url: @base_url,
+      route_formatter: @route_formatter,
+      primary_resource_klass: primary_resource_klass,
+    }
+
+    builder = JSONAPI::LinkBuilder.new(config)
+    source  = primary_resource_klass.new(@steve)
+    expected_link = "#{ @base_url }/boomshaka/admin_api/v1/people/#{ source.id }"
+
+    assert_equal expected_link, builder.self_link(source)
+  end
+
   def test_primary_resources_url_for_regular_app
     config = {
       base_url: @base_url,
@@ -167,6 +183,20 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
     assert_equal expected_link, builder.query_link(query)
   end
 
+  def test_query_link_for_regular_app_with_camel_case_scope
+    config = {
+      base_url: @base_url,
+      route_formatter: @route_formatter,
+      primary_resource_klass: AdminApi::V1::PersonResource
+    }
+
+    query         = { page: { offset: 0, limit: 12 } }
+    builder       = JSONAPI::LinkBuilder.new(config)
+    expected_link = "#{ @base_url }/admin_api/v1/people?page%5Blimit%5D=12&page%5Boffset%5D=0"
+
+    assert_equal expected_link, builder.query_link(query)
+  end
+
   def test_query_link_for_engine
     config = {
       base_url: @base_url,
@@ -177,6 +207,20 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
     query         = { page: { offset: 0, limit: 12 } }
     builder       = JSONAPI::LinkBuilder.new(config)
     expected_link = "#{ @base_url }/boomshaka/api/v1/people?page%5Blimit%5D=12&page%5Boffset%5D=0"
+
+    assert_equal expected_link, builder.query_link(query)
+  end
+
+  def test_query_link_for_engine_with_camel_case_scope
+    config = {
+      base_url: @base_url,
+      route_formatter: @route_formatter,
+      primary_resource_klass: MyEngine::AdminApi::V1::PersonResource
+    }
+
+    query         = { page: { offset: 0, limit: 12 } }
+    builder       = JSONAPI::LinkBuilder.new(config)
+    expected_link = "#{ @base_url }/boomshaka/admin_api/v1/people?page%5Blimit%5D=12&page%5Boffset%5D=0"
 
     assert_equal expected_link, builder.query_link(query)
   end


### PR DESCRIPTION
Currently camelcase scopes are incorrectly evaluated, so that `AdminApi` becomes `adminapi` instead of `admin_api`. 
As a result `url_helper` receives invalid method and crashes the app. 
