### PR TITLE
fix bug when no related resource

### DIFF
--- a/lib/jsonapi/operation.rb
+++ b/lib/jsonapi/operation.rb
@@ -185,7 +185,7 @@ module JSONAPI
                                               sort_criteria: @sort_criteria,
                                               paginator: @paginator)
 
-      return JSONAPI::RelatedResourcesOperationResult.new(:ok, source_resource, related_resource, options)
+      return JSONAPI::RelatedResourcesOperationResult.new(:ok, source_resource, @relationship_type, related_resource, options)
 
     rescue JSONAPI::Exceptions::Error => e
       return JSONAPI::ErrorsOperationResult.new(e.errors[0].code, e.errors)

--- a/lib/jsonapi/operation_result.rb
+++ b/lib/jsonapi/operation_result.rb
@@ -43,10 +43,11 @@ module JSONAPI
   end
 
   class RelatedResourcesOperationResult < ResourcesOperationResult
-    attr_accessor :source_resource
+    attr_accessor :source_resource, :_type
 
-    def initialize(code, source_resource, resources, options = {})
+    def initialize(code, source_resource, type, resources, options = {})
       @source_resource = source_resource
+      @_type = type
       super(code, resources, options)
     end
   end

--- a/lib/jsonapi/response_document.rb
+++ b/lib/jsonapi/response_document.rb
@@ -70,16 +70,14 @@ module JSONAPI
 
         # Build pagination links
         if result.is_a?(JSONAPI::ResourcesOperationResult) || result.is_a?(JSONAPI::RelatedResourcesOperationResult)
-          if result.resources.size > 0
             result.pagination_params.each_pair do |link_name, params|
               if result.is_a?(JSONAPI::RelatedResourcesOperationResult)
-                relationship = result.source_resource.class._relationships[result.resources.first.class._type]
+                relationship = result.source_resource.class._relationships[result._type.to_sym]
                 links[link_name] = serializer.url_generator.relationships_related_link(result.source_resource, relationship, query_params(params))
               else
                 links[link_name] = serializer.find_link(query_params(params))
               end
             end
-          end
         end
       end
 

--- a/lib/jsonapi/response_document.rb
+++ b/lib/jsonapi/response_document.rb
@@ -70,12 +70,14 @@ module JSONAPI
 
         # Build pagination links
         if result.is_a?(JSONAPI::ResourcesOperationResult) || result.is_a?(JSONAPI::RelatedResourcesOperationResult)
-          result.pagination_params.each_pair do |link_name, params|
-            if result.is_a?(JSONAPI::RelatedResourcesOperationResult)
-              relationship = result.source_resource.class._relationships[result.resources.first.class._type]
-              links[link_name] = serializer.url_generator.relationships_related_link(result.source_resource, relationship, query_params(params))
-            else
-              links[link_name] = serializer.find_link(query_params(params))
+          if result.resources.size > 0
+            result.pagination_params.each_pair do |link_name, params|
+              if result.is_a?(JSONAPI::RelatedResourcesOperationResult)
+                relationship = result.source_resource.class._relationships[result.resources.first.class._type]
+                links[link_name] = serializer.url_generator.relationships_related_link(result.source_resource, relationship, query_params(params))
+              else
+                links[link_name] = serializer.find_link(query_params(params))
+              end
             end
           end
         end

--- a/test/integration/requests/request_test.rb
+++ b/test/integration/requests/request_test.rb
@@ -398,6 +398,13 @@ class RequestTest < ActionDispatch::IntegrationTest
     assert_equal 'http://www.example.com/api/v2/books/1/book_comments?page%5Blimit%5D=10&page%5Boffset%5D=41', json_response['links']['last']
   end
 
+  def test_pagination_related_resources_without_related
+    Api::V2::BookResource.paginator :offset
+    Api::V2::BookCommentResource.paginator :offset
+    get '/api/v2/books/10/book_comments'
+    assert_equal 200, status
+  end
+
   def test_pagination_related_resources_data_includes
     Api::V2::BookResource.paginator :offset
     Api::V2::BookCommentResource.paginator :offset

--- a/test/integration/requests/request_test.rb
+++ b/test/integration/requests/request_test.rb
@@ -403,6 +403,9 @@ class RequestTest < ActionDispatch::IntegrationTest
     Api::V2::BookCommentResource.paginator :offset
     get '/api/v2/books/10/book_comments'
     assert_equal 200, status
+    assert_nil json_response['links']['next']
+    assert_equal 'http://www.example.com/api/v2/books/10/book_comments?page%5Blimit%5D=10&page%5Boffset%5D=0', json_response['links']['first']
+    assert_equal 'http://www.example.com/api/v2/books/10/book_comments?page%5Blimit%5D=10&page%5Boffset%5D=0', json_response['links']['last']
   end
 
   def test_pagination_related_resources_data_includes
@@ -412,6 +415,17 @@ class RequestTest < ActionDispatch::IntegrationTest
     assert_equal 200, status
     assert_equal 10, json_response['data'].size
     assert_equal 'This is comment 18 on book 1.', json_response['data'][9]['attributes']['body']
+  end
+
+  def test_pagination_empty_results
+    Api::V2::BookResource.paginator :offset
+    Api::V2::BookCommentResource.paginator :offset
+    get '/api/v2/books?filter[id]=2000&page[limit]=10'
+    assert_equal 200, status
+    assert_equal 0, json_response['data'].size
+    assert_nil json_response['links']['next']
+    assert_equal 'http://www.example.com/api/v2/books?filter%5Bid%5D=2000&page%5Blimit%5D=10&page%5Boffset%5D=0', json_response['links']['first']
+    assert_equal 'http://www.example.com/api/v2/books?filter%5Bid%5D=2000&page%5Blimit%5D=10&page%5Boffset%5D=0', json_response['links']['last']
   end
 
   # def test_pagination_related_resources_data_includes


### PR DESCRIPTION
Unfortunately my PR #366 has a bug. When there arn't any related resources 500 error is raised.
So this PR is going to fix the error. 
Additionally the fix removes pagination links from all responses with empty resources, which I think is good )
