### PR TITLE
Relation name

### DIFF
--- a/lib/jsonapi/relationship.rb
+++ b/lib/jsonapi/relationship.rb
@@ -24,7 +24,7 @@ module JSONAPI
       @resource_klass ||= Resource.resource_for(@module_path + @class_name)
     end
 
-    def relation_name(options = {})
+    def relation_name(options)
       case @relation_name
         when Symbol
           # :nocov:

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -165,10 +165,11 @@ module JSONAPI
       relationship_key_values.each do |relationship_key_value|
         related_resource = relationship.resource_klass.find_by_key(relationship_key_value, context: @context)
 
+        relation_name = relationship.relation_name(context: @context)
         # TODO: Add option to skip relations that already exist instead of returning an error?
-        relation = @model.public_send(relationship.type).where(relationship.primary_key => relationship_key_value).first
+        relation = @model.public_send(relation_name).where(relationship.primary_key => relationship_key_value).first
         if relation.nil?
-          @model.public_send(relationship.type) << related_resource.model
+          @model.public_send(relation_name) << related_resource.model
         else
           fail JSONAPI::Exceptions::HasManyRelationExists.new(relationship_key_value)
         end

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -397,8 +397,11 @@ end
 class PurchaseOrder < ActiveRecord::Base
   belongs_to :customer
   has_many :line_items
+  has_many :admin_line_items, class_name: 'LineItem', foreign_key: 'purchase_order_id'
 
   has_and_belongs_to_many :order_flags, join_table: :purchase_orders_order_flags
+
+  has_and_belongs_to_many :admin_order_flags, join_table: :purchase_orders_order_flags, class_name: 'OrderFlag'
 end
 
 class OrderFlag < ActiveRecord::Base
@@ -618,6 +621,9 @@ module Api
     end
 
     class PurchaseOrdersController < JSONAPI::ResourceController
+      def context
+        {current_user: $test_user}
+      end
     end
 
     class LineItemsController < JSONAPI::ResourceController
@@ -1202,8 +1208,28 @@ module Api
       attribute :total
 
       has_one :customer
-      has_many :line_items
-      has_many :order_flags, acts_as_set: true
+      has_many :line_items, relation_name: -> (options = {}) {
+                            context = options[:context]
+                            current_user = context ? context[:current_user] : nil
+
+                            unless current_user && current_user.book_admin
+                              :line_items
+                            else
+                              :admin_line_items
+                            end
+                          }
+
+      has_many :order_flags, acts_as_set: true,
+               relation_name: -> (options = {}) {
+                             context = options[:context]
+                             current_user = context ? context[:current_user] : nil
+
+                             unless current_user && current_user.book_admin
+                               :order_flags
+                             else
+                               :admin_order_flags
+                             end
+                           }
     end
 
     class OrderFlagResource < JSONAPI::Resource

--- a/test/fixtures/customers.yml
+++ b/test/fixtures/customers.yml
@@ -5,3 +5,7 @@ xyz_corp:
 abc_corp:
   id: 2
   name: ABC Corporation
+
+asdfg_corp:
+  id: 3
+  name: ASDFG Corporation

--- a/test/fixtures/line_items.yml
+++ b/test/fixtures/line_items.yml
@@ -29,3 +29,9 @@ li_5:
   part_number: 5WERT
   quantity: 1
   item_cost: 299.98
+
+li_6:
+  id: 6
+  part_number: 25washer
+  quantity: 10
+  item_cost: 0.98

--- a/test/fixtures/purchase_orders.yml
+++ b/test/fixtures/purchase_orders.yml
@@ -15,3 +15,9 @@ po_3:
   requested_delivery_date:
   delivery_date: nil
   customer_id: 1
+
+po_4:
+  id: 4
+  requested_delivery_date:
+  delivery_date: nil
+  customer_id: 3

--- a/test/integration/requests/request_test.rb
+++ b/test/integration/requests/request_test.rb
@@ -750,6 +750,40 @@ class RequestTest < ActionDispatch::IntegrationTest
     JSONAPI.configuration = original_config
   end
 
+  def test_patch_formatted_dasherized_replace_to_many_computed_relation
+    $original_test_user = $test_user
+    $test_user = Person.find(5)
+    original_config = JSONAPI.configuration.dup
+    JSONAPI.configuration.route_format = :dasherized_route
+    JSONAPI.configuration.json_key_format = :dasherized_key
+    patch '/api/v6/purchase-orders/2?include=line-items,order-flags',
+          {
+            'data' => {
+              'id' => '2',
+              'type' => 'purchase-orders',
+              'relationships' => {
+                'line-items' => {
+                  'data' => [
+                    {'type' => 'line-items', 'id' => '3'},
+                    {'type' => 'line-items', 'id' => '4'}
+                  ]
+                },
+                'order-flags' => {
+                  'data' => [
+                    {'type' => 'order-flags', 'id' => '1'},
+                    {'type' => 'order-flags', 'id' => '2'}
+                  ]
+                }
+              }
+            }
+          }.to_json, "CONTENT_TYPE" => JSONAPI::MEDIA_TYPE
+
+    assert_equal 200, status
+  ensure
+    JSONAPI.configuration = original_config
+    $test_user = $original_test_user
+  end
+
   def test_post_to_many_link
     original_config = JSONAPI.configuration.dup
     JSONAPI.configuration.route_format = :dasherized_route
@@ -767,6 +801,26 @@ class RequestTest < ActionDispatch::IntegrationTest
     JSONAPI.configuration = original_config
   end
 
+  def test_post_computed_relation_to_many
+    $original_test_user = $test_user
+    $test_user = Person.find(5)
+    original_config = JSONAPI.configuration.dup
+    JSONAPI.configuration.route_format = :dasherized_route
+    JSONAPI.configuration.json_key_format = :dasherized_key
+    post '/api/v6/purchase-orders/4/relationships/line-items',
+         {
+           'data' => [
+             {'type' => 'line-items', 'id' => '5'},
+             {'type' => 'line-items', 'id' => '6'}
+           ]
+         }.to_json, "CONTENT_TYPE" => JSONAPI::MEDIA_TYPE
+
+    assert_equal 204, status
+  ensure
+    JSONAPI.configuration = original_config
+    $test_user = $original_test_user
+  end
+
   def test_patch_to_many_link
     original_config = JSONAPI.configuration.dup
     JSONAPI.configuration.route_format = :dasherized_route
@@ -782,6 +836,26 @@ class RequestTest < ActionDispatch::IntegrationTest
     assert_equal 204, status
   ensure
     JSONAPI.configuration = original_config
+  end
+
+  def test_patch_to_many_link_computed_relation
+    $original_test_user = $test_user
+    $test_user = Person.find(5)
+    original_config = JSONAPI.configuration.dup
+    JSONAPI.configuration.route_format = :dasherized_route
+    JSONAPI.configuration.json_key_format = :dasherized_key
+    patch '/api/v6/purchase-orders/4/relationships/order-flags',
+          {
+            'data' => [
+              {'type' => 'order-flags', 'id' => '1'},
+              {'type' => 'order-flags', 'id' => '2'}
+            ]
+          }.to_json, "CONTENT_TYPE" => JSONAPI::MEDIA_TYPE
+
+    assert_equal 204, status
+  ensure
+    JSONAPI.configuration = original_config
+    $test_user = $original_test_user
   end
 
   def test_patch_to_one


### PR DESCRIPTION
Uses the relation_name instead of the type for _create_to_many_links.

May fix #386
