### PR TITLE
Fix Rails autoloading for Resources (code reload in development)

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -293,7 +293,7 @@ module JSONAPI
       end
 
       def resource_for(resource_path)
-        unless @@resource_types.key? resource_path
+        unless @@resource_types.key?(resource_path) && Rails.configuration.cache_classes
           klass_name = "#{resource_path.to_s.underscore.singularize}_resource".camelize
           klass = (klass_name.safe_constantize or
             fail NameError,


### PR DESCRIPTION
This is a simplistic attempt at fixing https://github.com/cerebris/jsonapi-resources/issues/551 by disabling the utilization of resource_types cache when cache_classes is false.

Though this forces recreation of resources on each call to resource_for, this fixes Rails autoloading to actually reload Resource code while in development (previously `@@resource_types` held on to the stale version of the class from before the autoload).

A more efficient solution would only reinstantiate the resources after the Rails `set_clear_dependencies_hook` clears `ActiveSupport::Dependencies`, but would likely require more complex callback/finalizer code.
