### PR TITLE
Some patches to support Rails 5 (WIP)

### DIFF
--- a/lib/jsonapi/mime_types.rb
+++ b/lib/jsonapi/mime_types.rb
@@ -1,9 +1,20 @@
+# coding: utf-8
 module JSONAPI
   MEDIA_TYPE = 'application/vnd.api+json'
 end
 
 Mime::Type.register JSONAPI::MEDIA_TYPE, :api_json
 
-ActionDispatch::ParamsParser::DEFAULT_PARSERS[Mime::Type.lookup(JSONAPI::MEDIA_TYPE)] = lambda do |body|
-  JSON.parse(body)
+if ActionDispatch::ParamsParser.constants.include? :DEFAULT_PARSERS
+  # Rails <= 4.y
+  ActionDispatch::ParamsParser::DEFAULT_PARSERS[Mime::Type.lookup(JSONAPI::MEDIA_TYPE)] =
+    lambda do |body|
+      JSON.parse(body)
+    end
+else
+  # Rails 5 >= rails/rails@b93c226d19615fe504f9e12d6c0ee2d70683e5fa
+  ActionDispatch::Http::Parameters::DEFAULT_PARSERS[Mime::Type.lookup(JSONAPI::MEDIA_TYPE)] =
+    lambda do |body|
+      JSON.parse(body)
+    end
 end

--- a/lib/jsonapi/routing_ext.rb
+++ b/lib/jsonapi/routing_ext.rb
@@ -33,7 +33,11 @@ module ActionDispatch
           end
 
           resource @resource_type, options do
-            @scope[:jsonapi_resource] = @resource_type
+            if @scope.respond_to? :[]= # Rails 4
+              @scope[:jsonapi_resource] = @resource_type
+            else # Rails 5
+              @scope = @scope.new jsonapi_resource: @resource_type
+            end
 
             if block_given?
               yield
@@ -81,7 +85,11 @@ module ActionDispatch
           end
 
           resources @resource_type, options do
-            @scope[:jsonapi_resource] = @resource_type
+            if @scope.respond_to? :[]= # Rails 4
+              @scope[:jsonapi_resource] = @resource_type
+            else # Rails 5
+              @scope = @scope.new jsonapi_resource: @resource_type
+            end
 
             if block_given?
               yield


### PR DESCRIPTION
While Rails 5 is still evolving towards a release check, catch some of the breaking changes and patch them.  It's not yet perfectly ready to merge, though, especially as this chases a moving target.

This doesn't seem to cause issues with Rails 4._x_ support.

Fixes #466.
Obsoletes #384.
