### PR TITLE
Moar Rails5 compatibility

### DIFF
--- a/lib/jsonapi/acts_as_resource_controller.rb
+++ b/lib/jsonapi/acts_as_resource_controller.rb
@@ -66,10 +66,6 @@ module JSONAPI
 
     rescue => e
       handle_exceptions(e)
-    ensure
-      if response.body.size > 0
-        response.headers['Content-Type'] = JSONAPI::MEDIA_TYPE
-      end
     end
 
     # set the operations processor in the configuration or override this to use another operations processor
@@ -152,7 +148,7 @@ module JSONAPI
 
     def render_results(operation_results)
       response_doc = create_response_document(operation_results)
-      render status: response_doc.status, json: response_doc.contents
+      render status: response_doc.status, json: response_doc.contents, content_type: JSONAPI::MEDIA_TYPE
     end
 
     def create_response_document(operation_results)

--- a/lib/jsonapi/mime_types.rb
+++ b/lib/jsonapi/mime_types.rb
@@ -4,7 +4,11 @@ end
 
 Mime::Type.register JSONAPI::MEDIA_TYPE, :api_json
 
-ActionDispatch::ParamsParser::DEFAULT_PARSERS[Mime::Type.lookup(JSONAPI::MEDIA_TYPE)] = lambda do |body|
+parsers = Rails::VERSION::MAJOR >= 5 ?
+            ActionDispatch::Http::Parameters :
+            ActionDispatch::ParamsParser
+
+parsers::DEFAULT_PARSERS[Mime::Type.lookup(JSONAPI::MEDIA_TYPE)] = lambda do |body|
   data = JSON.parse(body)
   data = {:_json => data} unless data.is_a?(Hash)
   data.with_indifferent_access

--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -384,7 +384,8 @@ module JSONAPI
         }
       end
 
-      if !raw.is_a?(Hash) || raw.length != 2 || !(raw.key?('type') && raw.key?('id'))
+      if !(raw.is_a?(Hash) || raw.is_a?(ActionController::Parameters)) ||
+         raw.keys.length != 2 || !(raw.key?('type') && raw.key?('id'))
         fail JSONAPI::Exceptions::InvalidLinksObject.new
       end
 
@@ -516,7 +517,7 @@ module JSONAPI
       params.each do |key, value|
         case key.to_s
         when 'relationships'
-          value.each_key do |links_key|
+          value.keys.each do |links_key|
             unless formatted_allowed_fields.include?(links_key.to_sym)
               params_not_allowed.push(links_key)
               unless JSONAPI.configuration.raise_if_parameters_not_allowed

--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -479,7 +479,7 @@ module JSONAPI
     def parse_to_many_relationship(link_value, relationship, &add_result)
       if link_value.is_a?(Array) && link_value.length == 0
         linkage = []
-      elsif link_value.is_a?(Hash)
+      elsif (link_value.is_a?(Hash) || link_value.is_a?(ActionController::Parameters))
         linkage = link_value[:data]
       else
         fail JSONAPI::Exceptions::InvalidLinksObject.new


### PR DESCRIPTION
# Overview

This brings in Rails 5 compatibility for every feature we're currently using. This is spiked out on an app we're likely going to production in the next few weeks. We haven't found any new issues the last week or so.
# Reasoning

I realize there are already multiple rails 5 pull requests out there but none of them worked for us 100% and the lack of movement on any of them led us to create a new one off of a more recent master. 
- https://github.com/cerebris/jsonapi-resources/pull/579
- https://github.com/cerebris/jsonapi-resources/pull/469
- https://github.com/cerebris/jsonapi-resources/pull/593

I'm going to try and cover what changes were made to this and why and I'd love to feedback on what the Rails 5 plan is going forward. Personally I'd love this, or the others to get pulled in so we can work off of an official release versus a branch.
# Changes for Rails 5 compatibility
- [x] Unable to modify 'Content-Type' as part of the ensure on `process_request` because headers have already been sent.
- [x] `ActionDispartch::ParamsParser` was moved to `ActionDispatch::Http::Parameters`
- [x] All levels of params [are now of type ActionController::Parameters](http://eileencodes.com/posts/actioncontroller-parameters-now-returns-an-object-instead-of-a-hash/) instead of a hash
- [x] Unable to modify `@scope` instead you must instantiate a new scope in the linked list
