### PR TITLE
Include options in apply_sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,6 +635,23 @@ def self.apply_filter(records, filter, value, options)
 end
 ```
 
+###### Applying Sorting
+
+You can override the `apply_sort` method to gain control over how the sorting is done. This may be useful in case you'd
+like to base the sorting on variables in your context.
+
+Example:
+
+```ruby
+def self.apply_sort(records, order_options, context = {})  
+  if order_options.has?(:trending)
+    records = records.order_by_trending_scope
+  end
+  
+  super(records, order_options, context)
+end
+```
+
 ###### Override finder methods
 
 Finally if you have more complex requirements for finding you can override the `find` and `find_by_key` methods on the

--- a/README.md
+++ b/README.md
@@ -646,6 +646,7 @@ Example:
 def self.apply_sort(records, order_options, context = {})  
   if order_options.has?(:trending)
     records = records.order_by_trending_scope
+    order_options - [:trending]
   end
   
   super(records, order_options, context)

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -486,7 +486,7 @@ module JSONAPI
         records
       end
 
-      def apply_sort(records, order_options, _options = {})
+      def apply_sort(records, order_options, _context = {})
         if order_options.any?
           records.order(order_options)
         else
@@ -528,8 +528,8 @@ module JSONAPI
         apply_includes(records, options)
       end
 
-      def sort_records(records, order_options, options = {})
-        apply_sort(records, order_options, options)
+      def sort_records(records, order_options, context = {})
+        apply_sort(records, order_options, context)
       end
 
       def find_count(filters, options = {})
@@ -841,7 +841,7 @@ module JSONAPI
               sort_criteria =  options.fetch(:sort_criteria, {})
               unless sort_criteria.nil? || sort_criteria.empty?
                 order_options = relationship.resource_klass.construct_order_options(sort_criteria)
-                records = resource_klass.apply_sort(records, order_options, context: @context)
+                records = resource_klass.apply_sort(records, order_options, @context)
               end
 
               paginator = options[:paginator]

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -486,7 +486,7 @@ module JSONAPI
         records
       end
 
-      def apply_sort(records, order_options, options = {})
+      def apply_sort(records, order_options, _options = {})
         if order_options.any?
           records.order(order_options)
         else

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -564,7 +564,7 @@ module JSONAPI
 
         sort_criteria = options.fetch(:sort_criteria) { [] }
         order_options = construct_order_options(sort_criteria)
-        records = sort_records(records, order_options, options)
+        records = sort_records(records, order_options, context)
 
         records = apply_pagination(records, options[:paginator], order_options)
 

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -841,7 +841,7 @@ module JSONAPI
               sort_criteria =  options.fetch(:sort_criteria, {})
               unless sort_criteria.nil? || sort_criteria.empty?
                 order_options = relationship.resource_klass.construct_order_options(sort_criteria)
-                records = resource_klass.apply_sort(records, order_options)
+                records = resource_klass.apply_sort(records, order_options, context: @context)
               end
 
               paginator = options[:paginator]

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -486,7 +486,7 @@ module JSONAPI
         records
       end
 
-      def apply_sort(records, order_options)
+      def apply_sort(records, order_options, options = {})
         if order_options.any?
           records.order(order_options)
         else
@@ -528,8 +528,8 @@ module JSONAPI
         apply_includes(records, options)
       end
 
-      def sort_records(records, order_options)
-        apply_sort(records, order_options)
+      def sort_records(records, order_options, options = {})
+        apply_sort(records, order_options, options)
       end
 
       def find_count(filters, options = {})
@@ -544,7 +544,7 @@ module JSONAPI
 
         sort_criteria = options.fetch(:sort_criteria) { [] }
         order_options = construct_order_options(sort_criteria)
-        records = sort_records(records, order_options)
+        records = sort_records(records, order_options, options)
 
         records = apply_pagination(records, options[:paginator], order_options)
 

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -240,7 +240,7 @@ class ResourceTest < ActiveSupport::TestCase
 
     # define apply_filters method on post resource to not respect filters
     PostResource.instance_eval do
-      def apply_sort(records, criteria)
+      def apply_sort(records, criteria, options = {})
         # :nocov:
         records
         # :nocov:
@@ -253,7 +253,7 @@ class ResourceTest < ActiveSupport::TestCase
   ensure
     # reset method to original implementation
     PostResource.instance_eval do
-      def apply_sort(records, criteria)
+      def apply_sort(records, criteria, options = {})
         # :nocov:
         super
         # :nocov:

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -295,7 +295,7 @@ class ResourceTest < ActiveSupport::TestCase
 
     # define apply_filters method on post resource to not respect filters
     PostResource.instance_eval do
-      def apply_sort(records, criteria, options = {})
+      def apply_sort(records, criteria, context = {})
         # :nocov:
         records
         # :nocov:
@@ -308,7 +308,7 @@ class ResourceTest < ActiveSupport::TestCase
   ensure
     # reset method to original implementation
     PostResource.instance_eval do
-      def apply_sort(records, criteria, options = {})
+      def apply_sort(records, criteria, context = {})
         # :nocov:
         super
         # :nocov:


### PR DESCRIPTION
Including options will allow to create sorting based on the actual context. It's especially useful when working with scopes that need request based parameters. In my case position or the current_user
