### PR TITLE
Verify and apply filters using a callback name

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -531,7 +531,11 @@ module JSONAPI
         strategy = _allowed_filters.fetch(filter.to_sym, Hash.new)[:apply]
 
         if strategy
-          strategy.call(records, value, options)
+          if strategy.is_a?(Symbol) || strategy.is_a?(String)
+            send(strategy, records, value, options)
+          else
+            strategy.call(records, value, options)
+          end
         else
           records.where(filter => value)
         end
@@ -630,7 +634,12 @@ module JSONAPI
         strategy = _allowed_filters.fetch(filter, Hash.new)[:verify]
 
         if strategy
-          [filter, strategy.call(filter_values, context)]
+          if strategy.is_a?(Symbol) || strategy.is_a?(String)
+            values = send(strategy, filter_values, context)
+          else
+            values = strategy.call(filter_values, context)
+          end
+          [filter, values]
         else
           if is_filter_relationship?(filter)
             verify_relationship_filter(filter, filter_values, context)


### PR DESCRIPTION
# What?

At the moment, the only way to customise the process of verifying or applying a filter is to write a callable inline, in the filter declaration.
My suggestion is to accept, as `apply:` and `verify:` parameter values, either a callable, or a method name (string or symbol).
# How?

Using the same `apply:` option as previously, we could also pass a callback name, that would need to be defined on the resource class.

``` ruby
filter :public, apply: :apply_public_filter

# (...)

def self.apply_public_filter(records, value, _options)
  records.where(public: (value == "public"))
end
```

Same goes with `verify:`

``` ruby
filter :user_id, verify: :verify_filter_user_id

# (...)

def self.verify_filter_user_id(values, _context)
  current_user = context ? context[:current_user] : nil
  values.map do |id|
    id == "me" ? current_user.try(:id) : id
  end
end
```
# Why?

Although the existing solution is a progress from the previous suggestion to override the `apply_filters` and `verify_filters` methods, it does not allow code factorisation, and sometimes makes the code harder to read. I personally ended up with a lot of, in my opinion disgraceful declarations like the one below:

``` ruby
filter :custom, apply: ->(*args) { my_custom_filter_callback(*args) }
```

The solution above makes it easier to factorise, and follows a pattern that I think is quite common.
