### PR TITLE
Rework request processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -972,8 +972,6 @@ end
 
 These `serialization_options` are passed to the `meta` method used to generate resource `meta` values.
 
-> __Note__: This gem [uses the filter chain to set up the request](https://github.com/cerebris/jsonapi-resources/issues/458#issuecomment-143297055). In some instances, variables that are set in the filter chain (such as `current_user`) may not be set at the right time. If this happens (i.e. `current_user` is `nil` in `context` but it's set properly everywhere else), you may want to have your authentication occur earlier in the filter chain, using `prepend_before_action` instead of `before_action`.
-
 ##### ActsAsResourceController
 
 `JSONAPI::Resources` also provides a module, `JSONAPI::ActsAsResourceController`. You can include this module to

--- a/lib/jsonapi/acts_as_resource_controller.rb
+++ b/lib/jsonapi/acts_as_resource_controller.rb
@@ -9,50 +9,50 @@ module JSONAPI
     end
 
     def index
-      setup_and_process_request
+      process_request
     end
 
     def show
-      setup_and_process_request
+      process_request
     end
 
     def show_relationship
-      setup_and_process_request
+      process_request
     end
 
     def create
-      setup_and_process_request
+      process_request
     end
 
     def create_relationship
-      setup_and_process_request
+      process_request
     end
 
     def update_relationship
-      setup_and_process_request
+      process_request
     end
 
     def update
-      setup_and_process_request
+      process_request
     end
 
     def destroy
-      setup_and_process_request
+      process_request
     end
 
     def destroy_relationship
-      setup_and_process_request
+      process_request
     end
 
     def get_related_resource
-      setup_and_process_request
+      process_request
     end
 
     def get_related_resources
-      setup_and_process_request
+      process_request
     end
 
-    def setup_and_process_request
+    def process_request
       @request = JSONAPI::Request.new(params, context: context,
                                       key_formatter: key_formatter,
                                       server_error_callbacks: (self.class.server_error_callbacks || []))

--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -22,7 +22,7 @@ module JSONAPI
       @include_directives = nil
       @paginator = nil
       @id = nil
-      @server_error_callbacks = []
+      @server_error_callbacks = options.fetch(:server_error_callbacks, [])
 
       setup_action(@params)
     end


### PR DESCRIPTION
By avoiding the before and after actions any derived controllers will avoid conflicts with actions/filters.

Fixes #458
