### PR TITLE
Context cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,12 +462,12 @@ class PostResource < JSONAPI::Resource
 
   # def record_for_author
   #   relation_name = relationship.relation_name(context: @context)
-  #   records_for(relation_name, context: @context)
+  #   records_for(relation_name)
   # end
 
   # def records_for_comments
   #   relation_name = relationship.relation_name(context: @context)
-  #   records_for(relation_name, context: @context)
+  #   records_for(relation_name)
   # end
 end
 
@@ -478,7 +478,7 @@ section for additional details on raising errors.
 
 ```ruby
 class BaseResource < JSONAPI::Resource
-  def records_for(relation_name, options={})
+  def records_for(relation_name)
     context = options[:context]
     records = model.public_send(relation_name)
 

--- a/README.md
+++ b/README.md
@@ -574,7 +574,7 @@ class AuthorResource < JSONAPI::Resource
     authors = context[:current_user].find_authors(filters)
 
     return authors.map do |author|
-      self.new(author)
+      self.new(author, context)
     end
   end
 end
@@ -1026,7 +1026,7 @@ The `ResourceSerializer` can be used to serialize a resource into JSON API compl
 
 ```ruby
 post = Post.find(1)
-JSONAPI::ResourceSerializer.new(PostResource).serialize_to_hash(PostResource.new(post))
+JSONAPI::ResourceSerializer.new(PostResource).serialize_to_hash(PostResource.new(post, nil))
 ```
 
 This returns results like this:
@@ -1111,7 +1111,7 @@ JSONAPI::ResourceSerializer.new(PostResource, include: include_resources,
     tags: [:name],
     comments: [:body, :post]
   }
-).serialize_to_hash(PostResource.new(post))
+).serialize_to_hash(PostResource.new(post, nil))
 ```
 
 ##### `context`

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -22,7 +22,7 @@ module JSONAPI
                                        :remove_to_one_link,
                                        :replace_fields
 
-    def initialize(model, context = nil)
+    def initialize(model, context)
       @model = model
       @context = context
     end

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -111,7 +111,7 @@ module JSONAPI
 
     # Override this on a resource to customize how the associated records
     # are fetched for a model. Particularly helpful for authorization.
-    def records_for(relation_name, _options = {})
+    def records_for(relation_name)
       model.public_send relation_name
     end
 
@@ -741,7 +741,7 @@ module JSONAPI
 
           define_method associated_records_method_name do
             relation_name = relationship.relation_name(context: @context)
-            records_for(relation_name, context: @context)
+            records_for(relation_name)
           end unless method_defined?(associated_records_method_name)
 
           if relationship.is_a?(JSONAPI::Relationship::ToOne)

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -955,7 +955,7 @@ class PreferencesResource < JSONAPI::Resource
   has_many :friends
 
   def self.find_by_key(key, options = {})
-    new(Preferences.first)
+    new(Preferences.first, nil)
   end
 end
 

--- a/test/unit/serializer/link_builder_test.rb
+++ b/test/unit/serializer/link_builder_test.rb
@@ -41,7 +41,7 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
     }
 
     builder = JSONAPI::LinkBuilder.new(config)
-    source  = primary_resource_klass.new(@steve)
+    source  = primary_resource_klass.new(@steve, nil)
     expected_link = "#{ @base_url }/api/v1/people/#{ source.id }"
 
     assert_equal expected_link, builder.self_link(source)
@@ -57,7 +57,7 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
     }
 
     builder = JSONAPI::LinkBuilder.new(config)
-    source  = primary_resource_klass.new(@steve)
+    source  = primary_resource_klass.new(@steve, nil)
     expected_link = "#{ @base_url }/boomshaka/api/v1/people/#{ source.id }"
 
     assert_equal expected_link, builder.self_link(source)
@@ -73,7 +73,7 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
     }
 
     builder = JSONAPI::LinkBuilder.new(config)
-    source  = primary_resource_klass.new(@steve)
+    source  = primary_resource_klass.new(@steve, nil)
     expected_link = "#{ @base_url }/boomshaka/admin_api/v1/people/#{ source.id }"
 
     assert_equal expected_link, builder.self_link(source)
@@ -113,7 +113,7 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
     }
 
     builder       = JSONAPI::LinkBuilder.new(config)
-    source        = Api::V1::PersonResource.new(@steve)
+    source        = Api::V1::PersonResource.new(@steve, nil)
     relationship  = JSONAPI::Relationship::ToMany.new("posts", {})
     expected_link = "#{ @base_url }/api/v1/people/#{ @steve.id }/relationships/posts"
 
@@ -129,7 +129,7 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
     }
 
     builder       = JSONAPI::LinkBuilder.new(config)
