### PR TITLE
update dasherized key formatter to handle camel cased input

### DIFF
--- a/lib/jsonapi/formatter.rb
+++ b/lib/jsonapi/formatter.rb
@@ -76,7 +76,7 @@ end
 class DasherizedKeyFormatter < JSONAPI::KeyFormatter
   class << self
     def format(key)
-      super.dasherize
+      super.underscore.dasherize
     end
 
     def unformat(formatted_key)

--- a/test/unit/formatters/dasherized_key_formatter_test.rb
+++ b/test/unit/formatters/dasherized_key_formatter_test.rb
@@ -1,0 +1,8 @@
+require File.expand_path('../../../test_helper', __FILE__)
+
+class DasherizedKeyFormatterTest < ActiveSupport::TestCase
+  def test_dasherize_camelize
+    formatted = DasherizedKeyFormatter.format("CarWash")
+    assert_equal formatted, "car-wash"
+  end
+end


### PR DESCRIPTION
The dasherized key formatter wasn't correctly converting from camel case
into the dasherized format. This was causing problems with polymorphic
has many relationships.
