### PR TITLE
Revert "Make fetchable_fields more like other field overrides"

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ end
 ##### Fetchable Attributes
 
 By default all attributes are assumed to be fetchable. The list of fetchable attributes can be filtered by overriding
-the `self.fetchable_fields` method.
+the `fetchable_fields` method.
 
 Here's an example that prevents guest users from seeing the `email` field:
 
@@ -198,7 +198,7 @@ class AuthorResource < JSONAPI::Resource
   model_name 'Person'
   has_many :posts
 
-  def self.fetchable_fields(context)
+  def fetchable_fields
     if (context[:current_user].guest)
       super - [:email]
     else

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -105,8 +105,9 @@ module JSONAPI
       end
     end
 
+    # Override this on a resource instance to override the fetchable keys
     def fetchable_fields
-      self.class.fetchable_fields(context)
+      self.class.fields
     end
 
     # Override this on a resource to customize how the associated records
@@ -439,11 +440,6 @@ module JSONAPI
         end
       end
       # :nocov:
-
-      # Override in your resource to filter the fetchable keys
-      def fetchable_fields(_context = nil)
-        fields
-      end
 
       # Override in your resource to filter the updatable keys
       def updatable_fields(_context = nil)


### PR DESCRIPTION
This reverts my earlier accepted PR #534. :disappointed: 

I now realize that a class-level implementation of `fetchable_fields` loses access to the requested `@model` object, making checks like "is the requested model owned by the current user" impossible.

Example from my `UserResource`:

``` ruby
def fetchable_fields
  filtered_fields = [:password]

  current_user = context[:current_user]
  unless current_user && (current_user.admin? || current_user == @model)
    filtered_fields << :email
  end

  super - filtered_fields
end
```
