### PR TITLE
Custom filter lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -616,7 +616,7 @@ This callable will be used to apply that filter.
 This example shows how you can implement different approaches for different filters.
 
 ```ruby
-filter :visibility, with: ->(records, value, _) {
+filter :visibility, apply: ->(records, value, _) {
   records.where('users.publicly_visible = ?', value == :public)
 }
 

--- a/README.md
+++ b/README.md
@@ -610,16 +610,18 @@ end
 
 ###### Applying Filters
 
-The `apply_filter` method is called to apply each filter to the `Arel` relation. You may override this method to gain
-control over how the filters are applied to the `Arel` relation.
+You may customize how a filter behaves by suppling a callable to the `:with` option.
+This callable will be used to apply that filter.
 
 This example shows how you can implement different approaches for different filters.
 
 ```ruby
+filter :visibility, with: ->(records, value, _) {
+  records.where('users.publicly_visible = ?', value == :public)
+}
+
 def self.apply_filter(records, filter, value, options)
   case filter
-    when :visibility
-      records.where('users.publicly_visible = ?', value == :public)
     when :last_name, :first_name, :name
       if value.is_a?(Array)
         value.each do |val|

--- a/README.md
+++ b/README.md
@@ -616,7 +616,7 @@ This callable will be used to apply that filter.
 This example shows how you can implement different approaches for different filters.
 
 ```ruby
-filter :visibility, apply: ->(records, value, _) {
+filter :visibility, apply: ->(records, value, _options) {
   records.where('users.publicly_visible = ?', value == :public)
 }
 

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -597,7 +597,13 @@ module JSONAPI
         if is_filter_relationship?(filter)
           verify_relationship_filter(filter, filter_values, context)
         else
-          verify_custom_filter(filter, filter_values, context)
+          strategy = _allowed_filters.fetch(filter, Hash.new)[:verify]
+
+          if strategy
+            strategy.(filter, filter_values, context)
+          else
+            verify_custom_filter(filter, filter_values, context)
+          end
         end
       end
 

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -495,7 +495,7 @@ module JSONAPI
       end
 
       def apply_filter(records, filter, value, options = {})
-        strategy = _allowed_filters.fetch(filter.to_sym, Hash.new)[:with]
+        strategy = _allowed_filters.fetch(filter.to_sym, Hash.new)[:apply]
 
         if strategy
           strategy.(records, value, options)

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -494,8 +494,14 @@ module JSONAPI
         end
       end
 
-      def apply_filter(records, filter, value, _options = {})
-        records.where(filter => value)
+      def apply_filter(records, filter, value, options = {})
+        strategy = _allowed_filters.fetch(filter.to_sym, Hash.new)[:with]
+
+        if strategy
+          strategy.(records, value, options)
+        else
+          records.where(filter => value)
+        end
       end
 
       def apply_filters(records, filters, options = {})

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -1133,7 +1133,7 @@ module Api
       has_many :aliased_comments, class_name: 'BookComments', relation_name: :approved_book_comments
 
       filters :book_comments
-      filter :banned, with: ->(records, value, options) {
+      filter :banned, apply: ->(records, value, options) {
         context = options[:context]
         current_user = context ? context[:current_user] : nil
 
@@ -1173,7 +1173,7 @@ module Api
       has_one :author, class_name: 'Person'
 
       filters :book
-      filter :approved, with: ->(records, value, options) {
+      filter :approved, apply: ->(records, value, options) {
         context = options[:context]
         current_user = context ? context[:current_user] : nil
 


### PR DESCRIPTION
Here's an implementation following #526.

In brief, this allows for the following syntax instead of overriding `apply_filter` on a resource.

``` ruby
filter :custom, with: -> (records, value) { records.custom(value) }
```

Based on the feedback from that issue, there are a couple things which may still need to be addressed.
- [x] Consider renaming the `:with` option to `:apply`
- [x] Consider adding an additional option for a `:verify` lambda
