### PR TITLE
Make params parsing behave more like Rails

### DIFF
--- a/lib/jsonapi/mime_types.rb
+++ b/lib/jsonapi/mime_types.rb
@@ -5,5 +5,7 @@ end
 Mime::Type.register JSONAPI::MEDIA_TYPE, :api_json
 
 ActionDispatch::ParamsParser::DEFAULT_PARSERS[Mime::Type.lookup(JSONAPI::MEDIA_TYPE)] = lambda do |body|
-  JSON.parse(body)
+  data = JSON.parse(body)
+  data = {:_json => data} unless data.is_a?(Hash)
+  data.with_indifferent_access
 end


### PR DESCRIPTION
Specifically, ensure that the parsed params end up as a HashWithIndifferentAccess instead of a vanilla Hash.
