### PR TITLE
Fix pagination links for small and empty result sizes.

### DIFF
--- a/lib/jsonapi/paginator.rb
+++ b/lib/jsonapi/paginator.rb
@@ -74,8 +74,12 @@ class OffsetPaginator < JSONAPI::Paginator
     end
 
     if record_count
+      last_offset = record_count - @limit
+
+      last_offset = 0 if last_offset < 0
+
       links_page_params['last'] = {
-        'offset' => record_count - @limit,
+        'offset' => last_offset,
         'limit' => @limit
       }
     end
@@ -159,7 +163,7 @@ class PagedPaginator < JSONAPI::Paginator
 
     if record_count
       links_page_params['last'] = {
-        'number' => page_count,
+        'number' => page_count == 0 ? 1 : page_count,
         'size' => @size
       }
     end

--- a/test/unit/pagination/offset_paginator_test.rb
+++ b/test/unit/pagination/offset_paginator_test.rb
@@ -82,6 +82,45 @@ class OffsetPaginatorTest < ActiveSupport::TestCase
     assert_equal 0, paginator.offset
   end
 
+  def test_offset_links_page_params_empty_results
+    params = ActionController::Parameters.new(
+      {
+        limit: 5,
+        offset: 0
+      }
+    )
+
+    paginator = OffsetPaginator.new(params)
+    links_params = paginator.links_page_params(record_count: 0)
+
+    assert_equal 2, links_params.size
+
+    assert_equal 5, links_params['first']['limit']
+    assert_equal 0, links_params['first']['offset']
+
+    assert_equal 5, links_params['last']['limit']
+    assert_equal 0, links_params['last']['offset']
+  end
+
+  def test_offset_links_page_params_small_resultsets
+    params = ActionController::Parameters.new(
+      {
+        limit: 5,
+        offset: 0
+      }
+    )
+
+    paginator = OffsetPaginator.new(params)
+    links_params = paginator.links_page_params(record_count: 3)
+
+    assert_equal 2, links_params.size
+
+    assert_equal 5, links_params['first']['limit']
+    assert_equal 0, links_params['first']['offset']
+
+    assert_equal 5, links_params['last']['limit']
+    assert_equal 0, links_params['last']['offset']
+  end
 
   def test_offset_links_page_params_large_data_set_start
     params = ActionController::Parameters.new(

--- a/test/unit/pagination/paged_paginator_test.rb
+++ b/test/unit/pagination/paged_paginator_test.rb
@@ -82,6 +82,45 @@ class PagedPaginatorTest < ActiveSupport::TestCase
     assert_equal 1, paginator.number
   end
 
+  def test_paged_links_page_params_empty_results
+    params = ActionController::Parameters.new(
+      {
+        size: 5,
+        number: 1
+      }
+    )
+
+    paginator = PagedPaginator.new(params)
+    links_params = paginator.links_page_params(record_count: 0)
+
+    assert_equal 2, links_params.size
+
+    assert_equal 5, links_params['first']['size']
+    assert_equal 1, links_params['first']['number']
+
+    assert_equal 5, links_params['last']['size']
+    assert_equal 1, links_params['last']['number']
+  end
+
+  def test_paged_links_page_params_small_resultsets
+    params = ActionController::Parameters.new(
+      {
+        size: 5,
+        number: 1
+      }
+    )
+
+    paginator = PagedPaginator.new(params)
+    links_params = paginator.links_page_params(record_count: 3)
+
+    assert_equal 2, links_params.size
+
+    assert_equal 5, links_params['first']['size']
+    assert_equal 1, links_params['first']['number']
+
+    assert_equal 5, links_params['last']['size']
+    assert_equal 1, links_params['last']['number']
+  end
 
   def test_paged_links_page_params_large_data_set_start_full_pages
     params = ActionController::Parameters.new(


### PR DESCRIPTION
When looking at #372 that the paginators were generating the invalid parameters with small and empty sized results.
