### PR TITLE
Test case for JR::Resource.resource_for_model_path

### DIFF
--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -15,6 +15,7 @@ ActiveRecord::Schema.define do
     t.belongs_to :preferences
     t.integer    :hair_cut_id, index: true
     t.boolean    :book_admin, default: false
+    t.boolean    :special, default: false
     t.timestamps null: false
   end
 
@@ -767,6 +768,14 @@ class PersonResource < BaseResource
         end
     end
     return filter, values
+  end
+end
+
+class SpecialPersonResource < BaseResource
+  model_name 'Person'
+
+  def self.records(options = {})
+    Person.where(special: true)
   end
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -116,6 +116,7 @@ end
 JSONAPI.configuration.route_format = :underscored_route
 TestApp.routes.draw do
   jsonapi_resources :people
+  jsonapi_resources :special_people
   jsonapi_resources :comments
   jsonapi_resources :firms
   jsonapi_resources :tags

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -471,4 +471,11 @@ class ResourceTest < ActiveSupport::TestCase
     end
     assert_equal(err.error_messages[:base], ['Boom! Error added in after_save callback.'])
   end
+
+  def test_resource_for_model_path_two_model_with_same_model_name
+    special_person = Person.create!(name: 'Special', date_joined: Date.today, special: true)
+    special_resource = SpecialPersonResource.new(special_person, nil)
+    resource_model = SpecialPersonResource.records({}).first # simulate a find
+    assert_equal(SpecialPersonResource, JSONAPI::Resource.resource_for_model_path(resource_model, ''))
+  end
 end


### PR DESCRIPTION
The problem occurs when we have two Resources with the same
`model_name`, when we try to find the resource for a model, it returns
the first Resource that was loaded using `resource_for`, not the correct
one.
