### PR TITLE
Model hints for namespaced models

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ end
 
 Resource instances are created from model records. The determination of the correct resource type is performed using a
 simple rule based on the model's name. The name is used to find a resource in the same module (as the originating 
-resource) that matches the name. This usually works quite well, however it can fail when model name's do not match
+resource) that matches the name. This usually works quite well, however it can fail when model names do not match
 resource names. It can also fail when using namespaced models. In this case a `model_hint` can be created to map model
 names to resources. For example:
 

--- a/README.md
+++ b/README.md
@@ -361,6 +361,39 @@ class AuthorResource < JSONAPI::Resource
 end
 ```
 
+When the `model_name` is called a corresponding `model_hint` is also added. This can be skipped by using the
+`model_hint` option set to false. For example:
+
+```ruby
+class AuthorResource < JSONAPI::Resource
+  model_name 'Legacy::Person', model_hint: false
+  model_hint model: 'Legacy::Person', resource: 'person'
+end
+```
+
+#### Model Hints
+
+Resource instances are created from model records. The determination of the correct resource type is performed using a
+simple rule based on the model's name. The name is used to find a resource in the same module (as the originating 
+resource) that matches the name. This usually works quite well, however it can fail when model name's do not match
+resource names. It can also fail when using namespaced models. In this case a `model_hint` can be created to map model
+names to resources. For example:
+
+```ruby
+class AuthorResource < JSONAPI::Resource
+  attribute :name
+  model_name 'Person'
+  model_hint model: Commenter, resource: :special_person
+
+  has_many :posts
+  has_many :commenters
+end
+```
+
+Model hints inherit from parent resources, but are not global in scope. The `model_hint` method requires a `model` and
+a `resource` named parameter. `model` takes an ActiveRecord class or class name, and `resource` takes a resource type or
+a resource class.
+
 #### Relationships
 
 Related resources need to be specified in the resource. These may be declared with the `relationship` or the `has_one`

--- a/README.md
+++ b/README.md
@@ -361,16 +361,6 @@ class AuthorResource < JSONAPI::Resource
 end
 ```
 
-When the `model_name` is called a corresponding `model_hint` is also added. This can be skipped by using the
-`model_hint` option set to false. For example:
-
-```ruby
-class AuthorResource < JSONAPI::Resource
-  model_name 'Legacy::Person', model_hint: false
-  model_hint model: 'Legacy::Person', resource: 'person'
-end
-```
-
 #### Model Hints
 
 Resource instances are created from model records. The determination of the correct resource type is performed using a
