### PR TITLE
Include exception message and backtrace in response

### DIFF
--- a/lib/jsonapi/error.rb
+++ b/lib/jsonapi/error.rb
@@ -1,6 +1,6 @@
 module JSONAPI
   class Error
-    attr_accessor :title, :detail, :id, :href, :code, :source, :links, :status
+    attr_accessor :title, :detail, :id, :href, :code, :source, :links, :status, :meta
 
     def initialize(options = {})
       @title          = options[:title]
@@ -16,6 +16,7 @@ module JSONAPI
       @links          = options[:links]
 
       @status         = Rack::Utils::SYMBOL_TO_STATUS_CODE[options[:status]].to_s
+      @meta           = options[:meta]
     end
   end
 

--- a/lib/jsonapi/exceptions.rb
+++ b/lib/jsonapi/exceptions.rb
@@ -10,10 +10,17 @@ module JSONAPI
       end
 
       def errors
+        unless Rails.env.prod?
+          meta = Hash.new
+          meta[:exception] = exception.message
+          meta[:backtrace] = exception.backtrace
+        end
+
         [JSONAPI::Error.new(code: JSONAPI::INTERNAL_SERVER_ERROR,
                             status: :internal_server_error,
                             title: 'Internal Server Error',
-                            detail: 'Internal Server Error')]
+                            detail: 'Internal Server Error',
+                            meta: meta)]
       end
     end
 


### PR DESCRIPTION
Following #502, this is a simple potential solution to communicating exception information in non-prod.

It bothers me a bit to submit a change that doesn't have a test, but wasn't clear where such a test would exist as the response of internal server errors doesn't appear to be tested. To that end, this is something of a development support feature and presumably as long as it doesn't break production functionality it should be safe to ship.
### TIL

One thing I did realize while I was working on this is that the backtrace produced by the error _is_ logged to `log/test.log`. So one could conceivably monitor this file if they encountered an unexpected error in test. I must have failed to realize this before simple because it's not my typical workflow. Maybe that's not true for others?

---

So, what do you think? Is this useful?
