### PR TITLE
Use @model.id.nil? to determine resource#is_new? instead of resource#id.nil?

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -32,7 +32,7 @@ module JSONAPI
     end
 
     def is_new?
-      id.nil?
+      @model.new_record?
     end
 
     def change(callback)

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -32,7 +32,7 @@ module JSONAPI
     end
 
     def is_new?
-      @model.new_record?
+      model.id.nil?
     end
 
     def change(callback)


### PR DESCRIPTION
Fixes create callback and resource saving when id is overridden to something else, like an UUID.
This happens when I want to keep integer id’s internally for the database relations but use an UUID on the public JSON interface.
Since UUID creation happens on resource initialization create callbacks never run.

Example resource:

```
class Api::V1::MyResource < JSONAPI::Resource
  def id
    @model.uuid
  end
end
```
