### PR TITLE
Simplify `process_primary`.

### DIFF
--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -93,14 +93,7 @@ module JSONAPI
     # The fields options controls both fields and included links references.
     def process_primary(source, include_directives)
       if source.respond_to?(:to_ary)
-        source.each do |resource|
-          id = resource.id
-          if already_serialized?(resource.class._type, id)
-            set_primary(@primary_class_name, id)
-          end
-
-          add_included_object(id, object_hash(resource,  include_directives), true)
-        end
+        source.each { |resource| process_primary(resource, include_directives) }
       else
         return {} if source.nil?
 


### PR DESCRIPTION
The following check:

``` ruby
if already_serialized?(resource.class._type, id)
  set_primary(@primary_class_name, id)
end
```

being already done inside `add_included_object`, the `process_primary` method can be simplified as suggested.
This is mainly a cosmetic change though.
