### PR TITLE
Fix for when ActiveRecord is not loaded.

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -686,7 +686,7 @@ module JSONAPI
           check_reserved_relationship_name(attr)
 
           # Initialize from an ActiveRecord model's properties
-          if _model_class && _model_class < ActiveRecord::Base
+          if _model_class && _model_class.ancestors.collect{|ancestor| ancestor.name}.include?('ActiveRecord::Base')
             model_association = _model_class.reflect_on_association(attr)
             if model_association
               options[:class_name] ||= model_association.class_name


### PR DESCRIPTION
Check if model is derived from ActiveRecord::Base by name, not class.

Hopefully fixes #360
