### PR TITLE
correctly set model_name of subclasses of non-abstract resources

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -279,7 +279,7 @@ module JSONAPI
         subclass.abstract(false)
         subclass.immutable(false)
         subclass._attributes = (_attributes || {}).dup
-        subclass.model_name(_model_name, add_model_hint: false) unless _model_name == ''
+        subclass.model_name(subclass._model_name, add_model_hint: false) unless subclass._model_name == ''
         subclass._model_hints = (_model_hints || {}).dup
 
         subclass._relationships = {}

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -279,7 +279,6 @@ module JSONAPI
         subclass.abstract(false)
         subclass.immutable(false)
         subclass._attributes = (_attributes || {}).dup
-        subclass.model_name(subclass._model_name, add_model_hint: false)
         subclass._model_hints = (_model_hints || {}).dup
 
         subclass._relationships = {}

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -279,7 +279,7 @@ module JSONAPI
         subclass.abstract(false)
         subclass.immutable(false)
         subclass._attributes = (_attributes || {}).dup
-        subclass.model_name(subclass._model_name, add_model_hint: false) unless subclass._model_name == ''
+        subclass.model_name(subclass._model_name, add_model_hint: false)
         subclass._model_hints = (_model_hints || {}).dup
 
         subclass._relationships = {}

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -86,11 +86,11 @@ class ResourceTest < ActiveSupport::TestCase
   end
 
   def test_model_name
-    assert_equal(:Post, PostResource._model_name)
+    assert_equal("Post", PostResource._model_name)
   end
 
   def test_model_name_of_subclassed_non_abstract_resource
-    assert_equal(:Firm, FirmResource._model_name)
+    assert_equal("Firm", FirmResource._model_name)
   end
 
   def test_model

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -86,7 +86,11 @@ class ResourceTest < ActiveSupport::TestCase
   end
 
   def test_model_name
-    assert_equal(PostResource._model_name, 'Post')
+    assert_equal(:Post, PostResource._model_name)
+  end
+
+  def test_model_name_of_subclassed_non_abstract_resource
+    assert_equal(:Firm, FirmResource._model_name)
   end
 
   def test_model


### PR DESCRIPTION
The `_model_name` of the superclass was being carried over its subclass (and overriding its `_model_name`) if the superclass wasn't abstract (as is the case with STI classes).
