### PR TITLE
Allow attribute named 'model'

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,7 +516,7 @@ section for additional details on raising errors.
 class BaseResource < JSONAPI::Resource
   def records_for(relation_name)
     context = options[:context]
-    records = model.public_send(relation_name)
+    records = _model.public_send(relation_name)
 
     unless context[:current_user].can_view?(records)
       raise NotAuthorizedError

--- a/lib/jsonapi/exceptions.rb
+++ b/lib/jsonapi/exceptions.rb
@@ -297,7 +297,7 @@ module JSONAPI
       attr_reader :error_messages, :resource_relationships
 
       def initialize(resource)
-        @error_messages = resource.model.errors.messages
+        @error_messages = resource._model.errors.messages
         @resource_relationships = resource.class._relationships.keys
         @key_formatter = JSONAPI.configuration.key_formatter
       end

--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -282,7 +282,7 @@ module JSONAPI
     def foreign_key_types_and_values(source, relationship)
       if relationship.is_a?(JSONAPI::Relationship::ToMany)
         if relationship.polymorphic?
-          source.model.public_send(relationship.name).pluck(:type, :id).map do |type, id|
+          source._model.public_send(relationship.name).pluck(:type, :id).map do |type, id|
             [type.pluralize, IdValueFormatter.format(id)]
           end
         else

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -220,6 +220,10 @@ ActiveRecord::Schema.define do
     t.string :serial_number
     t.integer :person_id
   end
+
+  create_table :makes, force: true do |t|
+    t.string :model
+  end
 end
 
 ### MODELS
@@ -472,6 +476,9 @@ end
 
 class Product < ActiveRecord::Base
   has_one :picture, as: :imageable
+end
+
+class Make < ActiveRecord::Base
 end
 
 ### OperationsProcessor
@@ -1003,11 +1010,15 @@ class ProductResource < JSONAPI::Resource
   has_one :picture, always_include_linkage_data: true
 
   def picture_id
-    model.picture.id
+    _model.picture.id
   end
 end
 
 class ImageableResource < JSONAPI::Resource
+end
+
+class MakeResource < JSONAPI::Resource
+  attribute :model
 end
 
 module Api

--- a/test/fixtures/makes.yml
+++ b/test/fixtures/makes.yml
@@ -1,0 +1,2 @@
+make1:
+  model: A model attribute

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -111,7 +111,7 @@ class ResourceTest < ActiveSupport::TestCase
 
   def test_find_with_customized_base_records
     author = Person.find(1)
-    posts = ArticleResource.find([], context: author).map(&:model)
+    posts = ArticleResource.find([], context: author).map(&:_model)
 
     assert(posts.include?(Post.find(1)))
     refute(posts.include?(Post.find(3)))
@@ -123,10 +123,10 @@ class ResourceTest < ActiveSupport::TestCase
     refute(preferences == nil)
     author.update! preferences: preferences
     author_resource = PersonResource.new(author, nil)
-    assert_equal(author_resource.preferences.model, preferences)
+    assert_equal(author_resource.preferences._model, preferences)
 
     author_resource = PersonWithCustomRecordsForResource.new(author, nil)
-    assert_equal(author_resource.preferences.model, :records_for)
+    assert_equal(author_resource.preferences._model, :records_for)
 
     author_resource = PersonWithCustomRecordsForErrorResource.new(author, nil)
     assert_raises PersonWithCustomRecordsForErrorResource::AuthorizationError do
@@ -165,11 +165,11 @@ class ResourceTest < ActiveSupport::TestCase
   def test_find_by_key_with_customized_base_records
     author = Person.find(1)
 
-    post = ArticleResource.find_by_key(1, context: author).model
+    post = ArticleResource.find_by_key(1, context: author)._model
     assert_equal(post, Post.find(1))
 
     assert_raises JSONAPI::Exceptions::RecordNotFound do
-      ArticleResource.find_by_key(3, context: author).model
+      ArticleResource.find_by_key(3, context: author)._model
     end
   end
 
@@ -221,7 +221,7 @@ class ResourceTest < ActiveSupport::TestCase
 
   def test_to_many_relationship_sorts
     post_resource = PostResource.new(Post.find(1), nil)
-    comment_ids = post_resource.comments.map{|c| c.model.id }
+    comment_ids = post_resource.comments.map{|c| c._model.id }
     assert_equal [1,2], comment_ids
 
     # define apply_filters method on post resource to not respect filters
@@ -233,7 +233,7 @@ class ResourceTest < ActiveSupport::TestCase
       end
     end
 
-    sorted_comment_ids = post_resource.comments(sort_criteria: [{ field: 'id', direction: :desc}]).map{|c| c.model.id }
+    sorted_comment_ids = post_resource.comments(sort_criteria: [{ field: 'id', direction: :desc}]).map{|c| c._model.id }
     assert_equal [2,1], sorted_comment_ids
 
   ensure

--- a/test/unit/serializer/serializer_test.rb
+++ b/test/unit/serializer/serializer_test.rb
@@ -1736,4 +1736,18 @@ class SerializerTest < ActionDispatch::IntegrationTest
       serialized
     )
   end
+
+  def test_serialize_model_attr
+    @make = Make.first
+    serialized = JSONAPI::ResourceSerializer.new(
+      MakeResource,
+    ).serialize_to_hash(MakeResource.new(@make, nil))
+
+    assert_hash_equals(
+      {
+        "model" => "A model attribute"
+      },
+      serialized[:data]["attributes"]
+    )
+  end
 end


### PR DESCRIPTION
Accessing the the underlying model uses the `_model_` method instead of
`model`. Accesing by variable still remains `@model`

Fix for #480 
