### PR TITLE
Check that destroys actually succeed.

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -197,8 +197,9 @@ module JSONAPI
     end
 
     def _remove
-      @model.destroy
-
+      unless @model.destroy
+        fail JSONAPI::Exceptions::ValidationErrors.new(self)
+      end
       :completed
     end
 

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -1653,6 +1653,14 @@ class PostsControllerTest < ActionController::TestCase
     assert_response :bad_request
   end
 
+  def test_delete_with_validation_error
+    post = Post.create!(title: "can't destroy me", author: Person.first)
+    delete :destroy, { id: post.id }
+
+    assert_equal "can't destroy me", json_response['errors'][0]['title']
+    assert_response :unprocessable_entity
+  end
+
   def test_delete_single
     initial_count = Post.count
     delete :destroy, {id: '4'}

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -282,6 +282,15 @@ class Post < ActiveRecord::Base
 
   validates :author, presence: true
   validates :title, length: { maximum: 35 }
+
+  before_destroy :destroy_callback
+
+  def destroy_callback
+    if title == "can't destroy me"
+      errors.add(:title, "can't destroy me")
+      return false
+    end
+  end
 end
 
 class SpecialPostTag < ActiveRecord::Base


### PR DESCRIPTION
Original implementation did not check return value from calls to
`destroy`, allowing failed destroys to return to the client as
successful. Use existing exceptions to return errors in cases
where it does fail.

Resolves conflict in #518
