### PR TITLE
Minor consistency improvements

### DIFF
--- a/lib/jsonapi/link_builder.rb
+++ b/lib/jsonapi/link_builder.rb
@@ -116,7 +116,7 @@ module JSONAPI
     def regular_primary_resources_path
       [
         formatted_module_path_from_class(primary_resource_klass),
-        route_formatter.format(primary_resource_klass._type.to_s),
+        format_route(primary_resource_klass._type.to_s),
       ].join
     end
 
@@ -127,7 +127,7 @@ module JSONAPI
     def regular_resource_path(source)
       [
         formatted_module_path_from_class(source.class),
-        route_formatter.format(source.class._type.to_s),
+        format_route(source.class._type.to_s),
         "/#{ source.id }",
       ].join
     end

--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -1,7 +1,7 @@
 module JSONAPI
   class ResourceSerializer
 
-    attr_reader :url_generator, :key_formatter, :serialization_options, :primary_class_name
+    attr_reader :link_builder, :key_formatter, :serialization_options, :primary_class_name
 
     # initialize
     # Options can include
@@ -21,7 +21,7 @@ module JSONAPI
       @include            = options.fetch(:include, [])
       @include_directives = options[:include_directives]
       @key_formatter      = options.fetch(:key_formatter, JSONAPI.configuration.key_formatter)
-      @url_generator      = generate_link_builder(primary_resource_klass, options)
+      @link_builder       = generate_link_builder(primary_resource_klass, options)
       @always_include_to_one_linkage_data = options.fetch(:always_include_to_one_linkage_data,
                                                           JSONAPI.configuration.always_include_to_one_linkage_data)
       @always_include_to_many_linkage_data = options.fetch(:always_include_to_many_linkage_data,
@@ -73,7 +73,7 @@ module JSONAPI
     end
 
     def query_link(query_params)
-      url_generator.query_link(query_params)
+      link_builder.query_link(query_params)
     end
 
     def format_key(key)
@@ -226,7 +226,7 @@ module JSONAPI
 
     def relationship_links(source)
       links = {}
-      links[:self] = url_generator.self_link(source)
+      links[:self] = link_builder.self_link(source)
 
       links
     end
@@ -237,11 +237,11 @@ module JSONAPI
     end
 
     def self_link(source, relationship)
-      url_generator.relationships_self_link(source, relationship)
+      link_builder.relationships_self_link(source, relationship)
     end
 
     def related_link(source, relationship)
-      url_generator.relationships_related_link(source, relationship)
+      link_builder.relationships_related_link(source, relationship)
     end
 
     def to_one_linkage(source, relationship)

--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -72,7 +72,7 @@ module JSONAPI
       }
     end
 
-    def find_link(query_params)
+    def query_link(query_params)
       url_generator.query_link(query_params)
     end
 

--- a/lib/jsonapi/response_document.rb
+++ b/lib/jsonapi/response_document.rb
@@ -76,7 +76,7 @@ module JSONAPI
                 relationship = result.source_resource.class._relationships[result._type.to_sym]
                 links[link_name] = serializer.url_generator.relationships_related_link(result.source_resource, relationship, query_params(params))
               else
-                links[link_name] = serializer.find_link(query_params(params))
+                links[link_name] = serializer.query_link(query_params(params))
               end
             end
         end

--- a/lib/jsonapi/response_document.rb
+++ b/lib/jsonapi/response_document.rb
@@ -74,7 +74,7 @@ module JSONAPI
             result.pagination_params.each_pair do |link_name, params|
               if result.is_a?(JSONAPI::RelatedResourcesOperationResult)
                 relationship = result.source_resource.class._relationships[result._type.to_sym]
-                links[link_name] = serializer.url_generator.relationships_related_link(result.source_resource, relationship, query_params(params))
+                links[link_name] = serializer.link_builder.relationships_related_link(result.source_resource, relationship, query_params(params))
               else
                 links[link_name] = serializer.query_link(query_params(params))
               end

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -2288,7 +2288,7 @@ class Api::V5::AuthorsControllerTest < ActionController::TestCase
       def meta(options)
         {
           fixed: 'Hardcoded value',
-          computed: "#{self.class._type.to_s}: #{options[:serializer].url_generator.self_link(self)}",
+          computed: "#{self.class._type.to_s}: #{options[:serializer].link_builder.self_link(self)}",
           computed_foo: options[:serialization_options][:foo],
           options[:serializer].format_key('test_key') => 'test value'
         }
@@ -2322,7 +2322,7 @@ class Api::V5::AuthorsControllerTest < ActionController::TestCase
         {
           custom_hash: {
             fixed: 'Hardcoded value',
-            computed: "#{self.class._type.to_s}: #{options[:serializer].url_generator.self_link(self)}",
+            computed: "#{self.class._type.to_s}: #{options[:serializer].link_builder.self_link(self)}",
             computed_foo: options[:serialization_options][:foo],
             options[:serializer].format_key('test_key') => 'test value'
           }

--- a/test/unit/serializer/serializer_test.rb
+++ b/test/unit/serializer/serializer_test.rb
@@ -1742,7 +1742,7 @@ class SerializerTest < ActionDispatch::IntegrationTest
       def meta(options)
         {
           fixed: 'Hardcoded value',
-          computed: "#{self.class._type.to_s}: #{options[:serializer].url_generator.self_link(self)}"
+          computed: "#{self.class._type.to_s}: #{options[:serializer].link_builder.self_link(self)}"
         }
       end
     end


### PR DESCRIPTION
Rename a couple of variables for consistency and improve #format_route encapsulation in LinkBuilder.
