### PR TITLE
Use `records_for_relation_type` method in ShowRelatedResourcesOperation

### DIFF
--- a/lib/jsonapi/operation.rb
+++ b/lib/jsonapi/operation.rb
@@ -158,7 +158,7 @@ module JSONAPI
     end
 
     def records
-      related_resource_records = source_resource.public_send(@relationship_type)
+      related_resource_records = source_resource.public_send("records_for_" + @relationship_type)
       @resource_klass.filter_records(@filters, @options, related_resource_records)
     end
 

--- a/test/integration/requests/request_test.rb
+++ b/test/integration/requests/request_test.rb
@@ -426,6 +426,16 @@ class RequestTest < ActionDispatch::IntegrationTest
     JSONAPI.configuration.top_level_meta_include_record_count = false
   end
 
+  def test_filter_related_resources
+    JSONAPI.configuration.top_level_meta_include_record_count = true
+    get '/api/v2/books/1/book_comments?filter[book]=2'
+    assert_equal 0, json_response['meta']['record_count']
+    get '/api/v2/books/1/book_comments?filter[book]=1&page[limit]=20'
+    assert_equal 26, json_response['meta']['record_count']
+  ensure
+    JSONAPI.configuration.top_level_meta_include_record_count = false
+  end
+
   def test_pagination_related_resources_without_related
     Api::V2::BookResource.paginator :offset
     Api::V2::BookCommentResource.paginator :offset


### PR DESCRIPTION
The change from using `records_for` to `public_send(@relation_type)` caused errors because the `records` method in `ShowRelatedResourcesOperation` returned an `Array` of `RelatedResource` instead of an `ActiveRecord::Relation` of the records. The change also fixes an untested bug related to record counts for related resources.
