### PR TITLE
Accept nil data when updating polymorphic to_one relationship 

### DIFF
--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -584,8 +584,8 @@ module JSONAPI
       if relationship.is_a?(JSONAPI::Relationship::ToOne)
         if relationship.polymorphic?
           operation_args[1].merge!(
-            key_value: verified_params[:to_one].values[0][:id],
-            key_type: verified_params[:to_one].values[0][:type]
+            key_value: verified_params[:to_one].values[0] && verified_params[:to_one].values[0][:id],
+            key_type: verified_params[:to_one].values[0] && verified_params[:to_one].values[0][:type]
           )
 
           operation_klass = JSONAPI::ReplacePolymorphicToOneRelationshipOperation


### PR DESCRIPTION
Related to #656
Ensure that `verified_params[:to_one].values[0]` is present before calling `[:id]` and `[:type]`

This way the following request clear the polymorphic relationship in the same way as a non-polymorphic relationship.

```
PATCH /articles/1/relationships/author HTTP/1.1
Content-Type: application/vnd.api+json
Accept: application/vnd.api+json

{
  "data": null
}
```

Wasn't able to create a test case using defined test model since there is no to_one retaltionship.
