### PR TITLE
Add support for nesting attributes in jsonapi resources.

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -330,7 +330,7 @@ module JSONAPI
         end
       end
 
-      attr_accessor :_attributes, :_relationships, :_allowed_filters, :_type, :_paginator, :_model_hints
+      attr_accessor :_attributes, :_relationships, :_allowed_filters, :_type, :_paginator, :_model_hints, :_include_links
 
       def create(context)
         new(create_model, context)
@@ -346,6 +346,14 @@ module JSONAPI
 
       def routing_resource_options
         @_routing_resource_options ||= {}
+      end
+
+      def render_links(choice)
+        @_include_links = choice
+      end
+
+      def _include_links
+        @_include_links.nil? ? true : @_include_links
       end
 
       # Methods used in defining a resource class

--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -94,9 +94,10 @@ module JSONAPI
         format = source.class._attribute_options(name)[:format]
         unless name == :id
           if format == :nested_attribute
-            hash[format_key(name)] = format_value(source.public_send(name),
-                                                  format,
-                                                  source.class._attribute_options(name).merge(context: source.context))
+            formatted_value = format_value(source.public_send(name),
+                                           format,
+                                           source.class._attribute_options(name).merge(context: source.context))
+            hash[format_key(name)] = formatted_value if source.public_send(name)
           else
             hash[format_key(name)] = format_value(source.public_send(name), format)
           end

--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -122,7 +122,7 @@ module JSONAPI
       obj_hash['type'] = format_key(source.class._type.to_s)
 
       links = relationship_links(source)
-      obj_hash['links'] = links unless links.empty?
+      obj_hash['links'] = links unless links.empty? || !source.class._include_links
 
       attributes = attribute_hash(source)
       obj_hash['attributes'] = attributes unless attributes.empty?

--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -86,6 +86,7 @@ module JSONAPI
     end
 
     def attribute_hash(source)
+      return if source._model.nil?
       requested = requested_fields(source.class)
       fields = source.fetchable_fields & source.class._attributes.keys.to_a
       fields = requested & fields unless requested.nil?

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -247,6 +247,16 @@ ActiveRecord::Schema.define do
 
   create_table :questionables, force: true do |t|
   end
+
+  create_table :parents, force: true do |t|
+    t.string :name
+  end
+
+  create_table :children, force: true do |t|
+    t.string :name
+    t.integer :age
+    t.integer :parent_id
+  end
   # special cases
 end
 
@@ -510,6 +520,14 @@ class Make < ActiveRecord::Base
 end
 
 class WebPage < ActiveRecord::Base
+end
+
+class Parent < ActiveRecord::Base
+  has_many :children
+end
+
+class Child < ActiveRecord:: Base
+  belongs_to :parent
 end
 
 module Api
@@ -1006,6 +1024,16 @@ class PlanetResource < JSONAPI::Resource
   def records_for_moons
     Moon.joins(:craters).select('moons.*, craters.code').distinct
   end
+end
+
+class ChildResource < JSONAPI::Resource
+  attribute :name
+  attribute :age
+end
+
+class ParentResource < JSONAPI::Resource
+  attribute :name
+  attribute :children, format: :nested_attribute, with: ChildResource
 end
 
 class PropertyResource < JSONAPI::Resource

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -324,6 +324,12 @@ end
 class Cat < ActiveRecord::Base
 end
 
+# No table backing needed.
+class NoLinks
+  include ActiveModel::Model
+  attr_accessor :name, :id
+end
+
 class IsoCurrency < ActiveRecord::Base
   self.primary_key = :code
   # has_many :expense_entries, foreign_key: 'currency_code'
@@ -1107,6 +1113,11 @@ end
 
 class AuthorDetailResource < JSONAPI::Resource
   attributes :author_stuff
+end
+
+class NoLinksResource < JSONAPI::Resource
+  attributes :name
+  render_links false
 end
 
 module Api

--- a/test/fixtures/child.yml
+++ b/test/fixtures/child.yml
@@ -1,0 +1,11 @@
+a:
+  id: 1
+  name: John Smith Jr.
+  age: 2
+  parent_id: 1
+
+b:
+  id: 2
+  name: Jane Smith
+  age: 5
+  parent_id: 1

