### PR TITLE
enable config.always_include_to_many_linkage_data

### DIFF
--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -256,6 +256,7 @@ module JSONAPI
     end
 
     def link_object_to_many(source, relationship, include_linkage)
+      include_linkage = include_linkage | @always_include_to_many_linkage_data | relationship.always_include_linkage_data
       link_object_hash = {}
       link_object_hash[:links] = {}
       link_object_hash[:links][:self] = self_link(source, relationship)


### PR DESCRIPTION
The README specifically states that

> always_include_to_many_linkage_data is not currently implemented

However, config is already set up to receive that configuration parameter, and adding only one line to the code (as well as enabling it in the config) makes this feature start working. 

Given that this feature is so close to being implemented, but you left it out, I have to assume there is a good reason. However, I couldn't find any reason that it shouldn't be allowed. Can you help me understand why this isn't enabled right now?

This is more of a question than anything. It might have been good as an issue, but a pull request lets me easily attach the code I'm referring to.

Thanks!
