### PR TITLE
Allow values of attributes to be delegated. This allows the json api …

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -399,11 +399,11 @@ module JSONAPI
         @_attributes ||= {}
         @_attributes[attr] = options
         define_method attr do
-          @model.public_send(attr)
+          @model.public_send(options[:delegate] ? options[:delegate].to_sym : attr)
         end unless method_defined?(attr)
 
         define_method "#{attr}=" do |value|
-          @model.public_send "#{attr}=", value
+          @model.public_send "#{options[:delegate] ? options[:delegate].to_sym : attr}=", value
         end unless method_defined?("#{attr}=")
       end
 

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -33,6 +33,7 @@ end
 class CatResource < JSONAPI::Resource
   attribute :name
   attribute :breed
+  attribute :kind, :delegate => :breed
 
   has_one :mother, class_name: 'Cat'
   has_one :father, class_name: 'Cat'
@@ -173,7 +174,7 @@ class ResourceTest < ActiveSupport::TestCase
   def test_class_attributes
     attrs = CatResource._attributes
     assert_kind_of(Hash, attrs)
-    assert_equal(attrs.keys.size, 3)
+    assert_equal(attrs.keys.size, 4)
   end
 
   def test_class_relationships
@@ -253,14 +254,14 @@ class ResourceTest < ActiveSupport::TestCase
   # TODO: Please remove after `updateable_fields` is removed
   def test_updateable_fields_delegates_to_updatable_fields_with_deprecation
     ActiveSupport::Deprecation.silence do
-      assert_empty(CatResource.updateable_fields(nil) - [:mother, :father, :name, :breed])
+      assert_empty(CatResource.updateable_fields(nil) - [:mother, :father, :name, :breed, :kind])
     end
   end
 
   # TODO: Please remove after `createable_fields` is removed
   def test_createable_fields_delegates_to_creatable_fields_with_deprecation
     ActiveSupport::Deprecation.silence do
-      assert_empty(CatResource.createable_fields(nil) - [:mother, :father, :name, :breed, :id])
+      assert_empty(CatResource.createable_fields(nil) - [:mother, :father, :name, :breed, :id, :kind])
     end
   end
 


### PR DESCRIPTION
…resource attribute to

easily have a different name without having to define a method for it.