--- a/test/fixtures/parents.yml
+++ b/test/fixtures/parents.yml
@@ -1,0 +1,3 @@
+a:
+  id: 1
+  name: John Smith

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -146,6 +146,8 @@ TestApp.routes.draw do
   jsonapi_resources :books
   jsonapi_resources :authors
 
+  jsonapi_resources :parents
+
   namespace :api do
     namespace :v1 do
       jsonapi_resources :people
@@ -311,7 +313,7 @@ end
 
 class DateWithTimezoneValueFormatter < JSONAPI::ValueFormatter
   class << self
-    def format(raw_value)
+    def format(raw_value, options = {})
       raw_value.in_time_zone('Eastern Time (US & Canada)').to_s
     end
   end
@@ -319,7 +321,7 @@ end
 
 class DateValueFormatter < JSONAPI::ValueFormatter
   class << self
-    def format(raw_value)
+    def format(raw_value, options = {})
       raw_value.strftime('%m/%d/%Y')
     end
   end
@@ -327,7 +329,7 @@ end
 
 class TitleValueFormatter < JSONAPI::ValueFormatter
   class << self
-    def format(raw_value)
+    def format(raw_value, options = {})
       super(raw_value).titlecase
     end
 

--- a/test/unit/serializer/serializer_test.rb
+++ b/test/unit/serializer/serializer_test.rb
@@ -1480,9 +1480,38 @@ class SerializerTest < ActionDispatch::IntegrationTest
     )
   end
 
+  def test_nested_attributes_serialization
+    planet_hash = JSONAPI::ResourceSerializer.new(ParentResource).serialize_to_hash(
+        ParentResource.new(Parent.find(1), nil))
+
+    assert_hash_equals(
+      {
+        data: {
+          type: 'parents',
+          id: '1',
+          links: {
+            self: '/parents/1'
+          },
+          attributes: {
+            name: 'John Smith',
+            children: [
+              {
+                name: 'John Smith Jr.',
+                age: 2
+              },
+              {
+                name: 'Jane Smith',
+                age: 5
+              }
+            ]
+        }
+      }
+      }, planet_hash)
+  end
+
   def test_serializer_empty_links_null_and_array
     planet_hash = JSONAPI::ResourceSerializer.new(PlanetResource).serialize_to_hash(
-      PlanetResource.new(Planet.find(8), nil))
+        PlanetResource.new(Planet.find(8), nil))
 
     assert_hash_equals(
       {

--- a/test/unit/serializer/serializer_test.rb
+++ b/test/unit/serializer/serializer_test.rb
@@ -1942,4 +1942,24 @@ class SerializerTest < ActionDispatch::IntegrationTest
       out.strip
     )
   end
+
+  def test_optional_links
+    @resource = NoLinks.new(name: 'Mike')
+    serialized = JSONAPI::ResourceSerializer.new(
+        NoLinksResource,
+    ).serialize_to_hash(NoLinksResource.new(@resource, nil))
+
+    assert_hash_equals(
+      {
+        data: {
+          id: nil,
+          type: "noLinks",
+          attributes: {
+            name: "Mike"
+          }
+        }
+      },
+      serialized
+    )
+  end
 end


### PR DESCRIPTION
This pull request addresses the issue of nesting additional data in attributes within a resource file, opened here #437. 

We came across a use case where we wanted to nest data within an attribute of the data object. I was able to implement the functionality following the approach in #437, however that solution is very manual and might have to be done in more than one resource depending on the complexity of your API. 

My changes now allow a user to specify data they wish to be nested in a clean way like the following 

``` Ruby
class ParentResource < JSONAPI::Resource
  attribute :name
  attribute :children, format: :nested_attribute, with: ChildResource
end
```

Which will produce the following

``` Ruby
{
  data: {
    type: 'parents',
    id: '1',
    links: {
      self: '/parents/1'
    },
    attributes: {
      name: 'John Smith',
      children: [
        {
          name: 'John Smith Jr.',
          age: 2
        },
        {
          name: 'Jane Smith',
          age: 5
        }
      ]
  }
}
```

Just a note, the test use model relationships to test the functionality for simplicity sake, direct relationships however should adhere to JSON api standard. The changes I am proposing would apply to situations where the nested data does not directly relate to the primary object or other 'special circumstance' situations where adhering strictly to the JSON api spec might not be possible. 
