### PR TITLE
Half-new relationship option: always_include_linkage_data

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,7 @@ The relationship methods (`relationship`, `has_one`, and `has_many`) support the
  * `acts_as_set` - allows the entire set of related records to be replaced in one operation. Defaults to false if not set.
  * `polymorphic` - set to true to identify relationships that are polymorphic.
  * `relation_name` - the name of the relation to use on the model. A lambda may be provided which allows conditional selection of the relation based on the context.
+ * `always_include_linkage_data` - if set to true, the relationship includes linkage data. Defaults to false if not set.
 
 `to_one` relationships support the additional option:
  * `foreign_key_on` - defaults to `:self`. To indicate that the foreign key is on the related resource specify `:related`.

--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -278,6 +278,7 @@ module JSONAPI
     end
 
     def link_object_to_many(source, relationship, include_linkage)
+      include_linkage = include_linkage | relationship.always_include_linkage_data
       link_object_hash = {}
       link_object_hash[:links] = {}
       link_object_hash[:links][:self] = self_link(source, relationship)


### PR DESCRIPTION
The option existed (undocumented) for has_one. This change documents it
and implements it for has_many as well.
