### PR TITLE
Fix related count

### DIFF
--- a/lib/jsonapi/operation.rb
+++ b/lib/jsonapi/operation.rb
@@ -158,7 +158,7 @@ module JSONAPI
     end
 
     def records
-      related_resource_records = source_resource.records_for(@relationship_type)
+      related_resource_records = source_resource.public_send(@relationship_type)
       @resource_klass.filter_records(@filters, @options, related_resource_records)
     end
 

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -111,8 +111,8 @@ module JSONAPI
 
     # Override this on a resource to customize how the associated records
     # are fetched for a model. Particularly helpful for authorization.
-    def records_for(relationship_name, _options = {})
-      model.public_send relationship_name
+    def records_for(relation_name, _options = {})
+      model.public_send relation_name
     end
 
     private

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -1026,6 +1026,8 @@ module Api
         end
       }
 
+      has_many :aliased_comments, class_name: 'BookComments', relation_name: :approved_book_comments
+
       filters :banned, :book_comments
 
       class << self

--- a/test/integration/requests/request_test.rb
+++ b/test/integration/requests/request_test.rb
@@ -410,7 +410,7 @@ class RequestTest < ActionDispatch::IntegrationTest
     get '/api/v2/books/1/book_comments?page[limit]=10'
     assert_equal 'http://www.example.com/api/v2/books/1/book_comments?page%5Blimit%5D=10&page%5Boffset%5D=0', json_response['links']['first']
     assert_equal 'http://www.example.com/api/v2/books/1/book_comments?page%5Blimit%5D=10&page%5Boffset%5D=10', json_response['links']['next']
-    assert_equal 'http://www.example.com/api/v2/books/1/book_comments?page%5Blimit%5D=10&page%5Boffset%5D=41', json_response['links']['last']
+    assert_equal 'http://www.example.com/api/v2/books/1/book_comments?page%5Blimit%5D=10&page%5Boffset%5D=16', json_response['links']['last']
   end
 
   def test_pagination_related_resources_links_meta
@@ -418,10 +418,10 @@ class RequestTest < ActionDispatch::IntegrationTest
     Api::V2::BookCommentResource.paginator :offset
     JSONAPI.configuration.top_level_meta_include_record_count = true
     get '/api/v2/books/1/book_comments?page[limit]=10'
-    assert_equal 51, json_response['meta']['record_count']
+    assert_equal 26, json_response['meta']['record_count']
     assert_equal 'http://www.example.com/api/v2/books/1/book_comments?page%5Blimit%5D=10&page%5Boffset%5D=0', json_response['links']['first']
     assert_equal 'http://www.example.com/api/v2/books/1/book_comments?page%5Blimit%5D=10&page%5Boffset%5D=10', json_response['links']['next']
-    assert_equal 'http://www.example.com/api/v2/books/1/book_comments?page%5Blimit%5D=10&page%5Boffset%5D=41', json_response['links']['last']
+    assert_equal 'http://www.example.com/api/v2/books/1/book_comments?page%5Blimit%5D=10&page%5Boffset%5D=16', json_response['links']['last']
   ensure
     JSONAPI.configuration.top_level_meta_include_record_count = false
   end

--- a/test/integration/requests/request_test.rb
+++ b/test/integration/requests/request_test.rb
@@ -436,6 +436,18 @@ class RequestTest < ActionDispatch::IntegrationTest
     assert_equal 'http://www.example.com/api/v2/books/10/book_comments?page%5Blimit%5D=10&page%5Boffset%5D=0', json_response['links']['last']
   end
 
+  def test_related_resource_alternate_relation_name_record_count
+    original_config = JSONAPI.configuration.dup
+    JSONAPI.configuration.default_paginator = :paged
+    JSONAPI.configuration.top_level_meta_include_record_count = true
+
+    get '/api/v2/books/1/aliased_comments'
+    assert_equal 200, status
+    assert_equal 26, json_response['meta']['record_count']
+  ensure
+    JSONAPI.configuration = original_config
+  end
+
   def test_pagination_related_resources_data_includes
     Api::V2::BookResource.paginator :offset
     Api::V2::BookCommentResource.paginator :offset


### PR DESCRIPTION
Fixes issue with getting related resources count where the relation name doesn't match the resource name.

Fixes #378
