### PR TITLE
Remove unused minitest-reporters gem

### DIFF
--- a/jsonapi-resources.gemspec
+++ b/jsonapi-resources.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'minitest'
   spec.add_development_dependency 'minitest-spec-rails'
-  spec.add_development_dependency 'minitest-reporters'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'pry'
   spec.add_dependency 'rails', '>= 4.0'


### PR DESCRIPTION
We are no longer using this gem and the newest 1.1.0 is now causing a
build error if it’s not initialized.

Fixes #428
