### PR TITLE
Fix for #504 - surface correct validation error messages if save…

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -146,7 +146,13 @@ module JSONAPI
 
       if defined? @model.save
         saved = @model.save(validate: false)
-        fail JSONAPI::Exceptions::SaveFailed.new unless saved
+        unless saved
+          if @model.errors.present?
+            fail JSONAPI::Exceptions::ValidationErrors.new(self)
+          else
+            fail JSONAPI::Exceptions::SaveFailed.new
+          end
+        end
       else
         saved = true
       end

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -21,10 +21,6 @@ end
 class ArticleWithBadAfterSaveResource < JSONAPI::Resource
   model_name 'PostWithBadAfterSave'
   attribute :title
-
-  def self.records(options)
-    options[:context].posts
-  end
 end
 
 class NoMatchResource < JSONAPI::Resource

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -8,6 +8,25 @@ class ArticleResource < JSONAPI::Resource
   end
 end
 
+class PostWithBadAfterSave < ActiveRecord::Base
+  self.table_name = 'posts'
+  after_save :do_some_after_save_stuff
+
+  def do_some_after_save_stuff
+    errors[:base] << 'Boom! Error added in after_save callback.'
+    raise ActiveRecord::RecordInvalid.new(self)
+  end
+end
+
+class ArticleWithBadAfterSaveResource < JSONAPI::Resource
+  model_name 'PostWithBadAfterSave'
+  attribute :title
+
+  def self.records(options)
+    options[:context].posts
+  end
+end
+
 class NoMatchResource < JSONAPI::Resource
 end
 
@@ -446,5 +465,14 @@ class ResourceTest < ActiveSupport::TestCase
       CODE
     end
     assert_match "", err
+  end
+
+  def test_correct_error_surfaced_if_validation_errors_in_after_save_callback
+    post = PostWithBadAfterSave.find(1)
+    post_resource = ArticleWithBadAfterSaveResource.new(post, nil)
+    err = assert_raises JSONAPI::Exceptions::ValidationErrors do
+      post_resource.replace_fields({:attributes => {:title => 'Some title'}})
+    end
+    assert_equal(err.error_messages[:base], ['Boom! Error added in after_save callback.'])
   end
 end


### PR DESCRIPTION
... fails in an after_save block.

Note: Need to add tests, if this is deemed to be in the right direction.
