### PR TITLE
Use the ':git' source when bundling Rails master

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,12 +11,13 @@ platforms :jruby do
 end
 
 version = ENV['RAILS_VERSION'] || 'default'
-rails = case version
-        when 'master'
-          { github: 'rails/rails' }
-        when 'default'
-          '>= 4.2'
-        else
-          "~> #{version}"
-        end
-gem 'rails', rails
+
+case version
+when 'master'
+  gem 'rails', { git: 'https://github.com/rails/rails.git' }
+  gem 'arel', { git: 'https://github.com/rails/arel.git' }
+when 'default'
+  gem 'rails', '>= 4.2'
+else
+  gem 'rails', "~> #{version}"
+end


### PR DESCRIPTION
As per http://bundler.io/git.html:

> `http://` and `git://` URLs are insecure. A man-in-the-middle attacker
> could tamper with the code as you check it out, and potentially supply
> you with malicious code instead of the code you meant to check
> out. Because the `:github` shortcut uses a `git://` URL in Bundler 1.x
> versions, we recommend using using HTTPS URLs or overriding the
> `:github` shortcut with your own HTTPS git source.

Also, as Rails master (currently 5.0.0.alpha) has a dependency on Arel
master (currently 7.0.0.alpha), we must pull this in too.
