### PR TITLE
add tests about link check for nested resource routes

### DIFF
--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -643,6 +643,18 @@ class AuthorsController < JSONAPI::ResourceController
 end
 
 ### CONTROLLERS
+module NestedApi
+  class PostsController < ActionController::Base
+    include JSONAPI::ActsAsResourceController
+    def context
+      {writer_id: params[:writer_id]}
+    end
+  end
+  class WritersController < ActionController::Base
+    include JSONAPI::ActsAsResourceController
+  end
+end
+
 module Api
   module V1
     class AuthorsController < JSONAPI::ResourceController
@@ -1208,6 +1220,23 @@ class CustomLinkWithLambda < JSONAPI::Resource
   end
 end
 
+module NestedApi
+  class WriterResource < JSONAPI::Resource
+    attributes :name
+    model_name 'Person'
+    has_many :posts
+  end
+
+  class PostResource < JSONAPI::Resource
+    attributes :title, :body
+    has_one :writer, foreign_key: 'author_id', class_name: 'Writer'
+
+    def self.records(options = {})
+      context = options.fetch(:context, {})
+      super.where(author_id: context[:writer_id])
+    end
+  end
+end
 
 module Api
   module V1

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -149,6 +149,12 @@ TestApp.routes.draw do
   jsonapi_resources :books
   jsonapi_resources :authors
 
+  namespace :nested_api do
+    jsonapi_resources :writers do
+      jsonapi_resources :posts
+    end
+  end
+
   namespace :api do
     namespace :v1 do
       jsonapi_resources :people


### PR DESCRIPTION
jsonapi_resource generate incorrect links when using nested resources
_routes.rb_

``` ruby
jsonapi_resources :writers do
  jsonapi_resources :posts
end
```

4 tests failed:

```
Minitest::Assertion: --- expected
+++ actual
@@ -1 +1 @@
-{"self"=>"http://www.example.com/nested_api/writers/1/posts/1/relationships/writer", "related"=>"http://www.example.com/nested_api/writers/1"}
+{"self"=>"http://www.example.com/nested_api/posts/1/relationships/writer", "related"=>"http://www.example.com/nested_api/posts/1/writer"}


Minitest::Assertion: --- expected
+++ actual
@@ -1 +1 @@
-{"first"=>"http://www.example.com/nested_api/writers/1/posts?page%5Bnumber%5D=1&page%5Bsize%5D=1", "next"=>"http://www.example.com/nested_api/writers/1/posts?page%5Bnumber%5D=2&page%5Bsize%5D=1", "last"=>"http://www.example.com/nested_api/writers/1/posts?page%5Bnumber%5D=3&page%5Bsize%5D=1"}
+{"first"=>"http://www.example.com/nested_api/posts?page%5Bnumber%5D=1&page%5Bsize%5D=1", "next"=>"http://www.example.com/nested_api/posts?page%5Bnumber%5D=2&page%5Bsize%5D=1", "last"=>"http://www.example.com/nested_api/posts?page%5Bnumber%5D=3&page%5Bsize%5D=1"}


Minitest::Assertion: --- expected
+++ actual
@@ -1 +1 @@
-"application/vnd.api+json"
+#<Mime::Type:0xXXXXXX @synonyms=["application/xhtml+xml"], @symbol=:html, @string="text/html">


Minitest::Assertion: --- expected
+++ actual
@@ -1 +1 @@
-{"self"=>"http://www.example.com/nested_api/writers/1/posts/1"}
+{"self"=>"http://www.example.com/nested_api/posts/1"}
```
