### PR TITLE
Allow 'href' and 'link' as field names

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -705,13 +705,13 @@ module JSONAPI
       def check_reserved_attribute_name(name)
         # Allow :id since it can be used to specify the format. Since it is a method on the base Resource
         # an attribute method won't be created for it.
-        if [:type, :href, :links].include?(name.to_sym)
+        if [:type].include?(name.to_sym)
           warn "[NAME COLLISION] `#{name}` is a reserved key in #{@@resource_types[_type]}."
         end
       end
 
       def check_reserved_relationship_name(name)
-        if [:id, :ids, :type, :types, :href, :hrefs, :link, :links].include?(name.to_sym)
+        if [:id, :ids, :type, :types].include?(name.to_sym)
           warn "[NAME COLLISION] `#{name}` is a reserved relationship name in #{@@resource_types[_type]}."
         end
       end

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -224,6 +224,24 @@ ActiveRecord::Schema.define do
   create_table :makes, force: true do |t|
     t.string :model
   end
+
+  # special cases - fields that look like they should be reserved names
+  create_table :hrefs, force: true do |t|
+    t.string :name
+  end
+
+  create_table :links, force: true do |t|
+    t.string :name
+  end
+
+  create_table :web_pages, force: true do |t|
+    t.string :href
+    t.string :link
+  end
+
+  create_table :questionables, force: true do |t|
+  end
+  # special cases
 end
 
 ### MODELS
@@ -479,6 +497,9 @@ class Product < ActiveRecord::Base
 end
 
 class Make < ActiveRecord::Base
+end
+
+class WebPage < ActiveRecord::Base
 end
 
 ### OperationsProcessor
@@ -1021,6 +1042,11 @@ class MakeResource < JSONAPI::Resource
   attribute :model
 end
 
+class WebPageResource < JSONAPI::Resource
+  attribute :href
+  attribute :link
+end
+
 module Api
   module V1
     class WriterResource < JSONAPI::Resource
@@ -1338,22 +1364,6 @@ module MyEngine
     end
   end
 end
-
-warn 'start testing Name Collisions'
-# The name collisions only emmit warnings. Exceptions would change the flow of the tests
-
-class LinksResource < JSONAPI::Resource
-end
-
-class BadlyNamedAttributesResource < JSONAPI::Resource
-  attributes :type, :href, :links
-
-  has_many :links
-  has_one :href
-  has_one :id
-  has_many :types
-end
-warn 'end testing Name Collisions'
 
 ### PORO Data - don't do this in a production app
 $breed_data = BreedData.new

--- a/test/fixtures/web_pages.yml
+++ b/test/fixtures/web_pages.yml
@@ -1,0 +1,3 @@
+web_page1:
+  href: http://example.com
+  link: http://link.example.com

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -362,4 +362,45 @@ class ResourceTest < ActiveSupport::TestCase
       key_type nil
     end
   end
+
+  def test_links_resource_warning
+    _out, err = capture_io do
+      eval "class LinksResource < JSONAPI::Resource; end"
+    end
+    assert_match /LinksResource` is a reserved resource name/, err
+  end
+
+  def test_reserved_key_warnings
+    _out, err = capture_io do
+      eval <<-CODE
+        class BadlyNamedAttributesResource < JSONAPI::Resource
+          attributes :type
+        end
+      CODE
+    end
+    assert_match /`type` is a reserved key in ./, err
+  end
+
+  def test_reserved_relationship_warnings
+    %w(id type).each do |key|
+      _out, err = capture_io do
+        eval <<-CODE
+          class BadlyNamedAttributesResource < JSONAPI::Resource
+            has_one :#{key}
+          end
+        CODE
+      end
+      assert_match /`#{key}` is a reserved relationship name in ./, err
+    end
+    %w(types ids).each do |key|
+      _out, err = capture_io do
+        eval <<-CODE
+          class BadlyNamedAttributesResource < JSONAPI::Resource
+            has_many :#{key}
+          end
+        CODE
+      end
+      assert_match /`#{key}` is a reserved relationship name in ./, err
+    end
+  end
 end


### PR DESCRIPTION
Allow 'href' and 'link' as fields names. Also add test relationships named 'type' or 'id'.
