### PR TITLE
[Fixes #289] Add 'Location' header if single resource created

### DIFF
--- a/lib/jsonapi/acts_as_resource_controller.rb
+++ b/lib/jsonapi/acts_as_resource_controller.rb
@@ -152,7 +152,17 @@ module JSONAPI
 
     def render_results(operation_results)
       response_doc = create_response_document(operation_results)
-      render status: response_doc.status, json: response_doc.contents
+
+      render_options = {
+        status: response_doc.status,
+        json:   response_doc.contents
+      }
+
+      render_options[:location] = response_doc.contents[:data]["links"][:self] if (
+        response_doc.status == :created && response_doc.contents[:data].class != Array
+      )
+
+      render(render_options)
     end
 
     def create_response_document(operation_results)

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -419,6 +419,7 @@ class PostsControllerTest < ActionController::TestCase
     assert json_response['data'].is_a?(Hash)
     assert_equal 'JR is Great', json_response['data']['attributes']['title']
     assert_equal 'JSONAPIResources is the greatest thing since unsliced bread.', json_response['data']['attributes']['body']
+    assert_equal json_response['data']['links']['self'], response.location
   end
 
   def test_create_link_to_missing_object
@@ -440,6 +441,7 @@ class PostsControllerTest < ActionController::TestCase
     assert_response :unprocessable_entity
     # TODO: check if this validation is working
     assert_match /author - can't be blank/, response.body
+    assert_equal nil, response.location
   end
 
   def test_create_extra_param
@@ -461,6 +463,7 @@ class PostsControllerTest < ActionController::TestCase
 
     assert_response :bad_request
     assert_match /asdfg is not allowed/, response.body
+    assert_equal nil,response.location
   end
 
   def test_create_extra_param_allow_extra_params
@@ -493,6 +496,7 @@ class PostsControllerTest < ActionController::TestCase
     assert_equal "Param not allowed", json_response['meta']["warnings"][0]["title"]
     assert_equal "asdfg is not allowed.", json_response['meta']["warnings"][0]["detail"]
     assert_equal '105', json_response['meta']["warnings"][0]["code"]
+    assert_equal json_response['data']['links']['self'], response.location
   ensure
     JSONAPI.configuration.raise_if_parameters_not_allowed = true
   end
@@ -522,6 +526,7 @@ class PostsControllerTest < ActionController::TestCase
     assert_equal "/data/attributes/title", json_response['errors'][1]['source']['pointer']
     assert_equal "is too long (maximum is 35 characters)", json_response['errors'][1]['title']
     assert_equal "title - is too long (maximum is 35 characters)", json_response['errors'][1]['detail']
+    assert_equal nil, response.location
   end
 
   def test_create_multiple
@@ -558,6 +563,7 @@ class PostsControllerTest < ActionController::TestCase
     assert_nil json_response['data'][0]['relationships']['author']['data']
     assert_match /JR is Great/, response.body
     assert_match /Ember is Great/, response.body
+    assert_equal nil, response.location
   end
 
   def test_create_multiple_wrong_case
@@ -590,6 +596,7 @@ class PostsControllerTest < ActionController::TestCase
 
     assert_response :bad_request
     assert_match /Title/, json_response['errors'][0]['detail']
+    assert_equal nil, response.location
   end
 
   def test_create_simple_missing_posts
@@ -610,6 +617,7 @@ class PostsControllerTest < ActionController::TestCase
 
     assert_response :bad_request
     assert_match /The required parameter, data, is missing./, json_response['errors'][0]['detail']
+    assert_equal nil, response.location
   end
 
   def test_create_simple_wrong_type
@@ -630,6 +638,7 @@ class PostsControllerTest < ActionController::TestCase
 
     assert_response :bad_request
     assert_match /posts_spelled_wrong is not a valid resource./, json_response['errors'][0]['detail']
+    assert_equal nil, response.location
   end
 
   def test_create_simple_missing_type
@@ -649,6 +658,7 @@ class PostsControllerTest < ActionController::TestCase
 
     assert_response :bad_request
     assert_match /The required parameter, type, is missing./, json_response['errors'][0]['detail']
+    assert_equal nil, response.location
   end
 
   def test_create_simple_unpermitted_attributes
@@ -669,6 +679,7 @@ class PostsControllerTest < ActionController::TestCase
 
     assert_response :bad_request
     assert_match /subject/, json_response['errors'][0]['detail']
+    assert_equal nil, response.location
   end
 
   def test_create_simple_unpermitted_attributes_allow_extra_params
@@ -703,6 +714,7 @@ class PostsControllerTest < ActionController::TestCase
     assert_equal "Param not allowed", json_response['meta']["warnings"][0]["title"]
     assert_equal "subject is not allowed.", json_response['meta']["warnings"][0]["detail"]
     assert_equal '105', json_response['meta']["warnings"][0]["code"]
+    assert_equal json_response['data']['links']['self'], response.location
   ensure
     JSONAPI.configuration.raise_if_parameters_not_allowed = true
   end
@@ -730,6 +742,7 @@ class PostsControllerTest < ActionController::TestCase
     assert_equal '3', json_response['data']['relationships']['author']['data']['id']
     assert_equal 'JR is Great', json_response['data']['attributes']['title']
     assert_equal 'JSONAPIResources is the greatest thing since unsliced bread.', json_response['data']['attributes']['body']
+    assert_equal json_response['data']['links']['self'], response.location
   end
 
   def test_create_with_links_to_many_array
@@ -755,6 +768,7 @@ class PostsControllerTest < ActionController::TestCase
     assert_equal '3', json_response['data']['relationships']['author']['data']['id']
     assert_equal 'JR is Great', json_response['data']['attributes']['title']
     assert_equal 'JSONAPIResources is the greatest thing since unsliced bread.', json_response['data']['attributes']['body']
+    assert_equal json_response['data']['links']['self'], response.location
   end
 
   def test_create_with_links_include_and_fields
@@ -781,6 +795,7 @@ class PostsControllerTest < ActionController::TestCase
     assert_equal '3', json_response['data']['relationships']['author']['data']['id']
     assert_equal 'JR is Great!', json_response['data']['attributes']['title']
     assert_not_nil json_response['included'].size
+    assert_equal json_response['data']['links']['self'], response.location
   end
 
   def test_update_with_links


### PR DESCRIPTION
Adds `Location` response header, equal to `self` link, if user
successfully creates single resource. If multiple resources are created,
the `Location` header stays `nil`.

Fixes issue https://github.com/cerebris/jsonapi-resources/issues/289

From specification:

> **201 Created**
> ...
> The response SHOULD include a Location header identifying the location
> of the newly created resource.
> ...
> If the resource object returned by the response contains a self key in
> its links member and a Location header is provided, the value of the
> self member MUST match the value of the Location header.

http://jsonapi.org/format/#crud-creating-responses-201
