### PR TITLE
Add belongs_to as DSL warning wrapper to has_one to help beginners

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -431,7 +431,11 @@ module JSONAPI
       end
       
       def belongs_to(*attrs)
-        # TODO: Add cool deprecation message here
+        ActiveSupport::Deprecation.warn "In #{name} you exposed a `has_one` relationship "\
+                                        " using the `belongs_to` class method. We think `has_one`" \
+                                        " is more appropriate. If you know what you're doing," \
+                                        " and don't want to see this warning again, override the" \
+                                        " `belongs_to` class method on your resource."
         _add_relationship(Relationship::ToOne, *attrs)
       end
 

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -429,7 +429,11 @@ module JSONAPI
       def has_one(*attrs)
         _add_relationship(Relationship::ToOne, *attrs)
       end
-      alias_method :belongs_to, :has_one
+      
+      def belongs_to(*attrs)
+        # TODO: Add cool deprecation message here
+        _add_relationship(Relationship::ToOne, *attrs)
+      end
 
       def has_many(*attrs)
         _add_relationship(Relationship::ToMany, *attrs)

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -429,6 +429,7 @@ module JSONAPI
       def has_one(*attrs)
         _add_relationship(Relationship::ToOne, *attrs)
       end
+      alias_method :belongs_to, :has_one
 
       def has_many(*attrs)
         _add_relationship(Relationship::ToMany, *attrs)

--- a/test/unit/jsonapi_request/jsonapi_request_test.rb
+++ b/test/unit/jsonapi_request/jsonapi_request_test.rb
@@ -4,7 +4,7 @@ class CatResource < JSONAPI::Resource
   attribute :name
   attribute :breed
 
-  has_one :mother, class_name: 'Cat'
+  belongs_to :mother, class_name: 'Cat'
   has_one :father, class_name: 'Cat'
 
   filters :name


### PR DESCRIPTION
In order to reduce cognitive threshold for new users of JSONAPI::Resource, this PR introduces a method which does the same thing as `has_one`.

The user can write `belongs_to :thing` as well as `has_one :thing` and it means the same thing.

These are equivalent:

``` ruby
class MemberResource < JSONAPI::Resource
  has_one :club
end
```

``` ruby
class MemberResource < JSONAPI::Resource
  belongs_to :club
end
```

The user is also warned with a deprecation warning that tries to teach them about why `belongs_to` is the wrong name.
