### PR TITLE
Fix delete to many

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -167,7 +167,6 @@ module JSONAPI
 
         relation_name = relationship.relation_name(context: @context)
         # TODO: Add option to skip relations that already exist instead of returning an error?
-        # binding.pry if relation_name == :special_tags
         relation = @model.public_send(relation_name).where(relationship.primary_key => relationship_key_value).first
         if relation.nil?
           @model.public_send(relation_name) << related_resource.model

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -167,6 +167,7 @@ module JSONAPI
 
         relation_name = relationship.relation_name(context: @context)
         # TODO: Add option to skip relations that already exist instead of returning an error?
+        # binding.pry if relation_name == :special_tags
         relation = @model.public_send(relation_name).where(relationship.primary_key => relationship_key_value).first
         if relation.nil?
           @model.public_send(relation_name) << related_resource.model
@@ -180,7 +181,6 @@ module JSONAPI
 
     def _replace_to_many_links(relationship_type, relationship_key_values)
       relationship = self.class._relationships[relationship_type]
-
       send("#{relationship.foreign_key}=", relationship_key_values)
       @save_needed = true
 
@@ -208,9 +208,7 @@ module JSONAPI
     end
 
     def _remove_to_many_link(relationship_type, key)
-      relationship = self.class._relationships[relationship_type]
-
-      @model.public_send(relationship.type).delete(key)
+      @model.public_send(relationship_type).delete(key)
 
       :completed
     end

--- a/lib/jsonapi/routing_ext.rb
+++ b/lib/jsonapi/routing_ext.rb
@@ -154,7 +154,7 @@ module ActionDispatch
           end
 
           if methods.include?(:destroy)
-            match "relationships/#{formatted_relationship_name}/:keys", controller: options[:controller],
+            match "relationships/#{formatted_relationship_name}", controller: options[:controller],
                                                                         action: 'destroy_relationship', relationship: link_type.to_s, via: [:delete]
           end
         end

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -1208,7 +1208,7 @@ class PostsControllerTest < ActionController::TestCase
     p = Post.find(14)
     assert_equal [2, 3], p.tag_ids
 
-    delete :destroy_relationship, {post_id: 14, relationship: 'tags', keys: '3'}
+    delete :destroy_relationship, {post_id: 14, relationship: 'tags', data: [{type: 'tags', id: 3}]}
 
     p.reload
     assert_response :no_content
@@ -1224,7 +1224,7 @@ class PostsControllerTest < ActionController::TestCase
     assert_equal 1, Post.find(14).special_tags.count
     before_tags = Post.find(14).tags.count 
 
-    delete :destroy_relationship, {post_id: 14, relationship: 'special_tags', keys: '2'}
+    delete :destroy_relationship, {post_id: 14, relationship: 'special_tags', data: [{type: 'tags', id: 2}]}
     assert_equal 0, Post.find(14).special_tags.count, "Relationship that matches URL relationship not destroyed"
 
     #check that the tag association is not affected
@@ -1240,7 +1240,7 @@ class PostsControllerTest < ActionController::TestCase
     p = Post.find(14)
     assert_equal [2, 3], p.tag_ids
 
-    delete :destroy_relationship, {post_id: 14, relationship: 'tags', keys: '4'}
+    delete :destroy_relationship, {post_id: 14, relationship: 'tags', data: [{type: 'tags', id: 4}]}
 
     p.reload
     assert_response :not_found

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -1033,7 +1033,6 @@ module Api
 
     class BookResource < JSONAPI::Resource
       attribute :title
