### PR TITLE
Link Builder Not Working when used within a rails engine

### DIFF
--- a/lib/jsonapi/link_builder.rb
+++ b/lib/jsonapi/link_builder.rb
@@ -81,7 +81,7 @@ module JSONAPI
       scopes         = module_scopes_from_class(source.class)[1..-1]
       base_path_name = scopes.map { |scope| scope.underscore }.join("_")
       end_path_name  = source.class._type.to_s.singularize
-      "#{ base_path_name }_#{ end_path_name }_path"
+      [base_path_name, end_path_name, "path"].join("_")
     end
 
     def engine_resource_url(source)

--- a/lib/jsonapi/link_builder.rb
+++ b/lib/jsonapi/link_builder.rb
@@ -81,7 +81,7 @@ module JSONAPI
       scopes         = module_scopes_from_class(source.class)[1..-1]
       base_path_name = scopes.map { |scope| scope.underscore }.join("_")
       end_path_name  = source.class._type.to_s.singularize
-      [base_path_name, end_path_name, "path"].join("_")
+      [base_path_name, end_path_name, "path"].reject(&:blank?).join("_")
     end
 
     def engine_resource_url(source)


### PR DESCRIPTION
When I used the gem as part of a rails engine, with the models inside the namespace of the engine, the method used to generate the path of the resource has a "_" at the beginning, therefore causing method_missing errors. (.e.g. _user_path instead of user_path)
This was due to the engine_resource_path_name_from_source method calculating the method name by using the base_path_name followed by an underscore.
However, this does not allow for when base_path_name is an empty string.

So, this pull request instead uses an array of the components of the method name, filtering out any blanks and joining them with underscores.

I have not fully checked out the project - this change was done within github, so unfortunately no tests checked.  If you cant accept it without, then I can get on to doing these but not until mid week.

Thanks

Gary
