### PR TITLE
underscore JSONAPI::Resource#module_path when deriving from name

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -642,7 +642,7 @@ module JSONAPI
       end
 
       def module_path
-        @module_path ||= name =~ /::[^:]+\Z/ ? ($`.freeze.gsub('::', '/') + '/').downcase : ''
+        @module_path ||= name =~ /::[^:]+\Z/ ? ($`.freeze.gsub('::', '/') + '/').underscore : ''
       end
 
       def construct_order_options(sort_params)

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -46,6 +46,11 @@ class PersonWithCustomRecordsForErrorResource < PersonResource
   end
 end
 
+module MyModule
+  class MyNamespacedResource < JSONAPI::Resource
+  end
+end
+
 class ResourceTest < ActiveSupport::TestCase
   def setup
     @post = Post.first
@@ -57,6 +62,10 @@ class ResourceTest < ActiveSupport::TestCase
 
   def test_model
     assert_equal(PostResource._model_class, Post)
+  end
+
+  def test_module_path
+    assert_equal(MyModule::MyNamespacedResource.module_path, 'my_module/')
   end
 
   def test_base_resource_abstract


### PR DESCRIPTION
Using downcase does not have the intended effect. For example, a 
resource with name 'MyModuleNameSpace::NamespacedResource' previously 
had a module_path of 'mymodulenamespace'. Using underscore the 
module_path for 'MyModuleNameSpace::NamespacedResource' is 
'my_module_name_space'.
