### PR TITLE
Add create_operations_processor override example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1018,6 +1018,14 @@ JSONAPI.configure do |config|
 end
 ```
 
+To use a specific `OperationsProcessor` in a `ResourceController`, override the `create_operations_processor` method:
+
+```ruby
+def create_operations_processor
+  CountingActiveRecordOperationsProcessor.new
+end
+```
+
 The callback code will be called after each find. It will use the same options as the find operation, without the
 pagination, to collect the record count. This is stored in the `operation_meta`, which will be returned in the top level
 meta element.


### PR DESCRIPTION
I struggled a bit finding where to override this (thanks @barelyknown for pointing me in the right direction). I'm not sure if this section belongs here or below after ResourceControllers are introduced, but thought it would be a good addition to the README.
