### PR TITLE
underscorize resource type name in links

### DIFF
--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -306,7 +306,7 @@ module JSONAPI
       if relationship.is_a?(JSONAPI::Relationship::ToMany)
         if relationship.polymorphic?
           source._model.public_send(relationship.name).pluck(:type, :id).map do |type, id|
-            [type.pluralize, IdValueFormatter.format(id)]
+            [type.underscore.pluralize, IdValueFormatter.format(id)]
           end
         else
           source.public_send(relationship.foreign_key).map do |value|


### PR DESCRIPTION
Hello!

I came across a few issues when I tried to use polymorphic relationships. In my case the type field in the relationship object was something like "PurchaseRequisitions" instead of "purchase_requisitions".
