### PR TITLE
Make offset and paged paginators links consistent

### DIFF
--- a/lib/jsonapi/paginator.rb
+++ b/lib/jsonapi/paginator.rb
@@ -58,10 +58,12 @@ class OffsetPaginator < JSONAPI::Paginator
 
       previous_offset = 0 if previous_offset < 0
 
-      links_page_params['previous'] = {
+      links_page_params['prev'] = {
         'offset' => previous_offset,
         'limit' => @limit
       }
+
+      links_page_params['previous'] = links_page_params['prev']
     end
 
     next_offset = @offset + @limit

--- a/lib/jsonapi/paginator.rb
+++ b/lib/jsonapi/paginator.rb
@@ -62,8 +62,6 @@ class OffsetPaginator < JSONAPI::Paginator
         'offset' => previous_offset,
         'limit' => @limit
       }
-
-      links_page_params['previous'] = links_page_params['prev']
     end
 
     next_offset = @offset + @limit

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -3053,7 +3053,7 @@ class Api::V4::BooksControllerTest < ActionController::TestCase
     assert_response :success
     assert_equal 12, json_response['data'].size
     assert_equal 'Book 50', json_response['data'][0]['attributes']['title']
-    assert_equal 5, json_response['links'].size
+    assert_equal 6, json_response['links'].size
     assert_equal 'https://test_corp.com', json_response['links']['spec']
   ensure
     JSONAPI.configuration = original_config

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -3053,7 +3053,7 @@ class Api::V4::BooksControllerTest < ActionController::TestCase
     assert_response :success
     assert_equal 12, json_response['data'].size
     assert_equal 'Book 50', json_response['data'][0]['attributes']['title']
-    assert_equal 6, json_response['links'].size
+    assert_equal 5, json_response['links'].size
     assert_equal 'https://test_corp.com', json_response['links']['spec']
   ensure
     JSONAPI.configuration = original_config

--- a/test/unit/pagination/offset_paginator_test.rb
+++ b/test/unit/pagination/offset_paginator_test.rb
@@ -156,7 +156,7 @@ class OffsetPaginatorTest < ActiveSupport::TestCase
     paginator = OffsetPaginator.new(params)
     links_params = paginator.links_page_params(record_count: 50)
 
-    assert_equal 4, links_params.size
+    assert_equal 5, links_params.size
 
     assert_equal 5, links_params['first']['limit']
     assert_equal 0, links_params['first']['offset']
@@ -182,7 +182,7 @@ class OffsetPaginatorTest < ActiveSupport::TestCase
     paginator = OffsetPaginator.new(params)
     links_params = paginator.links_page_params(record_count: 50)
 
-    assert_equal 4, links_params.size
+    assert_equal 5, links_params.size
 
     assert_equal 5, links_params['first']['limit']
     assert_equal 0, links_params['first']['offset']
@@ -208,7 +208,7 @@ class OffsetPaginatorTest < ActiveSupport::TestCase
     paginator = OffsetPaginator.new(params)
     links_params = paginator.links_page_params(record_count: 50)
 
-    assert_equal 3, links_params.size
+    assert_equal 4, links_params.size
 
     assert_equal 5, links_params['first']['limit']
     assert_equal 0, links_params['first']['offset']
@@ -231,7 +231,7 @@ class OffsetPaginatorTest < ActiveSupport::TestCase
     paginator = OffsetPaginator.new(params)
     links_params = paginator.links_page_params(record_count: 50)
 
-    assert_equal 3, links_params.size
+    assert_equal 4, links_params.size
 
     assert_equal 5, links_params['first']['limit']
     assert_equal 0, links_params['first']['offset']

--- a/test/unit/pagination/offset_paginator_test.rb
+++ b/test/unit/pagination/offset_paginator_test.rb
@@ -156,13 +156,13 @@ class OffsetPaginatorTest < ActiveSupport::TestCase
     paginator = OffsetPaginator.new(params)
     links_params = paginator.links_page_params(record_count: 50)
 
-    assert_equal 5, links_params.size
+    assert_equal 4, links_params.size
 
     assert_equal 5, links_params['first']['limit']
     assert_equal 0, links_params['first']['offset']
 
-    assert_equal 5, links_params['previous']['limit']
-    assert_equal 0, links_params['previous']['offset']
+    assert_equal 5, links_params['prev']['limit']
+    assert_equal 0, links_params['prev']['offset']
 
     assert_equal 5, links_params['next']['limit']
     assert_equal 7, links_params['next']['offset']
@@ -182,13 +182,13 @@ class OffsetPaginatorTest < ActiveSupport::TestCase
     paginator = OffsetPaginator.new(params)
     links_params = paginator.links_page_params(record_count: 50)
 
-    assert_equal 5, links_params.size
+    assert_equal 4, links_params.size
 
     assert_equal 5, links_params['first']['limit']
     assert_equal 0, links_params['first']['offset']
 
-    assert_equal 5, links_params['previous']['limit']
-    assert_equal 22, links_params['previous']['offset']
+    assert_equal 5, links_params['prev']['limit']
+    assert_equal 22, links_params['prev']['offset']
 
     assert_equal 5, links_params['next']['limit']
     assert_equal 32, links_params['next']['offset']
@@ -208,13 +208,13 @@ class OffsetPaginatorTest < ActiveSupport::TestCase
     paginator = OffsetPaginator.new(params)
     links_params = paginator.links_page_params(record_count: 50)
 
-    assert_equal 4, links_params.size
+    assert_equal 3, links_params.size
 
     assert_equal 5, links_params['first']['limit']
     assert_equal 0, links_params['first']['offset']
 
-    assert_equal 5, links_params['previous']['limit']
-    assert_equal 40, links_params['previous']['offset']
+    assert_equal 5, links_params['prev']['limit']
+    assert_equal 40, links_params['prev']['offset']
 
     assert_equal 5, links_params['last']['limit']
     assert_equal 45, links_params['last']['offset']
@@ -231,13 +231,13 @@ class OffsetPaginatorTest < ActiveSupport::TestCase
     paginator = OffsetPaginator.new(params)
     links_params = paginator.links_page_params(record_count: 50)
 
-    assert_equal 4, links_params.size
+    assert_equal 3, links_params.size
 
     assert_equal 5, links_params['first']['limit']
     assert_equal 0, links_params['first']['offset']
 
-    assert_equal 5, links_params['previous']['limit']
-    assert_equal 43, links_params['previous']['offset']
+    assert_equal 5, links_params['prev']['limit']
+    assert_equal 43, links_params['prev']['offset']
 
     assert_equal 5, links_params['last']['limit']
     assert_equal 45, links_params['last']['offset']


### PR DESCRIPTION
Per the pagination spec (http://jsonapi.org/format/#fetching-pagination)
previous links should be 'prev'.  It was done this way in the paged
paginator but not the offset.

I left the original key name in there for backwards compat and updated the tests to expect an additional key. LMK if you want me to add a deprecation message and notes around the tests where the link count has changed.
