### PR TITLE
Handle namespaced models

### DIFF
--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -1381,6 +1381,20 @@ module MyEngine
   end
 end
 
+module Legacy
+  class FlatPost < ActiveRecord::Base
+    self.table_name = "posts"
+  end
+end
+
+class FlatPostResource < JSONAPI::Resource
+  model_name "::Legacy::FlatPost"
+  attribute :title
+end
+
+class FlatPostsController < JSONAPI::ResourceController
+end
+
 ### PORO Data - don't do this in a production app
 $breed_data = BreedData.new
 $breed_data.add(Breed.new(0, 'persian'))

--- a/test/integration/requests/namespaced_model_test.rb
+++ b/test/integration/requests/namespaced_model_test.rb
@@ -1,0 +1,13 @@
+require File.expand_path('../../../test_helper', __FILE__)
+
+class NamedspacedModelTest < ActionDispatch::IntegrationTest
+  def setup
+    JSONAPI.configuration.json_key_format = :underscored_key
+  end
+
+  def test_get_flat_posts
+    get '/flat_posts'
+    assert_equal 200, status
+    assert_equal "flat_posts", json_response["data"].first["type"]
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -140,6 +140,7 @@ TestApp.routes.draw do
   jsonapi_resources :vehicles
   jsonapi_resources :cars
   jsonapi_resources :boats
+  jsonapi_resources :flat_posts
 
   namespace :api do
     namespace :v1 do


### PR DESCRIPTION
Fix for #523 (possible fix for #513)

Resource lookup was failing unless the model namespace was the same as
the resource namespace, excluding the module path. So while it worked
for the resource, `/api/v2/posts` having a model `Post`. It didn't
reliably work for a model `Legacy::Post`.

Overriding `resource_for_type` did solve part of the problem, but when
the mismatched resource was a relationship, `module_path` was wrong
and the resource could not be found.

I tried creating `/api/v2/legacy/posts` as a copy of `/api/v2/posts` and
this got me further, but still there were some cases were the resource
could not be found. (So far I am unable to generalize these cases, as
I could see no differences between these and the ones where this
technique worked.)

I had to resort to storing the `model` and `path` in the
`@@resource_types` class variable. And use that information in the few
`resource_for` calls that tried to lookup by model.
