### PR TITLE
Translate exceptions arrising in the ActsAsResourceController code in…

### DIFF
--- a/lib/jsonapi/acts_as_resource_controller.rb
+++ b/lib/jsonapi/acts_as_resource_controller.rb
@@ -178,10 +178,10 @@ module JSONAPI
       case e
       when JSONAPI::Exceptions::Error
         render_errors(e.errors)
-      else # raise all other exceptions
-        # :nocov:
-        fail e
-        # :nocov:
+      else
+        internal_server_error = JSONAPI::Exceptions::InternalServerError.new(e)
+        Rails.logger.error { "Internal Server Error: #{e.message} #{e.backtrace.join("\n")}" }
+        render_errors(internal_server_error.errors)
       end
     end
 

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -3271,3 +3271,12 @@ class Api::V7::CustomersControllerTest < ActionController::TestCase
     assert_equal 'customers', json_response['data'][0]['type']
   end
 end
+
+class Api::V7::CategoriesControllerTest < ActionController::TestCase
+  def test_uncaught_error_in_controller
+
+    get :show, {id: '1'}
+    assert_response 500
+    assert_match /Internal Server Error/, json_response['errors'][0]['detail']
+  end
+end

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -565,6 +565,15 @@ class PostsController < BaseController
     head :forbidden
   end
 
+  def handle_exceptions(e)
+    case e
+      when PostsController::SpecialError
+        raise e
+      else
+        super(e)
+    end
+  end
+
   #called by test_on_server_error
   def self.set_callback_message(error)
     @callback_message = "Sent from method"
@@ -756,6 +765,9 @@ module Api
     end
 
     class OrderFlagsController < JSONAPI::ResourceController
+    end
+
+    class CategoriesController < JSONAPI::ResourceController
     end
 
     class ClientsController < JSONAPI::ResourceController
@@ -1406,6 +1418,14 @@ module Api
       has_many :purchase_orders
     end
 
+    class CategoryResource < CategoryResource
+      attribute :name
+
+      # Raise exception for failure in controller
+      def name
+        fail "Something Exceptional Happened"
+      end
+    end
   end
 
   module V8

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -229,6 +229,7 @@ TestApp.routes.draw do
       jsonapi_resources :customers
       jsonapi_resources :purchase_orders
       jsonapi_resources :line_items
+      jsonapi_resources :categories
 
       jsonapi_resources :clients
     end


### PR DESCRIPTION
…to `InternalServerError`s and log them to the Rails error logger.

If you want the old behavior you can again override the `handle_exceptions` method.