-      attribute :title
       attributes :isbn, :banned
 
       has_many :book_comments, relation_name: -> (options = {}) {

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -51,6 +51,11 @@ ActiveRecord::Schema.define do
   end
   add_index :posts_tags, [:post_id, :tag_id], unique: true
 
+  create_table :special_post_tags, force: true do |t|
+    t.references :post, :tag, index: true
+  end
+  add_index :special_post_tags, [:post_id, :tag_id], unique: true
+
   create_table :comments_tags, force: true do |t|
     t.references :comment, :tag, index: true
   end
@@ -234,10 +239,19 @@ class Post < ActiveRecord::Base
   belongs_to :writer, class_name: 'Person', foreign_key: 'author_id'
   has_many :comments
   has_and_belongs_to_many :tags, join_table: :posts_tags
+  has_many :special_post_tags, source: :tag
+  has_many :special_tags, through: :special_post_tags, source: :tag
+  # has_and_belongs_to_many :special_tags, join_table: :special_post_tags, source: :tag
+  # has_and_belongs_to_many :special_tags, join_table: :special_post_tags, source: :tag
   belongs_to :section
 
   validates :author, presence: true
   validates :title, length: { maximum: 35 }
+end
+
+class SpecialPostTag < ActiveRecord::Base
+  belongs_to :tag
+  belongs_to :post
 end
 
 class Comment < ActiveRecord::Base
@@ -719,6 +733,12 @@ class TagResource < JSONAPI::Resource
   #has_many :planets
 end
 
+class SpecialTagResource < JSONAPI::Resource
+  attributes :name
+
+  has_many :posts
+end
+
 class SectionResource < JSONAPI::Resource
   attributes 'name'
 end
@@ -732,6 +752,7 @@ class PostResource < JSONAPI::Resource
   has_one :section
   has_many :tags, acts_as_set: true
   has_many :comments, acts_as_set: false
+
 
   # Not needed - just for testing
   primary_key :id
@@ -972,6 +993,7 @@ module Api
       # V1 no longer supports tags and now calls author 'writer'
       attribute :title
       attribute :body
+      attribute :body
       attribute :subject
 
       has_one :writer, foreign_key: 'author_id', class_name: 'Writer'
@@ -1013,6 +1035,7 @@ module Api
     PostResource = PostResource.dup
 
     class BookResource < JSONAPI::Resource
+      attribute :title
       attribute :title
       attributes :isbn, :banned
 
@@ -1132,6 +1155,7 @@ module Api
     ExpenseEntryResource = ExpenseEntryResource.dup
     IsoCurrencyResource = IsoCurrencyResource.dup
 
+
     class BookResource < Api::V2::BookResource
       paginator :paged
     end
@@ -1176,6 +1200,7 @@ module Api
     PostResource = PostResource.dup
     ExpenseEntryResource = ExpenseEntryResource.dup
     IsoCurrencyResource = IsoCurrencyResource.dup
+    EmployeeResource = EmployeeResource.dup
     EmployeeResource = EmployeeResource.dup
   end
 end

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -241,8 +241,6 @@ class Post < ActiveRecord::Base
   has_and_belongs_to_many :tags, join_table: :posts_tags
   has_many :special_post_tags, source: :tag
   has_many :special_tags, through: :special_post_tags, source: :tag
-  # has_and_belongs_to_many :special_tags, join_table: :special_post_tags, source: :tag
-  # has_and_belongs_to_many :special_tags, join_table: :special_post_tags, source: :tag
   belongs_to :section
 
   validates :author, presence: true
@@ -993,7 +991,6 @@ module Api
       # V1 no longer supports tags and now calls author 'writer'
       attribute :title
       attribute :body
-      attribute :body
       attribute :subject
 
       has_one :writer, foreign_key: 'author_id', class_name: 'Writer'
@@ -1200,7 +1197,6 @@ module Api
     PostResource = PostResource.dup
     ExpenseEntryResource = ExpenseEntryResource.dup
     IsoCurrencyResource = IsoCurrencyResource.dup
-    EmployeeResource = EmployeeResource.dup
     EmployeeResource = EmployeeResource.dup
   end
 end

--- a/test/integration/routes/routes_test.rb
+++ b/test/integration/routes/routes_test.rb
@@ -38,8 +38,8 @@ class RoutesTest < ActionDispatch::IntegrationTest
   end
 
   def test_routing_posts_links_tags_destroy
-    assert_routing({path: '/posts/1/relationships/tags/1,2', method: :delete},
-                   {controller: 'posts', action: 'destroy_relationship', post_id: '1', keys: '1,2', relationship: 'tags'})
+    assert_routing({path: '/posts/1/relationships/tags', method: :delete},
+                   {controller: 'posts', action: 'destroy_relationship', post_id: '1', relationship: 'tags'})
   end
 
   def test_routing_posts_links_tags_create

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -118,6 +118,7 @@ TestApp.routes.draw do
   jsonapi_resources :tags
   jsonapi_resources :posts do
     jsonapi_relationships
+    jsonapi_links :special_tags
   end
   jsonapi_resources :sections
   jsonapi_resources :iso_currencies
@@ -133,6 +134,8 @@ TestApp.routes.draw do
   jsonapi_resources :pictures
   jsonapi_resources :documents
   jsonapi_resources :products
+
+  
 
   namespace :api do
     namespace :v1 do


### PR DESCRIPTION
Fixes what I think is a bug in deleting a to_many relationship. I issue is similar to what was addressed in #394 when creating a to_many. I had a look at the other relationship creation/destruction code in Resource and I'm wondering there maybe a similar problem in other methods. I fixed this one but don't have time at the moment to write tests for the others. 

Here's the gist of what I was getting:

My client is calling `DELETE /teams/1/relationships/team_leads/7`

Team has a relationship to both `employees` and `team_leads`, which can be the same record.

Before the change, JR was deleting the relationship to the employee with this id while not modifying the team lead relationship. It was doing so because `team_lead` has (I believe correctly) the type `employees`. It seems to me that JR should be using the value from the url here and not the type of underlying model?
