### PR TITLE
fix bug with server_error_callbacks being called from subclasses

### DIFF
--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -37,10 +37,10 @@ class PostsControllerTest < ActionController::TestCase
     JSONAPI.configuration.exception_class_whitelist = []
 
     @controller.class.instance_variable_set(:@callback_message, "none")
-    @controller.class.on_server_error do
+    BaseController.on_server_error do
       @controller.class.instance_variable_set(:@callback_message, "Sent from block")
     end
-    
+
     get :index
     assert_equal @controller.class.instance_variable_get(:@callback_message), "Sent from block"
 
@@ -54,7 +54,7 @@ class PostsControllerTest < ActionController::TestCase
   def test_on_server_error_method_callback_with_exception
     original_config = JSONAPI.configuration.dup
     JSONAPI.configuration.operations_processor = :error_raising
-    JSONAPI.configuration.exception_class_whitelist = [] 
+    JSONAPI.configuration.exception_class_whitelist = []
 
     #ignores methods that don't exist
     @controller.class.on_server_error :set_callback_message, :a_bogus_method
@@ -70,7 +70,7 @@ class PostsControllerTest < ActionController::TestCase
   end
 
   def test_on_server_error_callback_without_exception
-    
+
     callback = Proc.new { @controller.class.instance_variable_set(:@callback_message, "Sent from block") }
     @controller.class.on_server_error callback
     @controller.class.instance_variable_set(:@callback_message, "none")
@@ -1222,7 +1222,7 @@ class PostsControllerTest < ActionController::TestCase
 
     #check the relationship was created successfully
     assert_equal 1, Post.find(14).special_tags.count
-    before_tags = Post.find(14).tags.count 
+    before_tags = Post.find(14).tags.count
 
     delete :destroy_relationship, {post_id: 14, relationship: 'special_tags', data: [{type: 'tags', id: 2}]}
     assert_equal 0, Post.find(14).special_tags.count, "Relationship that matches URL relationship not destroyed"

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -530,8 +530,12 @@ end
 class PeopleController < JSONAPI::ResourceController
 end
 
-class PostsController < ActionController::Base
+class BaseController < ActionController::Base
   include JSONAPI::ActsAsResourceController
+end
+
+class PostsController < BaseController
+
   class SpecialError < StandardError; end
   class SubSpecialError < PostsController::SpecialError; end
 


### PR DESCRIPTION
Wow, this one took me a while to figure out.

There were a couple of recent changes made to `ActsAsResourceController`.
One of the changes switched away from the `ActiveSupport::Concern` `class_methods`
approach, and one of them refactored the way that the `server_error_callbacks`
were stored. The problem is that the class instance variable wasn't visible
to subclasses and the test suite missed it because it tested controller classes
that had the `on_server_error` block set directly on them. I fixed that problem
and completed the switch back to the non-`ActiveSupport::Concern` approach.

This is a bug that might impact a number of apps in a way that isn't clear if those apps
weren't testing that the `on_server_error` method/block was actually being called.
