### PR TITLE
Remove duplicate check for params.nil?

### DIFF
--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -32,11 +32,9 @@ module JSONAPI
 
       @resource_klass ||= Resource.resource_for(params[:controller]) if params[:controller]
 
-      unless params.nil?
-        setup_action_method_name = "setup_#{params[:action]}_action"
-        if respond_to?(setup_action_method_name)
-          send(setup_action_method_name, params)
-        end
+      setup_action_method_name = "setup_#{params[:action]}_action"
+      if respond_to?(setup_action_method_name)
+        send(setup_action_method_name, params)
       end
     rescue ActionController::ParameterMissing => e
       @errors.concat(JSONAPI::Exceptions::ParameterMissing.new(e.param).errors)


### PR DESCRIPTION
This function returns immediately if `params.nil?`, so the `unless params.nil?` check isn't necessary.
