### PR TITLE
Exceptions for invalid has_many post and patch

### DIFF
--- a/lib/jsonapi/exceptions.rb
+++ b/lib/jsonapi/exceptions.rb
@@ -45,6 +45,20 @@ module JSONAPI
       end
     end
 
+    class HasManyRecordNotFound < Error
+      attr_accessor :message
+      def initialize(message)
+        @message = message
+      end
+
+      def errors
+        [JSONAPI::Error.new(code: JSONAPI::RECORD_NOT_FOUND,
+                            status: :not_found,
+                            title: 'Record not found',
+                            detail: "#{message}")]
+      end
+    end
+
     class UnsupportedMediaTypeError < Error
       attr_accessor :media_type
       def initialize(media_type)

--- a/lib/jsonapi/operation.rb
+++ b/lib/jsonapi/operation.rb
@@ -206,6 +206,10 @@ module JSONAPI
 
       return JSONAPI::ResourceOperationResult.new((result == :completed ? :created : :accepted), resource)
 
+    rescue ActiveRecord::RecordNotFound => e
+      records_not_found = JSONAPI::Exceptions::HasManyRecordNotFound.new(e)
+      return JSONAPI::ErrorsOperationResult.new(records_not_found.errors[0].code, records_not_found.errors)
+
     rescue JSONAPI::Exceptions::Error => e
       return JSONAPI::ErrorsOperationResult.new(e.errors[0].code, e.errors)
     end
@@ -243,6 +247,11 @@ module JSONAPI
       result = resource.replace_fields(data)
 
       return JSONAPI::ResourceOperationResult.new(result == :completed ? :ok : :accepted, resource)
+
+      rescue ActiveRecord::RecordNotFound => e
+        records_not_found = JSONAPI::Exceptions::HasManyRecordNotFound.new(e)
+        return JSONAPI::ErrorsOperationResult.new(records_not_found.errors[0].code, records_not_found.errors)
+
     end
   end
 

--- a/test/integration/requests/request_test.rb
+++ b/test/integration/requests/request_test.rb
@@ -686,6 +686,32 @@ class RequestTest < ActionDispatch::IntegrationTest
     JSONAPI.configuration = original_config
   end
 
+  def test_post_formatted_invalid_relationship
+    original_config = JSONAPI.configuration.dup
+    JSONAPI.configuration.route_format = :dasherized_route
+    JSONAPI.configuration.json_key_format = :dasherized_key
+    post '/api/v6/purchase-orders',
+         {
+           'data' => {
+             'attributes' => {
+               'delivery-name' => 'ASDFG Corp'
+             },
+             'type' => 'purchase-orders',
+              'relationships' => {
+                'order-flags' => {
+                  'data' => [
+                    {'type' => 'order-flags', 'id' => '9999'}
+                  ]
+                }
+              }
+           }
+         }.to_json, "CONTENT_TYPE" => JSONAPI::MEDIA_TYPE
+
+    assert_equal 404, status
+  ensure
+    JSONAPI.configuration = original_config
+  end
+
   def test_patch_formatted_dasherized
     original_config = JSONAPI.configuration.dup
     JSONAPI.configuration.route_format = :dasherized_route
@@ -792,6 +818,30 @@ class RequestTest < ActionDispatch::IntegrationTest
   ensure
     JSONAPI.configuration = original_config
     $test_user = $original_test_user
+  end
+
+  def test_patch_to_many_invalid_relationship
+    $original_test_user = $test_user
+    $test_user = Person.find(5)
+    original_config = JSONAPI.configuration.dup
+    JSONAPI.configuration.route_format = :dasherized_route
+    JSONAPI.configuration.json_key_format = :dasherized_key
+    patch '/api/v6/purchase-orders/2?include=line-items,order-flags',
+          {
+            'data' => {
+              'id' => '2',
+              'type' => 'purchase-orders',
+              'relationships' => {
+                'order-flags' => {
+                  'data' => [
+                    {'type' => 'order-flags', 'id' => '9999'}
+                  ]
+                }
+              }
+            }
+          }.to_json, "CONTENT_TYPE" => JSONAPI::MEDIA_TYPE
+
+    assert_equal 404, status
   end
 
   def test_post_to_many_link


### PR DESCRIPTION
**Issue:** Post/patch of a has_many would throw 500 instead of 404 like the invalid post/patch of a has_one.

Example exception response with one valid and one invalid has_many:

```
{
    "errors": [{
        "title": "Record not found",
        "detail": "Couldn't find all Users with 'id': (1, 9999) (found 1 results, but was looking for 2)",
        "id": null,
        "href": null,
        "code": 404,
        "source": null,
        "links": null,
        "status": "not_found"
    }]
}
```

or with only one invalid has_many:

```
{
    "errors": [{
        "title": "Record not found",
        "detail": "Couldn't find User with 'id'=9999",
        "id": null,
        "href": null,
        "code": 404,
        "source": null,
        "links": null,
        "status": "not_found"
    }]
}

```