@@ -390,9 +380,18 @@ class AuthorResource < JSONAPI::Resource
 end
 ```
 
-Model hints inherit from parent resources, but are not global in scope. The `model_hint` method requires a `model` and
-a `resource` named parameter. `model` takes an ActiveRecord class or class name, and `resource` takes a resource type or
-a resource class.
+Note that when `model_name` is set a corresponding `model_hint` is also added. This can be skipped by using the
+`add_model_hint` option set to false. For example:
+
+```ruby
+class AuthorResource < JSONAPI::Resource
+  model_name 'Legacy::Person', add_model_hint: false
+end
+```
+
+Model hints inherit from parent resources, but are not global in scope. The `model_hint` method accepts `model` and
+`resource` named parameters. `model` takes an ActiveRecord class or class name (defaults to the model name), and 
+`resource` takes a resource type or a resource class (defaults to the current resource's type).
 
 #### Relationships
 

--- a/lib/jsonapi/relationship.rb
+++ b/lib/jsonapi/relationship.rb
@@ -1,14 +1,15 @@
 module JSONAPI
   class Relationship
     attr_reader :acts_as_set, :foreign_key, :type, :options, :name,
-                :class_name, :polymorphic, :always_include_linkage_data
+                :class_name, :polymorphic, :always_include_linkage_data,
+                :parent_resource
 
     def initialize(name, options = {})
       @name = name.to_s
       @options = options
       @acts_as_set = options.fetch(:acts_as_set, false) == true
       @foreign_key = options[:foreign_key] ? options[:foreign_key].to_sym : nil
-      @module_path = options[:module_path] || ''
+      @parent_resource = options[:parent_resource]
       @relation_name = options.fetch(:relation_name, @name)
       @polymorphic = options.fetch(:polymorphic, false) == true
       @always_include_linkage_data = options.fetch(:always_include_linkage_data, false) == true
@@ -21,7 +22,7 @@ module JSONAPI
     end
 
     def resource_klass
-      @resource_klass ||= Resource.resource_for(@module_path + @class_name)
+      @resource_klass = @parent_resource.resource_for(@class_name)
     end
 
     def relation_name(options)

--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -463,7 +463,7 @@ module JSONAPI
 
       unless links_object[:id].nil?
         resource = self.resource_klass || Resource
-        relationship_resource = resource.resource_for(@resource_klass.module_path + unformat_key(links_object[:type]).to_s)
+        relationship_resource = resource.resource_for(unformat_key(links_object[:type]).to_s)
         relationship_id = relationship_resource.verify_key(links_object[:id], @context)
         if relationship.polymorphic?
           { id: relationship_id, type: unformat_key(links_object[:type].to_s) }

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -671,7 +671,7 @@ module JSONAPI
       end
 
       def _model_name
-        @_model_name ||= name.demodulize.sub(/Resource$/, '')
+        _abstract ? '' : @_model_name ||= name.demodulize.sub(/Resource$/, '')
       end
 
       def _primary_key

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -398,7 +398,7 @@ module JSONAPI
       def model_name(model, options = {})
         @_model_name = model.to_sym
 
-        model_hint(model: @_model_name, resource: self) unless options[:model_hint] == false
+        model_hint(model: @_model_name, resource: self) unless options[:add_model_hint] == false
       end
 
       def model_hint(model: _model_name, resource: _type)

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -401,7 +401,7 @@ module JSONAPI
         model_hint(model: @_model_name, resource: self) unless options[:model_hint] == false
       end
 
-      def model_hint(model:, resource:)
+      def model_hint(model: _model_name, resource: _type)
         model_name = ((model.is_a?(Class)) && (model < ActiveRecord::Base)) ? model.name : model
         resource_type = ((resource.is_a?(Class)) && (resource < JSONAPI::Resource)) ? resource._type : resource.to_s
 

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -2183,7 +2183,7 @@ class PeopleControllerTest < ActionController::TestCase
     assert_equal json_response['data'][0]['attributes']['name'], 'Joe Author'
   end
 
-  def test_get_related_resource
+  def test_get_related_resource_no_namespace
     original_config = JSONAPI.configuration.dup
     JSONAPI.configuration.json_key_format = :dasherized_key
     JSONAPI.configuration.route_format = :underscored_key
@@ -2250,6 +2250,15 @@ class PeopleControllerTest < ActionController::TestCase
                          data: nil
                        }
 
+  end
+end
+
+class BooksControllerTest < ActionController::TestCase
+  def test_books_include_correct_type
+    $test_user = Person.find(1)
+    get :index, {filter: {id: '1'}, include: 'authors'}
+    assert_response :success
+    assert_equal 'authors', json_response['included'][0]['type']
   end
 end
 

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -3109,19 +3109,17 @@ class Api::V1::MoonsControllerTest < ActionController::TestCase
    def test_get_related_resource
       get :get_related_resource, {crater_id: 'S56D', relationship: 'moon', source: "api/v1/craters"}
       assert_response :success
-      assert_hash_equals json_response,
-                              {
-                                data: {
-                                  id: "1",
-                                  type: "moons",
-                                  links: {self: "http://test.host/moons/1"},
-                                  attributes: {name: "Titan", description: "Best known of the Saturn moons."},
-                                  relationships: {
-                                    planet: {links: {self: "http://test.host/moons/1/relationships/planet", related: "http://test.host/moons/1/planet"}},
-                                    craters: {links: {self: "http://test.host/moons/1/relationships/craters", related: "http://test.host/moons/1/craters"}}}
-                                  }
-                                }
-
+      assert_hash_equals({
+                           data: {
+                             id: "1",
+                             type: "moons",
+                             links: {self: "http://test.host/api/v1/moons/1"},
+                             attributes: {name: "Titan", description: "Best known of the Saturn moons."},
+                             relationships: {
+                               planet: {links: {self: "http://test.host/api/v1/moons/1/relationships/planet", related: "http://test.host/api/v1/moons/1/planet"}},
+                               craters: {links: {self: "http://test.host/api/v1/moons/1/relationships/craters", related: "http://test.host/api/v1/moons/1/craters"}}}
+                             }
+                           }, json_response)
    end
 
    def test_get_related_resources_with_select_some_db_columns
@@ -3150,23 +3148,24 @@ class Api::V1::CratersControllerTest < ActionController::TestCase
   def test_get_related_resources
     get :get_related_resources, {moon_id: '1', relationship: 'craters', source: "api/v1/moons"}
     assert_response :success
-    assert_hash_equals json_response,
-                      {
-                        data: [
-                          {id:"A4D3",
-                           type:"craters",
-                           links:{self: "http://test.host/api/v1/craters/A4D3"},
-                           attributes:{code: "A4D3", description: "Small crater"},
-                           relationships:{moon: {links: {self: "http://test.host/api/v1/craters/A4D3/relationships/moon", related: "http://test.host/api/v1/craters/A4D3/moon"}}}
-                          },
-                          {id: "S56D",
-                           type: "craters",
-                           links:{self: "http://test.host/api/v1/craters/S56D"},
-                           attributes:{code: "S56D", description: "Very large crater"},
-                           relationships:{moon: {links: {self: "http://test.host/api/v1/craters/S56D/relationships/moon", related: "http://test.host/api/v1/craters/S56D/moon"}}}
-                          }
-                        ]
-                      }
+    assert_hash_equals({
+                         data: [
+                           {
+                             id:"A4D3",
+                             type:"craters",
+                             links:{self: "http://test.host/api/v1/craters/A4D3"},
+                             attributes:{code: "A4D3", description: "Small crater"},
+                             relationships:{moon: {links: {self: "http://test.host/api/v1/craters/A4D3/relationships/moon", related: "http://test.host/api/v1/craters/A4D3/moon"}}}
+                           },
+                           {
+                             id: "S56D",
+                             type: "craters",
+                             links:{self: "http://test.host/api/v1/craters/S56D"},
+                             attributes:{code: "S56D", description: "Very large crater"},
+                             relationships:{moon: {links: {self: "http://test.host/api/v1/craters/S56D/relationships/moon", related: "http://test.host/api/v1/craters/S56D/moon"}}}
+                           }
+                         ]
+                       }, json_response)
   end
 
   def test_show_relationship

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -3236,3 +3236,30 @@ class VehiclesControllerTest < ActionController::TestCase
     end
   end
 end
+
+class Api::V7::ClientsControllerTest < ActionController::TestCase
+  def test_get_namespaced_model_not_matching_resource_using_model_hint
+    get :index
+    assert_response :success
+    assert_equal 'clients', json_response['data'][0]['type']
+  ensure
+    Api::V7::ClientResource._model_hints['api/v7/customer'] = 'clients'
+  end
+
+  def test_get_namespaced_model_not_matching_resource_not_using_model_hint
+    Api::V7::ClientResource._model_hints.delete('api/v7/customer')
+    get :index
+    assert_response :success
+    assert_equal 'customers', json_response['data'][0]['type']
+  ensure
+    Api::V7::ClientResource._model_hints['api/v7/customer'] = 'clients'
+  end
+end
+
+class Api::V7::CustomersControllerTest < ActionController::TestCase
+  def test_get_namespaced_model_matching_resource
+    get :index
+    assert_response :success
+    assert_equal 'customers', json_response['data'][0]['type']
+  end
+end

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -15,6 +15,7 @@ ActiveRecord::Schema.define do
     t.belongs_to :preferences
     t.integer    :hair_cut_id, index: true
     t.boolean    :book_admin, default: false
+    t.boolean    :special, default: false
     t.timestamps null: false
   end
 
@@ -767,6 +768,14 @@ class PersonResource < BaseResource
         end
     end
     return filter, values
+  end
+end
+
+class SpecialPersonResource < BaseResource
+  model_name 'Person'
+
+  def self.records(options = {})
+    Person.where(special: true)
   end
 end
 

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -503,6 +503,16 @@ end
 class WebPage < ActiveRecord::Base
 end
 
+module Api
+  module V7
+    class Client < Customer
+    end
+
+    class Customer < Customer
+    end
+  end
+end
+
 ### OperationsProcessor
 class CountingActiveRecordOperationsProcessor < ActiveRecordOperationsProcessor
   after_find_operation do
@@ -732,6 +742,9 @@ module Api
 
     class OrderFlagsController < JSONAPI::ResourceController
     end
+
+    class ClientsController < JSONAPI::ResourceController
+    end
   end
 
   module V8
@@ -771,7 +784,13 @@ class PersonResource < BaseResource
   end
 end
 
-class SpecialPersonResource < BaseResource
+class SpecialBaseResource < BaseResource
+  abstract
+
+  model_hint model: Person, resource: :special_person
+end
+
+class SpecialPersonResource < SpecialBaseResource
   model_name 'Person'
 
   def self.records(options = {})
@@ -1358,10 +1377,24 @@ module Api
   end
 
   module V7
-    CustomerResource = V6::CustomerResource.dup
     PurchaseOrderResource = V6::PurchaseOrderResource.dup
     OrderFlagResource = V6::OrderFlagResource.dup
     LineItemResource = V6::LineItemResource.dup
+
+    class CustomerResource < V6::CustomerResource
+      model_name 'Api::V7::Customer'
+      attribute :name
+      has_many :purchase_orders
+    end
+
+    class ClientResource < JSONAPI::Resource
+      model_name 'Api::V7::Customer'
+
+      attribute :name
+
+      has_many :purchase_orders
+    end
+
   end
 
   module V8
@@ -1401,7 +1434,10 @@ module Legacy
 end
 
 class FlatPostResource < JSONAPI::Resource
-  model_name "::Legacy::FlatPost"
+  model_name "Legacy::FlatPost", model_hint: false
+
+  model_hint model: "Legacy::FlatPost", resource: FlatPostResource
+
   attribute :title
 end
 

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -1434,7 +1434,7 @@ module Legacy
 end
 
 class FlatPostResource < JSONAPI::Resource
-  model_name "Legacy::FlatPost", model_hint: false
+  model_name "Legacy::FlatPost", add_model_hint: false
 
   model_hint model: "Legacy::FlatPost", resource: FlatPostResource
 

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -135,6 +135,11 @@ ActiveRecord::Schema.define do
     t.boolean :banned, default: false
   end
 
+  create_table :book_authors, force: true do |t|
+    t.integer :book_id
+    t.integer :person_id
+  end
+
   create_table :book_comments, force: true do |t|
     t.text       :body
     t.belongs_to :book, index: true
@@ -254,6 +259,8 @@ class Person < ActiveRecord::Base
   belongs_to :preferences
   belongs_to :hair_cut
   has_one :author_detail
+
+  has_and_belongs_to_many :books, join_table: :book_authors
 
   ### Validations
   validates :name, presence: true
@@ -409,6 +416,8 @@ end
 class Book < ActiveRecord::Base
   has_many :book_comments
   has_many :approved_book_comments, -> { where(approved: true) }, class_name: "BookComment"
+
+  has_and_belongs_to_many :authors, join_table: :book_authors, class_name: "Person"
 end
 
 class BookComment < ActiveRecord::Base
@@ -608,6 +617,12 @@ class CarsController < JSONAPI::ResourceController
 end
 
 class BoatsController < JSONAPI::ResourceController
+end
+
+class BooksController < JSONAPI::ResourceController
+end
+
+class AuthorsController < JSONAPI::ResourceController
 end
 
 ### CONTROLLERS
@@ -1084,6 +1099,19 @@ end
 class WebPageResource < JSONAPI::Resource
   attribute :href
   attribute :link
+end
+
+class AuthorResource < JSONAPI::Resource
+  model_name 'Person'
+  attributes :name
+end
+
+class BookResource < JSONAPI::Resource
+  has_many :authors, class_name: 'Author'
+end
+
+class AuthorDetailResource < JSONAPI::Resource
+  attributes :author_stuff
 end
 
 module Api

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -1144,32 +1144,32 @@ module Api
       filters :writer
     end
 
-    PersonResource = PersonResource.dup
-    CommentResource = CommentResource.dup
-    TagResource = TagResource.dup
-    SectionResource = SectionResource.dup
-    IsoCurrencyResource = IsoCurrencyResource.dup
-    ExpenseEntryResource = ExpenseEntryResource.dup
-    BreedResource = BreedResource.dup
-    PlanetResource = PlanetResource.dup
-    PlanetTypeResource = PlanetTypeResource.dup
-    MoonResource = MoonResource.dup
-    CraterResource = CraterResource.dup
-    PreferencesResource = PreferencesResource.dup
-    EmployeeResource = EmployeeResource.dup
-    FriendResource = FriendResource.dup
-    HairCutResource = HairCutResource.dup
-    VehicleResource = VehicleResource.dup
-    CarResource = CarResource.dup
-    BoatResource = BoatResource.dup
+    class PersonResource < PersonResource; end
+    class CommentResource < CommentResource; end
+    class TagResource < TagResource; end
+    class SectionResource < SectionResource; end
+    class IsoCurrencyResource < IsoCurrencyResource; end
+    class ExpenseEntryResource < ExpenseEntryResource; end
+    class BreedResource < BreedResource; end
+    class PlanetResource < PlanetResource; end
+    class PlanetTypeResource < PlanetTypeResource; end
+    class MoonResource < MoonResource; end
+    class CraterResource < CraterResource; end
+    class PreferencesResource < PreferencesResource; end
+    class EmployeeResource < EmployeeResource; end
+    class FriendResource < FriendResource; end
+    class HairCutResource < HairCutResource; end
+    class VehicleResource < VehicleResource; end
+    class CarResource < CarResource; end
+    class BoatResource < BoatResource; end
   end
 end
 
 module Api
   module V2
-    PreferencesResource = PreferencesResource.dup
-    PersonResource = PersonResource.dup
-    PostResource = PostResource.dup
+    class PreferencesResource < PreferencesResource; end
+    class PersonResource < PersonResource; end
+    class PostResource < PostResource; end
 
     class BookResource < JSONAPI::Resource
       attribute :title
@@ -1273,17 +1273,17 @@ end
 
 module Api
   module V3
-    PostResource = PostResource.dup
-    PreferencesResource = PreferencesResource.dup
+    class PostResource < PostResource; end
+    class PreferencesResource < PreferencesResource; end
   end
 end
 
 module Api
   module V4
-    PostResource = PostResource.dup
-    ExpenseEntryResource = ExpenseEntryResource.dup
-    IsoCurrencyResource = IsoCurrencyResource.dup
-
+    class PostResource < PostResource; end
+    class PersonResource < PersonResource; end
+    class ExpenseEntryResource < ExpenseEntryResource; end
+    class IsoCurrencyResource < IsoCurrencyResource; end
 
     class BookResource < Api::V2::BookResource
       paginator :paged
@@ -1334,11 +1334,14 @@ module Api
       attributes :author_stuff
     end
 
-    PersonResource = PersonResource.dup
-    PostResource = PostResource.dup
-    ExpenseEntryResource = ExpenseEntryResource.dup
-    IsoCurrencyResource = IsoCurrencyResource.dup
-    EmployeeResource = EmployeeResource.dup
+    class PersonResource < PersonResource; end
+    class PostResource < PostResource; end
+    class TagResource < TagResource; end
+    class SectionResource < SectionResource; end
+    class CommentResource < CommentResource; end
+    class ExpenseEntryResource < ExpenseEntryResource; end
+    class IsoCurrencyResource < IsoCurrencyResource; end
+    class EmployeeResource < EmployeeResource; end
   end
 end
 
@@ -1405,9 +1408,9 @@ module Api
   end
 
   module V7
-    PurchaseOrderResource = V6::PurchaseOrderResource.dup
-    OrderFlagResource = V6::OrderFlagResource.dup
-    LineItemResource = V6::LineItemResource.dup
+    class PurchaseOrderResource < V6::PurchaseOrderResource; end
+    class OrderFlagResource < V6::OrderFlagResource; end
+    class LineItemResource < V6::LineItemResource; end
 
     class CustomerResource < V6::CustomerResource
       model_name 'Api::V7::Customer'

--- a/test/fixtures/book_authors.yml
+++ b/test/fixtures/book_authors.yml
@@ -1,0 +1,3 @@
+book_author_1_1:
+  book_id: 1
+  person_id: 1

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -143,6 +143,9 @@ TestApp.routes.draw do
   jsonapi_resources :boats
   jsonapi_resources :flat_posts
 
+  jsonapi_resources :books
+  jsonapi_resources :authors
+
   namespace :api do
     namespace :v1 do
       jsonapi_resources :people

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -226,6 +226,8 @@ TestApp.routes.draw do
       jsonapi_resources :customers
       jsonapi_resources :purchase_orders
       jsonapi_resources :line_items
+
+      jsonapi_resources :clients
     end
 
     namespace :v8 do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -116,6 +116,7 @@ end
 JSONAPI.configuration.route_format = :underscored_route
 TestApp.routes.draw do
   jsonapi_resources :people
+  jsonapi_resources :special_people
   jsonapi_resources :comments
   jsonapi_resources :firms
   jsonapi_resources :tags

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -121,6 +121,23 @@ class ResourceTest < ActiveSupport::TestCase
   def test_resource_for_namespaced_resource
     assert_equal(MyModule::MyNamespacedResource.resource_for('related'), MyModule::RelatedResource)
   end
+
+  def test_relationship_parent_point_to_correct_resource
+    assert_equal MyModule::MyNamespacedResource, MyModule::MyNamespacedResource._relationships[:related].parent_resource
+  end
+
+  def test_relationship_parent_option_point_to_correct_resource
+    assert_equal MyModule::MyNamespacedResource, MyModule::MyNamespacedResource._relationships[:related].options[:parent_resource]
+  end
+
+  def test_derived_resources_relationships_parent_point_to_correct_resource
+    assert_equal MyAPI::MyNamespacedResource, MyAPI::MyNamespacedResource._relationships[:related].parent_resource
+  end
+
+  def test_derived_resources_relationships_parent_options_point_to_correct_resource
+    assert_equal MyAPI::MyNamespacedResource, MyAPI::MyNamespacedResource._relationships[:related].options[:parent_resource]
+  end
+
   def test_base_resource_abstract
     assert BaseResource._abstract
   end

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -63,6 +63,20 @@ end
 
 module MyModule
   class MyNamespacedResource < JSONAPI::Resource
+    model_name "Person"
+    has_many :related
+  end
+
+  class RelatedResource < JSONAPI::Resource
+    model_name "Comment"
+  end
+end
+
+module MyAPI
+  class MyNamespacedResource < MyModule::MyNamespacedResource
+  end
+
+  class RelatedResource < MyModule::RelatedResource
   end
 end
 
@@ -83,6 +97,30 @@ class ResourceTest < ActiveSupport::TestCase
     assert_equal(MyModule::MyNamespacedResource.module_path, 'my_module/')
   end
 
+  def test_resource_for_root_resource
+    assert_raises NameError do
+      JSONAPI::Resource.resource_for('related')
+    end
+  end
+
+  def test_resource_for_with_namespaced_paths
+    assert_equal(JSONAPI::Resource.resource_for('my_module/related'), MyModule::RelatedResource)
+    assert_equal(PostResource.resource_for('my_module/related'), MyModule::RelatedResource)
+    assert_equal(MyModule::MyNamespacedResource.resource_for('my_module/related'), MyModule::RelatedResource)
+  end
+
+  def test_resource_for_resource_does_not_exist_at_root
+    assert_raises NameError do
+      ArticleResource.resource_for('related')
+    end
+    assert_raises NameError do
+      JSONAPI::Resource.resource_for('related')
+    end
+  end
+
+  def test_resource_for_namespaced_resource
+    assert_equal(MyModule::MyNamespacedResource.resource_for('related'), MyModule::RelatedResource)
+  end
   def test_base_resource_abstract
     assert BaseResource._abstract
   end

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -472,10 +472,10 @@ class ResourceTest < ActiveSupport::TestCase
     assert_equal(err.error_messages[:base], ['Boom! Error added in after_save callback.'])
   end
 
-  def test_resource_for_model_path_two_model_with_same_model_name
+  def test_resource_for_model_use_hint
     special_person = Person.create!(name: 'Special', date_joined: Date.today, special: true)
     special_resource = SpecialPersonResource.new(special_person, nil)
     resource_model = SpecialPersonResource.records({}).first # simulate a find
-    assert_equal(SpecialPersonResource, JSONAPI::Resource.resource_for_model_path(resource_model, ''))
+    assert_equal(SpecialPersonResource, SpecialPersonResource.resource_for_model(resource_model))
   end
 end

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -471,4 +471,11 @@ class ResourceTest < ActiveSupport::TestCase
     end
     assert_equal(err.error_messages[:base], ['Boom! Error added in after_save callback.'])
   end
+
+  def test_resource_for_model_path_two_model_with_same_model_name
+    special_person = Person.create!(name: 'Special', date_joined: Date.today, special: true)
+    special_resource = SpecialPersonResource.new(special_person, nil)
+    resource_model = SpecialPersonResource.records({}).first # simulate a find
+    assert_equal(SpecialPersonResource, JSONAPI::Resource.resource_for_model_path(resource_model, ''))
+  end
 end


### PR DESCRIPTION
This PR may not be ready to merge and at this point is for discussion and testing only. I am open to other ideas on how to solve this issue, while still maintaining backwards compatibility.

This reverts the logic for namespaced models introduced in 0.6.2. This logic created a mapping between models and resources, but this mapping could not be relied on 100% of the time, as #541 identified. So in it's place a `model_hint` is used. This also maps models to resources, however these hints are added in the resource definition. In addition when the `model_name` is defined (say for a namespaced model) a hint is added (though this can be skipped with an option).

I am hoping this will fix #525 and #541while not breaking existing code, which fixed #523 (and possibly fixed #513).

Goals for this PR were:
- maintain backwards compatibility
  - particularly _not_ requiring namespaced models
- require a minimum of code to support namespaced models
  - work with existing `model_name` methodology
- However support custom mappings if needed
