### PR TITLE
Validation errors can have metadata added to them

### DIFF
--- a/lib/jsonapi/exceptions.rb
+++ b/lib/jsonapi/exceptions.rb
@@ -301,10 +301,11 @@ module JSONAPI
     end
 
     class ValidationErrors < Error
-      attr_reader :error_messages, :resource_relationships
+      attr_reader :error_messages, :error_metadata, :resource_relationships
 
       def initialize(resource)
         @error_messages = resource.model_error_messages
+        @error_metadata = resource.validation_error_metadata
         @resource_relationships = resource.class._relationships.keys
         @key_formatter = JSONAPI.configuration.key_formatter
       end
@@ -326,7 +327,13 @@ module JSONAPI
                            status: :unprocessable_entity,
                            title: message,
                            detail: "#{format_key(attr_key)} - #{message}",
-                           source: { pointer: pointer(attr_key) })
+                           source: { pointer: pointer(attr_key) },
+                           meta: metadata_for(attr_key, message))
+      end
+
+      def metadata_for(attr_key, message)
+        return if error_metadata.nil?
+        error_metadata[attr_key] ?  error_metadata[attr_key][message] : nil
       end
 
       def pointer(attr_or_relationship_name)

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -121,6 +121,29 @@ module JSONAPI
       _model.errors.messages
     end
 
+    # Add metadata to validation error objects.
+    #
+    # Suppose `model_error_messages` returned the following error messages
+    # hash:
+    #
+    #   {password: ["too_short", "format"]}
+    #
+    # Then to add data to the validation error `validation_error_metadata`
+    # could return:
+    #
+    #   {
+    #     password: {
+    #       "too_short": {"minimum_length" => 6},
+    #       "format": {"requirement" => "must contain letters and numbers"}
+    #     }
+    #   }
+    #
+    # The specified metadata is then be merged into the validation error
+    # object.
+    def validation_error_metadata
+      {}
+    end
+
     # Override this to return resource level meta data
     # must return a hash, and if the hash is empty the meta section will not be serialized with the resource
     # meta keys will be not be formatted with the key formatter for the serializer by default. They can however use the


### PR DESCRIPTION
The JSON API specification supports error objects having metadata added to them.  This PR adds support for metadata on validation errors.

A resource can now optionally define a `validation_error_metadata` method which can return any metadata to merge into the validation error.

Suppose `model_error_messages` returned the following error messages hash:

```
{password: ["too_short", "format"]}
```

Then to add data to the validation error `validation_error_metadata` could return:

```
{
  password: {
    "too_short": {"minimum_length" => 6},
    "format": {"requirement" => "must contain letters and numbers"}
  }
}
```

The specified metadata is then be merged into the validation error object.

An alternate API I considered was to have a `validation_error_metadata_for(attr_key, message)` method on `Resource` which would return the metadata for a single validation error object.
