### PR TITLE
Return a relation instead of a class from Resource.records

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -583,7 +583,7 @@ module JSONAPI
       # Override this method if you want to customize the relation for
       # finder methods (find, find_by_key)
       def records(_options = {})
-        _model_class
+        _model_class.all
       end
 
       def verify_filters(filters, context = nil)


### PR DESCRIPTION
When filter, sorting etc, the result is usually an `ActiveRecord::Relation`. However, the default `Resource.records` returns `_model_class` which is a `Class`. This caused some confusion in at least one comment: https://github.com/cerebris/jsonapi-resources/issues/16#issuecomment-137519516

Calling `.all` on the class returns a relation, making for more consistent behaviour.
