### PR TITLE
Flatten and check exception class whitelisting with a method

### DIFF
--- a/lib/jsonapi/acts_as_resource_controller.rb
+++ b/lib/jsonapi/acts_as_resource_controller.rb
@@ -179,7 +179,7 @@ module JSONAPI
       when JSONAPI::Exceptions::Error
         render_errors(e.errors)
       else
-        if JSONAPI.configuration.exception_class_whitelist.any? { |k| e.class.ancestors.include?(k) }
+        if JSONAPI.configuration.exception_class_whitelisted?(e)
           fail e
         else
           internal_server_error = JSONAPI::Exceptions::InternalServerError.new(e)

--- a/lib/jsonapi/configuration.rb
+++ b/lib/jsonapi/configuration.rb
@@ -95,6 +95,10 @@ module JSONAPI
       @operations_processor = JSONAPI::OperationsProcessor.operations_processor_for(@operations_processor_name)
     end
 
+    def exception_class_whitelisted?(e)
+      @exception_class_whitelist.flatten.any? { |k| e.class.ancestors.include?(k) }
+    end
+
     attr_writer :allow_include, :allow_sort, :allow_filter
 
     attr_writer :default_paginator

--- a/lib/jsonapi/operations_processor.rb
+++ b/lib/jsonapi/operations_processor.rb
@@ -92,7 +92,7 @@ module JSONAPI
       raise e
 
     rescue => e
-      if JSONAPI.configuration.exception_class_whitelist.any? { |k| e.class.ancestors.include?(k) }
+      if JSONAPI.configuration.exception_class_whitelisted?(e)
         raise e
       else
         @request.server_error_callbacks.each { |callback| safe_run_callback(callback, e) }


### PR DESCRIPTION
I just spent an embarrassingly long time chasing down the reason why my exceptions were not passed through, after adding them to the configuration as `config.exception_class_whitelist << [MyError]`. This, of course, caused a nested Array to be stored and the checks failed to account for that.

This PR extracts the exception class whitelist checking to a new method and adds a `flatten` to the chain to avoid just these kinds of situations.
