### PR TITLE
support STI

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -499,7 +499,7 @@ module JSONAPI
 
         resources = []
         records.each do |model|
-          resources.push new(model, context)
+          resources.push resource_for(module_path + model.class.to_s.underscore).new(model, context)
         end
 
         resources
@@ -642,7 +642,7 @@ module JSONAPI
       end
 
       def module_path
-        @module_path ||= name =~ /::[^:]+\Z/ ? ($`.freeze.gsub('::', '/') + '/').downcase : ''
+        name =~ /::[^:]+\Z/ ? ($`.freeze.gsub('::', '/') + '/').downcase : ''
       end
 
       def construct_order_options(sort_params)

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -776,9 +776,7 @@ module JSONAPI
               end
 
               return records.collect do |record|
-                if relationship.polymorphic?
-                  resource_klass = Resource.resource_for(self.class.resource_type_for(record))
-                end
+                resource_klass = Resource.resource_for(self.class.resource_type_for(record))
                 resource_klass.new(record, @context)
               end
             end unless method_defined?(attr)

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -2940,15 +2940,15 @@ class Api::V1::CratersControllerTest < ActionController::TestCase
                         data: [
                           {id:"A4D3",
                            type:"craters",
-                           links:{self: "http://test.host/craters/A4D3"},
+                           links:{self: "http://test.host/api/v1/craters/A4D3"},
                            attributes:{code: "A4D3", description: "Small crater"},
-                           relationships:{moon: {links: {self: "http://test.host/craters/A4D3/relationships/moon", related: "http://test.host/craters/A4D3/moon"}}}
+                           relationships:{moon: {links: {self: "http://test.host/api/v1/craters/A4D3/relationships/moon", related: "http://test.host/api/v1/craters/A4D3/moon"}}}
                           },
                           {id: "S56D",
                            type: "craters",
-                           links:{self: "http://test.host/craters/S56D"},
+                           links:{self: "http://test.host/api/v1/craters/S56D"},
                            attributes:{code: "S56D", description: "Very large crater"},
-                           relationships:{moon: {links: {self: "http://test.host/craters/S56D/relationships/moon", related: "http://test.host/craters/S56D/moon"}}}
+                           relationships:{moon: {links: {self: "http://test.host/api/v1/craters/S56D/relationships/moon", related: "http://test.host/api/v1/craters/S56D/moon"}}}
                           }
                         ]
                       }

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -513,6 +513,9 @@ end
 class ImageablesController < JSONAPI::ResourceController
 end
 
+class VehiclesController < JSONAPI::ResourceController
+end
+
 ### CONTROLLERS
 module Api
   module V1

--- a/test/integration/requests/request_test.rb
+++ b/test/integration/requests/request_test.rb
@@ -833,4 +833,10 @@ class RequestTest < ActionDispatch::IntegrationTest
     types = json_response['data'].map{|r| r['type']}.sort
     assert_equal ['boats', 'cars'], types
   end
+
+  def test_getting_resource_with_correct_type_when_sti
+    get '/vehicles/1'
+    assert_equal 200, status
+    assert_equal 'cars', json_response['data']['type']
+  end
 end

--- a/test/integration/requests/request_test.rb
+++ b/test/integration/requests/request_test.rb
@@ -826,4 +826,11 @@ class RequestTest < ActionDispatch::IntegrationTest
   ensure
     JSONAPI.configuration.allow_sort = true
   end
+
+  def test_getting_different_resources_when_sti
+    get '/vehicles'
+    assert_equal 200, status
+    types = json_response['data'].map{|r| r['type']}.sort
+    assert_equal ['boats', 'cars'], types
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -117,6 +117,7 @@ TestApp.routes.draw do
   jsonapi_resources :pictures
   jsonapi_resources :documents
   jsonapi_resources :products
+  jsonapi_resources :vehicles
 
   namespace :api do
     namespace :v1 do


### PR DESCRIPTION
can't wait util #364 is implemented. 

caching of `module_path` is removed because it works incorrectly for inherited resources.

```
(byebug) self
Api::V7::PurchaseOrderResource
(byebug) self.module_path
"api/v6/" #should be api/v7/
```