-    source        = MyEngine::Api::V1::PersonResource.new(@steve)
+    source        = MyEngine::Api::V1::PersonResource.new(@steve, nil)
     relationship  = JSONAPI::Relationship::ToMany.new("posts", {})
     expected_link = "#{ @base_url }/boomshaka/api/v1/people/#{ @steve.id }/relationships/posts"
 
@@ -145,7 +145,7 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
     }
 
     builder       = JSONAPI::LinkBuilder.new(config)
-    source        = Api::V1::PersonResource.new(@steve)
+    source        = Api::V1::PersonResource.new(@steve, nil)
     relationship  = JSONAPI::Relationship::ToMany.new("posts", {})
     expected_link = "#{ @base_url }/api/v1/people/#{ @steve.id }/posts"
 
@@ -161,7 +161,7 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
     }
 
     builder       = JSONAPI::LinkBuilder.new(config)
-    source        = MyEngine::Api::V1::PersonResource.new(@steve)
+    source        = MyEngine::Api::V1::PersonResource.new(@steve, nil)
     relationship  = JSONAPI::Relationship::ToMany.new("posts", {})
     expected_link = "#{ @base_url }/boomshaka/api/v1/people/#{ @steve.id }/posts"
 
@@ -177,7 +177,7 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
     }
 
     builder       = JSONAPI::LinkBuilder.new(config)
-    source        = Api::V1::PersonResource.new(@steve)
+    source        = Api::V1::PersonResource.new(@steve, nil)
     relationship  = JSONAPI::Relationship::ToMany.new("posts", {})
     expected_link = "#{ @base_url }/api/v1/people/#{ @steve.id }/posts?page%5Blimit%5D=12&page%5Boffset%5D=0"
     query         = { page: { offset: 0, limit: 12 } }

--- a/test/unit/serializer/polymorphic_serializer_test.rb
+++ b/test/unit/serializer/polymorphic_serializer_test.rb
@@ -27,7 +27,7 @@ class PolymorphismTest < ActionDispatch::IntegrationTest
     serialized_data = JSONAPI::ResourceSerializer.new(
       PersonResource,
       include: %w(vehicles)
-    ).serialize_to_hash(PersonResource.new(@person))
+    ).serialize_to_hash(PersonResource.new(@person, nil))
 
     assert_hash_equals(
       {
@@ -132,7 +132,7 @@ class PolymorphismTest < ActionDispatch::IntegrationTest
     serialized_data = JSONAPI::ResourceSerializer.new(
       PictureResource,
       include: %w(imageable)
-    ).serialize_to_hash(@pictures.map { |p| PictureResource.new p })
+    ).serialize_to_hash(@pictures.map { |p| PictureResource.new p, nil })
 
     assert_hash_equals(
       {

--- a/test/unit/serializer/serializer_test.rb
+++ b/test/unit/serializer/serializer_test.rb
@@ -23,7 +23,7 @@ class SerializerTest < ActionDispatch::IntegrationTest
 
     serialized = JSONAPI::ResourceSerializer.new(
       PostResource,
-      base_url: 'http://example.com').serialize_to_hash(PostResource.new(@post)
+      base_url: 'http://example.com').serialize_to_hash(PostResource.new(@post, nil)
     )
 
     assert_hash_equals(
@@ -118,7 +118,7 @@ class SerializerTest < ActionDispatch::IntegrationTest
       },
       JSONAPI::ResourceSerializer.new(Api::V1::PostResource,
                                       base_url: 'http://example.com').serialize_to_hash(
-        Api::V1::PostResource.new(@post))
+        Api::V1::PostResource.new(@post, nil))
     )
   end
 
@@ -146,7 +146,7 @@ class SerializerTest < ActionDispatch::IntegrationTest
         }
       },
       JSONAPI::ResourceSerializer.new(PostResource,
-                                      fields: {posts: [:id, :title, :author]}).serialize_to_hash(PostResource.new(@post))
+                                      fields: {posts: [:id, :title, :author]}).serialize_to_hash(PostResource.new(@post, nil))
     )
   end
 
@@ -154,7 +154,7 @@ class SerializerTest < ActionDispatch::IntegrationTest
     serialized = JSONAPI::ResourceSerializer.new(
       PostResource,
       include: ['author']
-    ).serialize_to_hash(PostResource.new(@post))
+    ).serialize_to_hash(PostResource.new(@post, nil))
 
     assert_hash_equals(
       {
@@ -256,7 +256,7 @@ class SerializerTest < ActionDispatch::IntegrationTest
       PostResource,
       include: ['author'],
       key_formatter: UnderscoredKeyFormatter
-    ).serialize_to_hash(PostResource.new(@post))
+    ).serialize_to_hash(PostResource.new(@post, nil))
 
     assert_hash_equals(
       {
@@ -525,7 +525,7 @@ class SerializerTest < ActionDispatch::IntegrationTest
           ]
       },
       JSONAPI::ResourceSerializer.new(PostResource,
-                                      include: ['comments', 'comments.tags']).serialize_to_hash(PostResource.new(@post))
+                                      include: ['comments', 'comments.tags']).serialize_to_hash(PostResource.new(@post, nil))
     )
   end
 
