### PR TITLE
Remove Rails 4.0.x testing from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 sudo: false
 env:
-  - "RAILS_VERSION=4.0.0"
   - "RAILS_VERSION=4.1.0"
   - "RAILS_VERSION=4.2.0"
 rvm:

--- a/test/config/database.yml
+++ b/test/config/database.yml
@@ -1,6 +1,5 @@
 test:
   adapter: sqlite3
-#  database: "test_db"
-  database: ":memory:"
+  database: test_db
   pool: 5
   timeout: 5000

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,7 @@ require 'simplecov'
 # COVERAGE=true rake test
 # To Switch rails versions and run a particular test order:
 # export RAILS_VERSION=4.2.0; bundle update rails; bundle exec rake TESTOPTS="--seed=39333" test
+# We are no longer having Travis test Rails 4.0.x. To test on Rails 4.0.x use this:
 # export RAILS_VERSION=4.0.0; bundle update rails; bundle exec rake test
 
 if ENV['COVERAGE']


### PR DESCRIPTION
This removes Travis testing for Rails 4.0.x. This is being done because using the in memory database sometimes crashes ruby. Using the file based database fails under Rails 4.0 with a readonly message.

I will still periodically test under Rails 4.0 using the in memory database, and if someone finds a solution to either of the above issues we can add Travis support back for Rails 4.0. It's just no worth any more of my time trying to track this down.
