### PR TITLE
Rename pagination "previous" link to "prev" per JSON API spec

### DIFF
--- a/lib/jsonapi/paginator.rb
+++ b/lib/jsonapi/paginator.rb
@@ -148,7 +148,7 @@ class PagedPaginator < JSONAPI::Paginator
     }
 
     if @number > 1
-      links_page_params['previous'] = {
+      links_page_params['prev'] = {
         'number' => @number - 1,
         'size' => @size
       }

--- a/test/unit/pagination/paged_paginator_test.rb
+++ b/test/unit/pagination/paged_paginator_test.rb
@@ -184,8 +184,8 @@ class PagedPaginatorTest < ActiveSupport::TestCase
     assert_equal 5, links_params['first']['size']
     assert_equal 1, links_params['first']['number']
 
-    assert_equal 5, links_params['previous']['size']
-    assert_equal 3, links_params['previous']['number']
+    assert_equal 5, links_params['prev']['size']
+    assert_equal 3, links_params['prev']['number']
 
     assert_equal 5, links_params['next']['size']
     assert_equal 5, links_params['next']['number']
@@ -210,8 +210,8 @@ class PagedPaginatorTest < ActiveSupport::TestCase
     assert_equal 5, links_params['first']['size']
     assert_equal 1, links_params['first']['number']
 
-    assert_equal 5, links_params['previous']['size']
-    assert_equal 9, links_params['previous']['number']
+    assert_equal 5, links_params['prev']['size']
+    assert_equal 9, links_params['prev']['number']
 
     assert_equal 5, links_params['last']['size']
     assert_equal 10, links_params['last']['number']
@@ -233,8 +233,8 @@ class PagedPaginatorTest < ActiveSupport::TestCase
     assert_equal 5, links_params['first']['size']
     assert_equal 1, links_params['first']['number']
 
-    assert_equal 5, links_params['previous']['size']
-    assert_equal 10, links_params['previous']['number']
+    assert_equal 5, links_params['prev']['size']
+    assert_equal 10, links_params['prev']['number']
 
     assert_equal 5, links_params['last']['size']
     assert_equal 10, links_params['last']['number']


### PR DESCRIPTION
We were running into this issue when we were using a JSON API client library that expected the pagination link for the previous page to be named `prev`, rather than `previous`.  It looks like that is what the official spec says it should be: http://jsonapi.org/format/#fetching-pagination
