### PR TITLE
Move fetchable_fields override to class level

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ end
 ##### Fetchable Attributes
 
 By default all attributes are assumed to be fetchable. The list of fetchable attributes can be filtered by overriding
-the `fetchable_fields` method.
+the `self.fetchable_fields` method.
 
 Here's an example that prevents guest users from seeing the `email` field:
 
@@ -197,7 +197,7 @@ class AuthorResource < JSONAPI::Resource
   model_name 'Person'
   has_many :posts
 
-  def fetchable_fields
+  def self.fetchable_fields(context)
     if (context[:current_user].guest)
       super - [:email]
     else

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -107,9 +107,8 @@ module JSONAPI
       end
     end
 
-    # Override this on a resource instance to override the fetchable keys
     def fetchable_fields
-      self.class.fields
+      self.class.fetchable_fields(context)
     end
 
     # Override this on a resource to customize how the associated records
@@ -427,6 +426,11 @@ module JSONAPI
         end
       end
       # :nocov:
+
+      # Override in your resource to filter the fetchable keys
+      def fetchable_fields(_context = nil)
+        fields
+      end
 
       # Override in your resource to filter the updatable keys
       def updatable_fields(_context = nil)


### PR DESCRIPTION
Just a small proposal to make the `*_fields` overrides more consistent.

Adds a class-level `self.fetchable_fields(context)` method to Resource and changes the existing `Resource#fetchable_fields` to call the class-level version with the current context. Updates docs to encourage overwriting `self.fetchable_fields` to be parallel with the workflows for `updatable_fields`, `creatable_fields`, and `sortable_fields`.

This change should be backwards-compatible with existing instance-level overrides of `fetchable_fields`.
