### PR TITLE
Fix typo in prod env check

### DIFF
--- a/lib/jsonapi/exceptions.rb
+++ b/lib/jsonapi/exceptions.rb
@@ -10,7 +10,7 @@ module JSONAPI
       end
 
       def errors
-        unless Rails.env.prod?
+        unless Rails.env.production?
           meta = Hash.new
           meta[:exception] = exception.message
           meta[:backtrace] = exception.backtrace


### PR DESCRIPTION
- The ActiveSupport::StringInquirer is just a fancy string comparison,
  so the strings have to match :laughing:. The correct environment name
  is "production".

h/t @xdmx https://github.com/cerebris/jsonapi-resources/pull/524#issuecomment-158616665