@@ -533,7 +533,7 @@ class SerializerTest < ActionDispatch::IntegrationTest
     serialized = JSONAPI::ResourceSerializer.new(
       PersonResource,
       include: ['comments']
-    ).serialize_to_hash(PersonResource.new(@fred))
+    ).serialize_to_hash(PersonResource.new(@fred, nil))
 
     assert_hash_equals(
       {
@@ -656,7 +656,7 @@ class SerializerTest < ActionDispatch::IntegrationTest
 
     posts = []
     Post.find(1, 2).each do |post|
-      posts.push PostResource.new(post)
+      posts.push PostResource.new(post, nil)
     end
 
     JSONAPI.configuration.always_include_to_one_linkage_data = true
@@ -972,7 +972,7 @@ class SerializerTest < ActionDispatch::IntegrationTest
 
     posts = []
     Post.find(1, 2).each do |post|
-      posts.push PostResource.new(post)
+      posts.push PostResource.new(post, nil)
     end
 
     assert_hash_equals(
@@ -1247,7 +1247,7 @@ class SerializerTest < ActionDispatch::IntegrationTest
 
     posts = []
     Post.find(1, 2).each do |post|
-      posts.push PostResource.new(post)
+      posts.push PostResource.new(post, nil)
     end
 
     assert_hash_equals(
@@ -1476,13 +1476,13 @@ class SerializerTest < ActionDispatch::IntegrationTest
       JSONAPI::ResourceSerializer.new(ExpenseEntryResource,
                                       include: ['iso_currency', 'employee'],
                                       fields: {people: [:id, :name, :email, :date_joined]}).serialize_to_hash(
-        ExpenseEntryResource.new(@expense_entry))
+        ExpenseEntryResource.new(@expense_entry, nil))
     )
   end
 
   def test_serializer_empty_links_null_and_array
     planet_hash = JSONAPI::ResourceSerializer.new(PlanetResource).serialize_to_hash(
-      PlanetResource.new(Planet.find(8)))
+      PlanetResource.new(Planet.find(8), nil))
 
     assert_hash_equals(
       {
@@ -1523,7 +1523,7 @@ class SerializerTest < ActionDispatch::IntegrationTest
   def test_serializer_include_with_empty_links_null_and_array
     planets = []
     Planet.find(7, 8).each do |planet|
-      planets.push PlanetResource.new(planet)
+      planets.push PlanetResource.new(planet, nil)
     end
 
     planet_hash = JSONAPI::ResourceSerializer.new(PlanetResource,
@@ -1619,7 +1619,7 @@ class SerializerTest < ActionDispatch::IntegrationTest
     original_config = JSONAPI.configuration.dup
     JSONAPI.configuration.json_key_format = :underscored_key
 
-    preferences = PreferencesResource.new(Preferences.find(1))
+    preferences = PreferencesResource.new(Preferences.find(1), nil)
 
     assert_hash_equals(
       {
@@ -1658,7 +1658,7 @@ class SerializerTest < ActionDispatch::IntegrationTest
     original_config = JSONAPI.configuration.dup
     JSONAPI.configuration.json_key_format = :underscored_key
 
-    facts = FactResource.new(Fact.find(1))
+    facts = FactResource.new(Fact.find(1), nil)
 
     assert_hash_equals(
       {
@@ -1691,7 +1691,7 @@ class SerializerTest < ActionDispatch::IntegrationTest
     serialized = JSONAPI::ResourceSerializer.new(
       Api::V5::AuthorResource,
       include: ['author_detail']
-    ).serialize_to_hash(Api::V5::AuthorResource.new(Person.find(1)))
+    ).serialize_to_hash(Api::V5::AuthorResource.new(Person.find(1), nil))
 
     assert_hash_equals(
       {


### PR DESCRIPTION
Hopefully this PR adds a little more rigor to the initialization of resources. By requiring the context to be set for initializing a resource we can prevent cases where users inadvertently create resources without the associated context. It would be an easy mistake to make when, for example, the find_by_key method is overridden to forget to pass in the context from the options hash.

This will require a minor version bump because it's potentially a breaking change.

May fix #458
