### PR TITLE
Use `module ClassMethods` instead of `class_methods do` to support Rails 4.0

### DIFF
--- a/lib/jsonapi/acts_as_resource_controller.rb
+++ b/lib/jsonapi/acts_as_resource_controller.rb
@@ -193,7 +193,7 @@ module JSONAPI
     # would normally depend on rails catching and rendering an exception.
     # Ignores whitelist exceptions from config
 
-    class_methods do 
+    module ClassMethods
       def on_server_error(*args, &callback_block)
         callbacks = []
 


### PR DESCRIPTION
This issue was introduced with 01814602920ede0620e4420cb5c553d503933186, released with 0.5.9.
