### PR TITLE
Add ability to specify validation context

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -182,8 +182,8 @@ module JSONAPI
     #   return :accepted
     # end
     # ```
-    def _save
-      unless @model.valid?
+    def _save(validation_context = nil)
+      unless @model.valid?(validation_context)
         fail JSONAPI::Exceptions::ValidationErrors.new(self)
       end
 

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -406,7 +406,7 @@ class Breed
     $breed_data.remove(@id)
   end
 
-  def valid?
+  def valid?(context = nil)
     @errors.clear
     if name.is_a?(String) && name.length > 0
       return true


### PR DESCRIPTION
In some cases, users want to run API-specific validations. This commit allows
to pass a validation context to the JSONAPI::Resource#_super method.
