### PR TITLE
Don't introduce git dependency in gemspec

### DIFF
--- a/jsonapi-resources.gemspec
+++ b/jsonapi-resources.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/cerebris/jsonapi-resources'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0")
+  spec.files         = Dir.glob("{bin,lib}/**/*") + %w(LICENSE.txt README.md)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']


### PR DESCRIPTION
## Description

Introducing `git` as a dependency in the `<gem-name>.gemspec` file introduces a problem for those of us isolating our applications within Docker containers that don't otherwise need `git`.
