### PR TITLE
Allow Hash values for filter params

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -638,7 +638,9 @@ module JSONAPI
 
       def verify_filter(filter, raw, context = nil)
         filter_values = []
-        filter_values += CSV.parse_line(raw) unless raw.nil? || raw.empty?
+        if raw.present?
+          filter_values += raw.is_a?(String) ? CSV.parse_line(raw) : [raw]
+        end
 
         strategy = _allowed_filters.fetch(filter, Hash.new)[:verify]
 

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -103,6 +103,13 @@ class PostsControllerTest < ActionController::TestCase
     assert_equal 1, json_response['data'].size
   end
 
+  def test_index_filter_with_hash_values
+    get :index, {filter: {search: {title: 'New post'}}}
+    assert_response :success
+    assert json_response['data'].is_a?(Array)
+    assert_equal 1, json_response['data'].size
+  end
+
   def test_index_filter_by_ids
     get :index, {filter: {ids: '1,2'}}
     assert_response :success

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -945,6 +945,14 @@ class PostResource < JSONAPI::Resource
            records.where('id IN (?)', value)
          }
 
+  filter :search,
+    verify: ->(values, context) {
+      values.all?{|v| v.is_a?(Hash) } && values
+    },
+    apply: -> (records, values, _options) {
+      records.where(title: values.first['title'])
+    }
+
   def self.updatable_fields(context)
     super(context) - [:author, :subject]
   end


### PR DESCRIPTION
e.g. `?filter[search][name]=fred&filter[search][facet]=orange`

Rails handles this nicely ,but JR was blowing up up when trying to CSV-parse the Hash prior to filter validation.
