### PR TITLE
Exception callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -988,6 +988,31 @@ JSONAPI.configure do |config|
 end
 ```
 
+
+#### Handling Exceptions
+
+By default, all exceptions raised downstream from a resource controller will be caught, logged, and a ```500 Internal Server Error``` will be rendered. Exceptions can be whitelisted in the config to pass through the handler and be caught manually, or you can pass a callback from a resource controller to insert logic into the rescue block without interrupting the control flow. This can be particularly useful for additional logging or monitoring without the added work of rendering responses.
+
+Pass a block, refer to controller class methods, or both. Note that methods must be defined as class methods on a controller and accept one parameter, which is passed the exception object that was rescued. 
+
+```ruby
+  class ApplicationController < JSONAPI::ResourceController
+
+    on_server_error :first_callback 
+
+    #or
+
+    # on_server_error do |error|
+      #do things
+    #end
+
+    def self.first_callback(error)
+      #env["airbrake.error_id"] = notify_airbrake(error)
+    end
+  end
+
+```
+
 ### Serializer
 
 The `ResourceSerializer` can be used to serialize a resource into JSON API compliant JSON. `ResourceSerializer` must be

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ backed by ActiveRecord models or by custom objects.
   * [Controllers] (#controllers)
     * [Namespaces] (#namespaces)
     * [Error Codes] (#error-codes)
+    * [Handling Exceptions] (#handling-exceptions)
   * [Serializer] (#serializer)
 * [Configuration] (#configuration)
 * [Contributing] (#contributing)

--- a/lib/jsonapi/active_record_operations_processor.rb
+++ b/lib/jsonapi/active_record_operations_processor.rb
@@ -15,26 +15,20 @@ class ActiveRecordOperationsProcessor < JSONAPI::OperationsProcessor
     fail ActiveRecord::Rollback if @transactional
   end
 
+  # Catch errors that should be handled before JSONAPI::Exceptions::Error
+  # and other unprocessed exceptions
   def process_operation(operation)
-    operation.apply
-  rescue ActiveRecord::DeleteRestrictionError => e
-    record_locked_error = JSONAPI::Exceptions::RecordLocked.new(e.message)
-    return JSONAPI::ErrorsOperationResult.new(record_locked_error.errors[0].code, record_locked_error.errors)
+    with_default_handling do 
+      begin
+        operation.apply
+      rescue ActiveRecord::DeleteRestrictionError => e
+        record_locked_error = JSONAPI::Exceptions::RecordLocked.new(e.message)
+        return JSONAPI::ErrorsOperationResult.new(record_locked_error.errors[0].code, record_locked_error.errors)
 
-  rescue ActiveRecord::RecordNotFound
-    record_not_found = JSONAPI::Exceptions::RecordNotFound.new(operation.associated_key)
-    return JSONAPI::ErrorsOperationResult.new(record_not_found.errors[0].code, record_not_found.errors)
-
-  rescue JSONAPI::Exceptions::Error => e
-    raise e
-
-  rescue => e
-    if JSONAPI.configuration.exception_class_whitelist.any? { |k| e.class.ancestors.include?(k) }
-      raise e
-    else
-      internal_server_error = JSONAPI::Exceptions::InternalServerError.new(e)
-      Rails.logger.error { "Internal Server Error: #{e.message} #{e.backtrace.join("\n")}" }
-      return JSONAPI::ErrorsOperationResult.new(internal_server_error.errors[0].code, internal_server_error.errors)
-    end
+      rescue ActiveRecord::RecordNotFound
+        record_not_found = JSONAPI::Exceptions::RecordNotFound.new(operation.associated_key)
+        return JSONAPI::ErrorsOperationResult.new(record_not_found.errors[0].code, record_not_found.errors)
+      end
+    end  
   end
 end

--- a/lib/jsonapi/acts_as_resource_controller.rb
+++ b/lib/jsonapi/acts_as_resource_controller.rb
@@ -206,7 +206,7 @@ module JSONAPI
             if self.respond_to? method
               send(method, error)
             else
-              Rails.log.warn("#{method} not defined on #{self}, skipping error callback")
+              Rails.logger.warn("#{method} not defined on #{self}, skipping error callback")
             end
           end
         end.compact

--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -5,7 +5,7 @@ module JSONAPI
   class Request
     attr_accessor :fields, :include, :filters, :sort_criteria, :errors, :operations,
                   :resource_klass, :context, :paginator, :source_klass, :source_id,
-                  :include_directives, :params, :warnings
+                  :include_directives, :params, :warnings, :server_error_callbacks
 
     def initialize(params = nil, options = {})
       @params = params
@@ -22,6 +22,7 @@ module JSONAPI
       @include_directives = nil
       @paginator = nil
       @id = nil
+      @server_error_callbacks = []
 
       setup_action(@params)
     end

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -31,6 +31,57 @@ class PostsControllerTest < ActionController::TestCase
     JSONAPI.configuration = original_config
   end
 
+  def test_on_server_error_block_callback_with_exception
+    original_config = JSONAPI.configuration.dup
+    JSONAPI.configuration.operations_processor = :error_raising
+    JSONAPI.configuration.exception_class_whitelist = []
+
+    @controller.class.instance_variable_set(:@callback_message, "none")
+    @controller.class.on_server_error do
+      @controller.class.instance_variable_set(:@callback_message, "Sent from block")
+    end
+    
+    get :index
+    assert_equal @controller.class.instance_variable_get(:@callback_message), "Sent from block"
+
+    # test that it renders the default server error response
+    assert_equal "Internal Server Error", json_response['errors'][0]['title']
+    assert_equal "Internal Server Error", json_response['errors'][0]['detail']
+  ensure
+    JSONAPI.configuration = original_config
+  end
+
+  def test_on_server_error_method_callback_with_exception
+    original_config = JSONAPI.configuration.dup
+    JSONAPI.configuration.operations_processor = :error_raising
+    JSONAPI.configuration.exception_class_whitelist = [] 
+
+    @controller.class.on_server_error :set_callback_message   
+    @controller.class.instance_variable_set(:@callback_message, "none")
+
+    get :index
+    assert_equal @controller.class.instance_variable_get(:@callback_message), "Sent from method"
+
+    # test that it renders the default server error response
+    assert_equal "Internal Server Error", json_response['errors'][0]['title']
+  ensure
+    JSONAPI.configuration = original_config
+  end
+
+  def test_on_server_error_callback_without_exception
+    
+    @controller.class.on_server_error do
+      @controller.class.instance_variable_set(:@callback_message, "Sent from block")
+    end
+    @controller.class.instance_variable_set(:@callback_message, "none")
+
+    get :index
+    assert_equal @controller.class.instance_variable_get(:@callback_message), "none"
+
+    # test that it does not render error
+    assert json_response.key?('data')
+  end
+
   def test_index_filter_with_empty_result
     get :index, {filter: {title: 'post that does not exist'}}
     assert_response :success

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -56,7 +56,8 @@ class PostsControllerTest < ActionController::TestCase
     JSONAPI.configuration.operations_processor = :error_raising
     JSONAPI.configuration.exception_class_whitelist = [] 
 
-    @controller.class.on_server_error :set_callback_message   
+    #ignores methods that don't exist
+    @controller.class.on_server_error :set_callback_message, :a_bogus_method
     @controller.class.instance_variable_set(:@callback_message, "none")
 
     get :index
@@ -70,9 +71,8 @@ class PostsControllerTest < ActionController::TestCase
 
   def test_on_server_error_callback_without_exception
     
-    @controller.class.on_server_error do
-      @controller.class.instance_variable_set(:@callback_message, "Sent from block")
-    end
+    callback = Proc.new { @controller.class.instance_variable_set(:@callback_message, "Sent from block") }
+    @controller.class.on_server_error callback
     @controller.class.instance_variable_set(:@callback_message, "none")
 
     get :index

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -461,6 +461,16 @@ class ErrorRaisingOperationsProcessor < ActiveRecordOperationsProcessor
   end
 end
 
+class CallbackCounter
+  def self.count
+    @count
+  end
+
+  def self.increment
+    @count += 1
+  end
+end
+
 ### CONTROLLERS
 class AuthorsController < JSONAPI::ResourceController
 end
@@ -477,6 +487,11 @@ class PostsController < ActionController::Base
   # the operations processor.
   rescue_from PostsController::SpecialError do
     head :forbidden
+  end
+
+  #called by test_on_server_error
+  def self.set_callback_message(error)
+    @callback_message = "Sent from method"
   end
 end
 

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -461,16 +461,6 @@ class ErrorRaisingOperationsProcessor < ActiveRecordOperationsProcessor
   end
 end
 
-class CallbackCounter
-  def self.count
-    @count
-  end
-
-  def self.increment
-    @count += 1
-  end
-end
-
 ### CONTROLLERS
 class AuthorsController < JSONAPI::ResourceController
 end

--- a/test/unit/operation/operations_processor_test.rb
+++ b/test/unit/operation/operations_processor_test.rb
@@ -503,4 +503,26 @@ class OperationsProcessorTest < Minitest::Test
     assert_equal(operation_results.results.size, 1)
     assert operation_results.has_errors?
   end
+
+  def test_safe_run_callback_pass
+    op = JSONAPI::OperationsProcessor.new
+    error = StandardError.new
+
+    check = false
+    callback = ->(error) { check = true}
+
+    op.send(:safe_run_callback, callback, error)
+    assert check
+  end
+
+  def test_safe_run_callback_catch_fail
+    op = JSONAPI::OperationsProcessor.new
+    error = StandardError.new
+
+    callback = ->(error) { nil.explosions}
+    result = op.send(:safe_run_callback, callback, error) 
+
+    assert_instance_of(JSONAPI::ErrorsOperationResult, result)
+    assert_equal(result.code, 500)
+  end
 end


### PR DESCRIPTION
Refactor of operations processors to reduce some duplication, and adding of feature to the ResourceController for passing callbacks to the general error catcher. 

I needed a way to have control of logging and place to put airbrake handling for exceptions that are being caught and rendered. The controller seemed like a good candidate, since the same handling will be used across resources and error logic seems more the business of a controller than a resource to me. 

I did manual testing of the feature in my own app. I had a look at the test suite and wasn't sure if and where it would make sense to add tests. It seems that the controller tests are all integration tests. I'm happy to add some unit tests if that's deemed important, but could use some direction if that's the case. I'm also happy to hear general feedback if there's something that doesn't seem right.
