### PR TITLE
Test deprecated id attribute

### DIFF
--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -708,7 +708,7 @@ class BaseResource < JSONAPI::Resource
 end
 
 class PersonResource < BaseResource
-  attributes :id, :name, :email
+  attributes :name, :email
   attribute :date_joined, format: :date_with_timezone
 
   has_many :comments
@@ -900,7 +900,6 @@ class FriendResource < JSONAPI::Resource
 end
 
 class BreedResource < JSONAPI::Resource
-  attribute :id, format_misspelled: :does_not_exist
   attribute :name, format: :title
 
   # This is unneeded, just here for testing

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -105,7 +105,6 @@ module Pets
     end
 
     class CatResource < JSONAPI::Resource
-      attribute :id
       attribute :name
       attribute :breed
 

--- a/test/unit/jsonapi_request/jsonapi_request_test.rb
+++ b/test/unit/jsonapi_request/jsonapi_request_test.rb
@@ -1,7 +1,6 @@
 require File.expand_path('../../../test_helper', __FILE__)
 
 class CatResource < JSONAPI::Resource
-  attribute :id
   attribute :name
   attribute :breed
 

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -16,7 +16,6 @@ class NoMatchAbstractResource < JSONAPI::Resource
 end
 
 class CatResource < JSONAPI::Resource
-  attribute :id
   attribute :name
   attribute :breed
 
@@ -361,5 +360,27 @@ class ResourceTest < ActiveSupport::TestCase
     CatResource.instance_eval do
       key_type nil
     end
+  end
+
+  def test_id_attr_deprecation
+    _out, err = capture_io do
+      eval <<-CODE
+        class ProblemResource < JSONAPI::Resource
+          attribute :id
+        end
+      CODE
+    end
+    assert_match /DEPRECATION WARNING: Id without format is no longer supported. Please remove ids from attributes, or specify a format./, err
+  end
+
+  def test_id_attr_with_format
+    _out, err = capture_io do
+      eval <<-CODE
+        class NotProblemResource < JSONAPI::Resource
+          attribute :id, format: :string
+        end
+      CODE
+    end
+    assert_equal "", err
   end
 end


### PR DESCRIPTION
Test setup was showing deprecation warnings on `attribute :id`, fixed those and added an explicit test since I didn't see one elsewhere.
