### PR TITLE
ActionDispatch::Routing::Mapper::Scope privacy change resolved

### DIFF
--- a/lib/jsonapi/routing_ext.rb
+++ b/lib/jsonapi/routing_ext.rb
@@ -33,7 +33,11 @@ module ActionDispatch
           end
 
           resource @resource_type, options do
-            @scope[:jsonapi_resource] = @resource_type
+            if @scope.respond_to? :[]= # Rails 4
+              @scope[:jsonapi_resource] = @resource_type
+            else # Rails 5
+              @scope = @scope.new jsonapi_resource: @resource_type
+            end
 
             if block_given?
               yield
@@ -77,7 +81,11 @@ module ActionDispatch
           end
 
           resources @resource_type, options do
-            @scope[:jsonapi_resource] = @resource_type
+            if @scope.respond_to? :[]= # Rails 4
+              @scope[:jsonapi_resource] = @resource_type
+            else # Rails 5
+              @scope = @scope.new jsonapi_resource: @resource_type
+            end
 
             if block_given?
               yield


### PR DESCRIPTION
**This patch is not yet ready to merge!**  
There are more upstream changes being addressed.

rails/rails#21231 advises that

> That class is entirely private and should not be used directly. We
> removed a private API method but you can use public methods to archive
> the same.

It _seems_ that we can get away with dup'ing `@scope` here, similarly to
a patch on plataformatec/devise#3701.  Likewise, Rails master has broken
things here, so more work will be required to make this patch land (let
alone pass tests).

Fixes #380.
