### PR TITLE
Fix get_related_resources when record_for_related_resources has join

### DIFF
--- a/lib/jsonapi/operation.rb
+++ b/lib/jsonapi/operation.rb
@@ -150,7 +150,7 @@ module JSONAPI
     end
 
     def record_count
-      @_record_count ||= records.count
+      @_record_count ||= records.count(:all)
     end
 
     def source_resource

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -2989,6 +2989,18 @@ class Api::V1::MoonsControllerTest < ActionController::TestCase
                                 }
 
    end
+
+   def test_get_related_resources_with_select_some_db_columns
+     PlanetResource.paginator :paged
+     original_config = JSONAPI.configuration.dup
+     JSONAPI.configuration.top_level_meta_include_record_count = true
+     JSONAPI.configuration.json_key_format = :dasherized_key
+     get :get_related_resources, {planet_id: '1', relationship: 'moons', source: 'api/v1/planets'}
+     assert_response :success
+     assert_equal 1, json_response['meta']['record-count']
+   ensure
+     JSONAPI.configuration = original_config
+   end
 end
 
 class Api::V1::CratersControllerTest < ActionController::TestCase

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -916,6 +916,10 @@ class PlanetResource < JSONAPI::Resource
   has_one :planet_type
 
   has_many :tags, acts_as_set: true
+
+  def records_for_moons
+    Moon.joins(:craters).select('moons.*, craters.code').distinct
+  end
 end
 
 class PropertyResource < JSONAPI::Resource


### PR DESCRIPTION
`#get_related_resources` breaks when the resource has `#records_for_` that joins to other association and selects some columns.

This PR will fix #482.
