### PR TITLE
Return HTTP 400 Bad Request when include is present and not allowed

### DIFF
--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -196,6 +196,10 @@ module JSONAPI
     def parse_include_directives(include)
       return if include.nil?
 
+      unless JSONAPI.configuration.allowed_request_params.include?(:include)
+        fail JSONAPI::Exceptions::ParametersNotAllowed.new([:include])
+      end
+
       included_resources = CSV.parse_line(include)
       return if included_resources.nil?
 

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -276,6 +276,14 @@ class PostsControllerTest < ActionController::TestCase
     assert_equal 2, json_response['included'].size
   end
 
+  def test_show_single_with_include_disallowed
+    JSONAPI.configuration.allowed_request_params.delete(:include)
+    get :show, {id: '1', include: 'comments'}
+    assert_response :bad_request
+  ensure
+    JSONAPI.configuration.allowed_request_params << :include
+  end
+
   def test_show_single_with_fields
     get :show, {id: '1', fields: {posts: 'author'}}
     assert_response :success

--- a/test/integration/requests/request_test.rb
+++ b/test/integration/requests/request_test.rb
@@ -691,4 +691,16 @@ class RequestTest < ActionDispatch::IntegrationTest
     assert_equal 204, status
   end
 
+  def test_include_parameter_allowed
+    get '/api/v2/books/1/book_comments?include=author'
+    assert_equal 200, status
+  end
+
+  def test_include_parameter_not_allowed
+    JSONAPI.configuration.allowed_request_params.delete(:include)
+    get '/api/v2/books/1/book_comments?include=author'
+    assert_equal 400, status
+  ensure
+    JSONAPI.configuration.allowed_request_params << :include
+  end
 end


### PR DESCRIPTION
From http://jsonapi.org/format/#fetching-includes:

> If an endpoint does not support the include parameter, it must respond with
> 400 Bad Request to any requests that include it.

This change makes jsonapi-resources adhere to cases where
`allowed_request_params` has been configured to not allow the `include`
parameter. Previously, this configuration option was silently ignored and
resources were included in the output regardless.
