### PR TITLE
Inherit ResourceController from ActionController::Metal

### DIFF
--- a/lib/jsonapi/resource_controller.rb
+++ b/lib/jsonapi/resource_controller.rb
@@ -1,5 +1,17 @@
 module JSONAPI
-  class ResourceController < ActionController::Base
-    include JSONAPI::ActsAsResourceController
+  class ResourceController < ActionController::Metal
+    MODULES = [
+      AbstractController::Rendering,
+      ActionController::Rendering,
+      ActionController::Renderers::All,
+      ActionController::StrongParameters,
+      ActionController::ForceSSL,
+      ActionController::Instrumentation,
+      JSONAPI::ActsAsResourceController
+    ].freeze
+
+    MODULES.each do |mod|
+      include mod
+    end
   end
 end


### PR DESCRIPTION
Cherry pick `ActionController` modules that are only required makes `ResourceController` leaner and faster.

On Rails 5, we could also inherit directly from `ActionController::API`: https://github.com/rails/rails/blob/master/actionpack/lib/action_controller/api.rb
