### PR TITLE
Allow fields param when name does not match resource

### DIFF
--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -159,8 +159,7 @@ module JSONAPI
           @errors.concat(e.errors)
         end
 
-        if type_resource.nil? || !(@resource_klass._type == underscored_type ||
-          @resource_klass._has_relationship?(underscored_type))
+        if type_resource.nil?
           @errors.concat(JSONAPI::Exceptions::InvalidResource.new(type).errors)
         else
           unless values.nil?

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -619,11 +619,6 @@ module JSONAPI
         @_relationships.map { |key, _relationship| key }
       end
 
-      def _has_relationship?(type)
-        type = type.to_s
-        @_relationships.key?(type.singularize.to_sym) || @_relationships.key?(type.pluralize.to_sym)
-      end
-
       def _relationship(type)
         type = type.to_sym
         @_relationships[type]

--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -122,12 +122,17 @@ module JSONAPI
       obj_hash
     end
 
-    def requested_fields(model)
-      @fields[model] if @fields
+    def requested_fields(klass)
+      return if @fields.nil? || @fields.empty?
+      if @fields[klass._type]
+        @fields[klass._type]
+      elsif klass.superclass != JSONAPI::Resource
+        requested_fields(klass.superclass)
+      end
     end
 
     def attribute_hash(source)
-      requested = requested_fields(source.class._type)
+      requested = requested_fields(source.class)
       fields = source.fetchable_fields & source.class._attributes.keys.to_a
       fields = requested & fields unless requested.nil?
 
@@ -141,7 +146,7 @@ module JSONAPI
 
     def relationship_data(source, include_directives)
       relationships = source.class._relationships
-      requested = requested_fields(source.class._type)
+      requested = requested_fields(source.class)
       fields = relationships.keys
       fields = requested & fields unless requested.nil?
 

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -38,6 +38,13 @@ ActiveRecord::Schema.define do
     t.timestamps null: false
   end
 
+  create_table :companies, force: true do |t|
+    t.string     :type
+    t.string     :name
+    t.string     :address
+    t.timestamps null: false
+  end
+
   create_table :tags, force: true do |t|
     t.string :name
   end
@@ -244,6 +251,12 @@ class Comment < ActiveRecord::Base
   belongs_to :author, class_name: 'Person', foreign_key: 'author_id'
   belongs_to :post
   has_and_belongs_to_many :tags, join_table: :comments_tags
+end
+
+class Company < ActiveRecord::Base
+end
+
+class Firm < Company
 end
 
 class Tag < ActiveRecord::Base
@@ -488,6 +501,9 @@ end
 class CommentsController < JSONAPI::ResourceController
 end
 
+class FirmsController < JSONAPI::ResourceController
+end
+
 class SectionsController < JSONAPI::ResourceController
 end
 
@@ -709,6 +725,13 @@ class CommentResource < JSONAPI::Resource
   has_many :tags
 
   filters :body
+end
+
+class CompanyResource < JSONAPI::Resource
+  attributes :name, :address
+end
+
+class FirmResource < CompanyResource
 end
 
 class TagResource < JSONAPI::Resource

--- a/test/fixtures/companies.yml
+++ b/test/fixtures/companies.yml
@@ -1,0 +1,4 @@
+firm1:
+  type: Firm
+  name: JSON Consulting Services
+  address: 456 1st Ave.

--- a/test/integration/sti_fields_test.rb
+++ b/test/integration/sti_fields_test.rb
@@ -1,0 +1,18 @@
+require File.expand_path("../../test_helper", __FILE__)
+
+class StiFieldsTest < ActionDispatch::IntegrationTest
+  def test_index_fields_when_resource_does_not_match_relationship
+    get "/posts", { filter: { id: "1,2" },
+                  include: "author",
+                  fields: { posts: "author", people: "email" } }
+    assert_response :success
+    assert_equal 2, json_response["data"].size
+    assert json_response["data"][0]["relationships"].key?("author")
+    assert json_response["included"][0]["attributes"].keys == ["email"]
+  end
+
+  def test_fields_for_parent_class
+    get "/firms", { fields: { companies: "name" } }
+    assert_equal json_response["data"][0]["attributes"].keys, ["name"]
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -115,6 +115,7 @@ JSONAPI.configuration.route_format = :underscored_route
 TestApp.routes.draw do
   jsonapi_resources :people
   jsonapi_resources :comments
+  jsonapi_resources :firms
   jsonapi_resources :tags
   jsonapi_resources :posts do
     jsonapi_relationships


### PR DESCRIPTION
The fields parameter checked that the type matched either the resource
or one of the relationships on the resource. This prevented allowing
a resource when its name didn't match the relationship and relationships
with more than one level of nesting.

Also when checking for the fields param for a resource, if not
specified, recursively check for field of parent classes until
JSONAPI::Resource is reached.
