### PR TITLE
Resource serialization fragment caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ backed by ActiveRecord models or by custom objects.
   * [Routing] (#routing)
     * [Nested Routes] (#nested-routes)
   * [Authorization](#authorization)
+  * [Resource Caching] (#resource-caching)
+    * [Caching Caveats] (#caching-caveats)
 * [Configuration] (#configuration)
 * [Contributing] (#contributing)
 * [License] (#license)
@@ -1644,10 +1646,11 @@ class DefaultValueFormatter < JSONAPI::ValueFormatter
   class << self
     def format(raw_value)
       case raw_value
-        when String, Integer
-          return raw_value
+        when Date, Time, DateTime, ActiveSupport::TimeWithZone, BigDecimal
+          # Use the as_json methods added to various base classes by ActiveSupport
+          return raw_value.as_json
         else
-          return raw_value.to_s
+          return raw_value
       end
     end
   end
@@ -1680,16 +1683,14 @@ resource for a system wide change).
 and
 
 ```ruby
-class MyDefaultValueFormatter < JSONAPI::ValueFormatter
+class MyDefaultValueFormatter < DefaultValueFormatter
   class << self
     def format(raw_value)
       case raw_value
-        when String, Integer
-          return raw_value
         when DateTime
-          return raw_value.in_time_zone('UTC').to_s
+          return super(raw_value.in_time_zone('UTC'))
         else
-          return raw_value.to_s
+          return super
       end
     end
   end
@@ -1905,6 +1906,103 @@ Currently `json-api-resources` doesn't come with built-in primitives for authori
 
 Refer to the comments/discussion [here](https://github.com/cerebris/jsonapi-resources/issues/16#issuecomment-222438975) for the differences between approaches
 
+### Resource Caching
+
+To improve the response time of GET requests, JR can cache the generated JSON fragments for
+Resources which are suitable. First, set `config.resource_cache` to an ActiveSupport cache store:
+
+```ruby
+JSONAPI.configure do |config|
+  config.resource_cache = Rails.cache
+end
+```
+
+Then, on each Resource you want to cache, call the `caching` method:
+
+```ruby
+class PostResource << JSONAPI::Resource
+  caching
+end
+```
+
+See the caveats section below for situations where you might not want to enable caching on particular
+Resources.
+
+The Resource model must also have a field that is updated whenever any of the model's data changes.
+The default Rails timestamps handle this pretty well, and the default cache key field is `updated_at` for this reason.
+You can use an alternate field (which you are then responsible for updating) by calling the `cache_field` method:
+
+```ruby
+class PostResource << JSONAPI::Resource
+  cache_field :change_counter
+
+  before_save do
+    if self.change_counter.nil?
+      self.change_counter = 1
+    elsif self.changed?
+      self.change_counter += 1
+    end
+  end
+
+  after_touch do
+    update_attribute(:change_counter, self.change_counter + 1)
+  end
+end
+```
+
+If context affects the content of the serialized result, you must define a class method `attribute_caching_context` on that Resource, which should return a different value for contexts that produce different results. In particular, if the `meta` or `fetchable_fields` methods, or any method providing the actual content of an attribute, changes depending on context, then you must provide `attribute_caching_context`. The actual value it
+returns isn't important, except that the value must be different if any relevant aspect of the context is different.
+
+```ruby
+class PostResource << JSONAPI::Resource
+  attributes :title, :body, :secret_field
+
+  def fetchable_fields
+    return super if context.user.superuser?
+    return super - [:secret_field]
+  end
+
+  def meta
+    if context.user.can_see_creation_dates?
+      return { created: _model.created_at }
+    else
+      return {}
+    end
+  end
+
+  def self.attribute_caching_context(context)
+    return {
+      admin: context.user.superuser?,
+      creation_date_viewer: context.user.can_see_creation_dates?
+    }
+  end
+end
+```
+
+#### Caching Caveats
+
+* Models for cached Resources must update a cache key field whenever their data changes. However, if you bypass Rails and e.g. alter the database row directly without changing the `updated_at` field, the cached entry for that resource will be inaccurate. Also, `updated_at` provides a narrow race condition window; if a resource is updated twice in the same second, it's possible that only the first update will be cached. If you're concerned about this, you will need to find a way to make sure your models' cache fields change on every update, e.g. by using a unique random value or a monotonic clock.
+* If an attribute's value is affected by related resources, e.g. the `spoken_languages` example above, then changes to the related resource must also touch the cache field on the resource that uses it. The `belongs_to` relation in ActiveRecord provides a `:touch` option for this purpose.
+* JR does not actively clean the cache, so you must use an ActiveSupport cache that automatically expires old entries, or you will leak resources. The MemoryCache built in to Rails does this by default, but other caches will have to be configured with an `:expires_in` option and/or a cache-specific clearing mechanism.
+* Similarly, if you make a substantial code change that affects a lot of serialized representations (i.e. changing the way an attribute is shown), you'll have to clear out all relevant cache entries yourself. You do not have to do this after merely adding or removing attributes; only changes that affect the actual content of attributes require manual cache clearing. The simplest way to do this is to run `JSONAPI.configuration.resource_cache.clear` from the console.
+* If resource caching is enabled at all, then custom relationship methods on any resource might not always be used, even resources that are not cached. For example, if you manually define a `comments` method or `records_for_comments` method on a Resource that `has_many :comments`, you cannot expect it to be used when caching is enabled, even if you never call `caching` on that particular Resource. Instead, you should use relationship name lambdas.
+* The above also applies to custom `find` or `find_by_key` methods. Instead, if you are using resource caching anywhere in your app, try overriding the `find_records` method to return an appropriate `ActiveRecord::Relation`.
+* Caching relies on ActiveRecord features; you cannot enable caching on resources based on non-AR models, e.g. PORO objects or singleton resources.
+* If you write a custom `ResourceSerializer` which takes new options, then you must define `config_description` to include those options if they might impact the serialized value:
+
+```ruby
+class MySerializer << JSONAPI::ResourceSerializer
+  def initialize(primary_resource_klass, options = {})
+    @my_special_option = options.delete(:my_special_option)
+    super
+  end
+
+  def config_description(resource_klass)
+    super.merge({my_special_option: @my_special_option})
+  end
+end
+```
+
 ## Configuration
 
 JR has a few configuration options. Some have already been mentioned above. To set configuration options create an
@@ -1983,7 +2081,30 @@ JSONAPI.configure do |config|
 
   # Formatter Caching
   # Set to false to disable caching of string operations on keys and links.
+  # Note that unlike the resource cache, formatter caching is always done
+  # internally in-memory and per-thread; no ActiveSupport::Cache is used.
   config.cache_formatters = true
+
+  # Resource cache
+  # An ActiveSupport::Cache::Store or similar, used by Resources with caching enabled.
+  # Set to `nil` (the default) to disable caching, or to `Rails.cache` to use the
+  # Rails cache store.
+  config.resource_cache = nil
+
+  # Default resource cache field
+  # On Resources with caching enabled, this field will be used to check for out-of-date
+  # cache entries, unless overridden on a specific Resource. Defaults to "updated_at".
+  config.default_resource_cache_field = :updated_at
+
+  # Resource cache digest function
+  # Provide a callable that returns a unique value for string inputs with
+  # low chance of collision. The default is SHA256 base64.
+  config.resource_cache_digest_function = Digest::SHA2.new.method(:base64digest)
+
+  # Resource cache usage reporting
+  # Optionally provide a callable which JSONAPI will call with information about cache
+  # performance. Should accept three arguments: resource name, hits count, misses count.
+  config.resource_cache_usage_report_function = nil
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -1920,7 +1920,7 @@ end
 Then, on each Resource you want to cache, call the `caching` method:
 
 ```ruby
-class PostResource << JSONAPI::Resource
+class PostResource < JSONAPI::Resource
   caching
 end
 ```
@@ -1933,7 +1933,8 @@ The default Rails timestamps handle this pretty well, and the default cache key 
 You can use an alternate field (which you are then responsible for updating) by calling the `cache_field` method:
 
 ```ruby
-class PostResource << JSONAPI::Resource
+class PostResource < JSONAPI::Resource
+  caching
   cache_field :change_counter
 
   before_save do
@@ -1951,10 +1952,12 @@ end
 ```
 
 If context affects the content of the serialized result, you must define a class method `attribute_caching_context` on that Resource, which should return a different value for contexts that produce different results. In particular, if the `meta` or `fetchable_fields` methods, or any method providing the actual content of an attribute, changes depending on context, then you must provide `attribute_caching_context`. The actual value it
-returns isn't important, except that the value must be different if any relevant aspect of the context is different.
+returns isn't important, what matters is that the value must be different if any relevant part of the context is different.
 
 ```ruby
-class PostResource << JSONAPI::Resource
+class PostResource < JSONAPI::Resource
+  caching
+
   attributes :title, :body, :secret_field
 
   def fetchable_fields
@@ -1984,14 +1987,14 @@ end
 * Models for cached Resources must update a cache key field whenever their data changes. However, if you bypass Rails and e.g. alter the database row directly without changing the `updated_at` field, the cached entry for that resource will be inaccurate. Also, `updated_at` provides a narrow race condition window; if a resource is updated twice in the same second, it's possible that only the first update will be cached. If you're concerned about this, you will need to find a way to make sure your models' cache fields change on every update, e.g. by using a unique random value or a monotonic clock.
 * If an attribute's value is affected by related resources, e.g. the `spoken_languages` example above, then changes to the related resource must also touch the cache field on the resource that uses it. The `belongs_to` relation in ActiveRecord provides a `:touch` option for this purpose.
 * JR does not actively clean the cache, so you must use an ActiveSupport cache that automatically expires old entries, or you will leak resources. The MemoryCache built in to Rails does this by default, but other caches will have to be configured with an `:expires_in` option and/or a cache-specific clearing mechanism.
-* Similarly, if you make a substantial code change that affects a lot of serialized representations (i.e. changing the way an attribute is shown), you'll have to clear out all relevant cache entries yourself. You do not have to do this after merely adding or removing attributes; only changes that affect the actual content of attributes require manual cache clearing. The simplest way to do this is to run `JSONAPI.configuration.resource_cache.clear` from the console.
+* Similarly, if you make a substantial code change that affects a lot of serialized representations (i.e. changing the way an attribute is shown), you'll have to clear out all relevant cache entries yourself. The simplest way to do this is to run `JSONAPI.configuration.resource_cache.clear` from the console. You do not have to do this after merely adding or removing attributes; only changes that affect the actual content of attributes require manual cache clearing.
 * If resource caching is enabled at all, then custom relationship methods on any resource might not always be used, even resources that are not cached. For example, if you manually define a `comments` method or `records_for_comments` method on a Resource that `has_many :comments`, you cannot expect it to be used when caching is enabled, even if you never call `caching` on that particular Resource. Instead, you should use relationship name lambdas.
 * The above also applies to custom `find` or `find_by_key` methods. Instead, if you are using resource caching anywhere in your app, try overriding the `find_records` method to return an appropriate `ActiveRecord::Relation`.
 * Caching relies on ActiveRecord features; you cannot enable caching on resources based on non-AR models, e.g. PORO objects or singleton resources.
 * If you write a custom `ResourceSerializer` which takes new options, then you must define `config_description` to include those options if they might impact the serialized value:
 
 ```ruby
-class MySerializer << JSONAPI::ResourceSerializer
+class MySerializer < JSONAPI::ResourceSerializer
   def initialize(primary_resource_klass, options = {})
     @my_special_option = options.delete(:my_special_option)
     super

--- a/lib/jsonapi-resources.rb
+++ b/lib/jsonapi-resources.rb
@@ -1,5 +1,7 @@
 require 'jsonapi/naive_cache'
+require 'jsonapi/compiled_json'
 require 'jsonapi/resource'
+require 'jsonapi/cached_resource_fragment'
 require 'jsonapi/response_document'
 require 'jsonapi/acts_as_resource_controller'
 require 'jsonapi/resource_controller'

--- a/lib/jsonapi/acts_as_resource_controller.rb
+++ b/lib/jsonapi/acts_as_resource_controller.rb
@@ -62,20 +62,24 @@ module JSONAPI
       @request = JSONAPI::RequestParser.new(params, context: context,
                                             key_formatter: key_formatter,
                                             server_error_callbacks: (self.class.server_error_callbacks || []))
+
       unless @request.errors.empty?
         render_errors(@request.errors)
       else
-        process_operations
-        render_results(@operation_results)
+        operations = @request.operations
+        unless JSONAPI.configuration.resource_cache.nil?
+          operations.each {|op| op.options[:cache_serializer] = resource_serializer }
+        end
+        results = process_operations(operations)
+        render_results(results)
       end
-
     rescue => e
       handle_exceptions(e)
     end
 
-    def process_operations
+    def process_operations(operations)
       run_callbacks :process_operations do
-        @operation_results = operation_dispatcher.process(@request.operations)
+        operation_dispatcher.process(operations)
       end
     end
 
@@ -107,6 +111,19 @@ module JSONAPI
 
     def resource_serializer_klass
       @resource_serializer_klass ||= JSONAPI::ResourceSerializer
+    end
+
+    def resource_serializer
+      @resource_serializer ||= resource_serializer_klass.new(
+        resource_klass,
+        include_directives: @request ? @request.include_directives : nil,
+        fields: @request ? @request.fields : {},
+        base_url: base_url,
+        key_formatter: key_formatter,
+        route_formatter: route_formatter,
+        serialization_options: serialization_options
+      )
+      @resource_serializer
     end
 
     def base_url
@@ -204,16 +221,24 @@ module JSONAPI
 
     def render_results(operation_results)
       response_doc = create_response_document(operation_results)
+      content = response_doc.contents
 
-      render_options = {
-        status: response_doc.status,
-        json:   response_doc.contents,
-        content_type: JSONAPI::MEDIA_TYPE
-      }
+      render_options = {}
+      if operation_results.has_errors?
+        render_options[:json] = content
+      else
+        # Bypasing ActiveSupport allows us to use CompiledJson objects for cached response fragments
+        render_options[:body] = JSON.generate(content)
+      end
 
-      render_options[:location] = response_doc.contents[:data]["links"][:self] if (
-        response_doc.status == :created && response_doc.contents[:data].class != Array
+      render_options[:location] = content[:data]["links"][:self] if (
+        response_doc.status == :created && content[:data].class != Array
       )
+
+      # For whatever reason, `render` ignores :status and :content_type when :body is set.
+      # But, we can just set those values directly in the Response object instead.
+      response.status = response_doc.status
+      response.headers['Content-Type'] = JSONAPI::MEDIA_TYPE
 
       render(render_options)
     end
@@ -221,17 +246,11 @@ module JSONAPI
     def create_response_document(operation_results)
       JSONAPI::ResponseDocument.new(
         operation_results,
-        primary_resource_klass: resource_klass,
-        include_directives: @request ? @request.include_directives : nil,
-        fields: @request ? @request.fields : nil,
-        base_url: base_url,
+        operation_results.has_errors? ? nil : resource_serializer,
         key_formatter: key_formatter,
-        route_formatter: route_formatter,
         base_meta: base_meta,
         base_links: base_response_links,
-        resource_serializer_klass: resource_serializer_klass,
-        request: @request,
-        serialization_options: serialization_options
+        request: @request
       )
     end
 

--- a/lib/jsonapi/cached_resource_fragment.rb
+++ b/lib/jsonapi/cached_resource_fragment.rb
@@ -1,0 +1,119 @@
+module JSONAPI
+  class CachedResourceFragment
+    def self.fetch_fragments(resource_klass, serializer, context, cache_ids)
+      serializer_config_key = serializer.config_key(resource_klass).gsub("/", "_")
+      context_json = resource_klass.attribute_caching_context(context).to_json
+      context_b64 = JSONAPI.configuration.resource_cache_digest_function.call(context_json)
+      context_key = "ATTR-CTX-#{context_b64.gsub("/", "_")}"
+
+      results = self.lookup(resource_klass, serializer_config_key, context_key, cache_ids)
+
+      miss_ids = results.select{|k,v| v.nil? }.keys
+      unless miss_ids.empty?
+        find_filters = {resource_klass._primary_key => miss_ids.uniq}
+        find_options = {context: context}
+        resource_klass.find(find_filters, find_options).each do |resource|
+          (id, cr) = write(resource_klass, resource, serializer, serializer_config_key, context_key)
+          results[id] = cr
+        end
+      end
+
+      if JSONAPI.configuration.resource_cache_usage_report_function
+        JSONAPI.configuration.resource_cache_usage_report_function.call(
+          resource_klass.name,
+          cache_ids.size - miss_ids.size,
+          miss_ids.size
+        )
+      end
+
+      return results
+    end
+
+    def self.from_cache_value(resource_klass, h)
+      new(
+        resource_klass,
+        h.fetch(:id),
+        h.fetch(:type),
+        h.fetch(:fetchable),
+        h.fetch(:rels, nil),
+        h.fetch(:links, nil),
+        h.fetch(:attrs, nil),
+        h.fetch(:meta, nil)
+      )
+    end
+
+    attr_reader :resource_klass, :id, :type, :fetchable_fields, :relationships,
+                :links_json, :attributes_json, :meta_json,
+                :preloaded_fragments
+
+    def initialize(resource_klass, id, type, fetchable_fields, relationships,
+                   links_json, attributes_json, meta_json)
+      @resource_klass = resource_klass
+      @id = id
+      @type = type
+      @fetchable_fields = Set.new(fetchable_fields)
+
+      # Relationships left uncompiled because we'll often want to insert included ids on retrieval
+      @relationships = relationships
+
+      @links_json = CompiledJson.of(links_json)
+      @attributes_json = CompiledJson.of(attributes_json)
+      @meta_json = CompiledJson.of(meta_json)
+
+      # A hash of hashes
+      @preloaded_fragments ||= Hash.new
+    end
+
+    def to_cache_value
+      {
+        id: id,
+        type: type,
+        fetchable: fetchable_fields,
+        rels: relationships,
+        links: links_json.try(:to_s),
+        attrs: attributes_json.try(:to_s),
+        meta: meta_json.try(:to_s)
+      }
+    end
+
+    private
+
+    def self.lookup(resource_klass, serializer_config_key, context_key, cache_ids)
+      type = resource_klass._type
+
+      keys = cache_ids.map do |(id, cache_key)|
+        [type, id, cache_key, serializer_config_key, context_key]
+      end
+
+      hits = JSONAPI.configuration.resource_cache.read_multi(*keys).reject{|_,v| v.nil? }
+      return keys.each_with_object({}) do |key, hash|
+        (_, id, _, _) = key
+        if hits.has_key?(key)
+          hash[id] = self.from_cache_value(resource_klass, hits[key])
+        else
+          hash[id] = nil
+        end
+      end
+    end
+
+    def self.write(resource_klass, resource, serializer, serializer_config_key, context_key)
+      (id, cache_key) = resource.cache_id
+      json = serializer.object_hash(resource) # No inclusions passed to object_hash
+      cr = self.new(
+        resource_klass,
+        json['id'],
+        json['type'],
+        resource.fetchable_fields,
+        json['relationships'],
+        json['links'],
+        json['attributes'],
+        json['meta']
+      )
+
+      key = [resource_klass._type, id, cache_key, serializer_config_key, context_key]
+      JSONAPI.configuration.resource_cache.write(key, cr.to_cache_value)
+      return [id, cr]
+    end
+
+  end
+end

--- a/lib/jsonapi/compiled_json.rb
+++ b/lib/jsonapi/compiled_json.rb
@@ -1,0 +1,36 @@
+module JSONAPI
+  class CompiledJson
+    def self.compile(h)
+      new(JSON.generate(h), h)
+    end
+
+    def self.of(obj)
+      case obj
+        when NilClass then nil
+        when CompiledJson then obj
+        when String then CompiledJson.new(obj)
+        when Hash then CompiledJson.compile(obj)
+        else raise "Can't figure out how to turn #{obj.inspect} into CompiledJson"
+      end
+    end
+
+    def initialize(json, h = nil)
+      @json = json
+      @h = h
+    end
+
+    def to_json(*args)
+      @json
+    end
+
+    def to_s
+      @json
+    end
+
+    def to_h
+      @h ||= JSON.parse(@json)
+    end
+
+    undef_method :as_json
+  end
+end

--- a/lib/jsonapi/exceptions.rb
+++ b/lib/jsonapi/exceptions.rb
@@ -1,6 +1,10 @@
 module JSONAPI
   module Exceptions
-    class Error < RuntimeError; end
+    class Error < RuntimeError
+      def errors
+        raise NotImplementedError, "Subclass of Error must implement errors method"
+      end
+    end
 
     class InternalServerError < Error
       attr_accessor :exception

--- a/lib/jsonapi/formatter.rb
+++ b/lib/jsonapi/formatter.rb
@@ -13,6 +13,10 @@ module JSONAPI
         return FormatterWrapperCache.new(self)
       end
 
+      def uncached
+        return self
+      end
+
       def formatter_for(format)
         "#{format.to_s.camelize}Formatter".safe_constantize
       end
@@ -80,6 +84,10 @@ module JSONAPI
     def cached
       self
     end
+
+    def uncached
+      return @formatter_klass
+    end
   end
 end
 
@@ -113,7 +121,13 @@ end
 class DefaultValueFormatter < JSONAPI::ValueFormatter
   class << self
     def format(raw_value)
-      raw_value
+      case raw_value
+        when Date, Time, DateTime, ActiveSupport::TimeWithZone, BigDecimal
+          # Use the as_json methods added to various base classes by ActiveSupport
+          return raw_value.as_json
+        else
+          return raw_value
+      end
     end
   end
 end

--- a/lib/jsonapi/include_directives.rb
+++ b/lib/jsonapi/include_directives.rb
@@ -36,6 +36,10 @@ module JSONAPI
       get_includes(@include_directives_hash)
     end
 
+    def paths
+      delve_paths(get_includes(@include_directives_hash, false))
+    end
+
     private
 
     def get_related(current_path)
@@ -59,9 +63,12 @@ module JSONAPI
       current
     end
 
-    def get_includes(directive)
-      directive[:include_related].select { |k,v| v[:include_in_join] }.map do |name, directive|
-        sub = get_includes(directive)
+    def get_includes(directive, only_joined_includes = true)
+      ir = directive[:include_related]
+      ir = ir.select { |k,v| v[:include_in_join] } if only_joined_includes
+
+      ir.map do |name, sub_directive|
+        sub = get_includes(sub_directive, only_joined_includes)
         sub.any? ? { name => sub } : name
       end
     end
@@ -74,6 +81,19 @@ module JSONAPI
         local_path += local_path.length > 0 ? ".#{name}" : name
         related = get_related(local_path)
         related[:include] = true
+      end
+    end
+
+    def delve_paths(obj)
+      case obj
+        when Array
+          obj.map{|elem| delve_paths(elem)}.flatten(1)
+        when Hash
+          obj.map{|k,v| [[k]] + delve_paths(v).map{|path| [k] + path } }.flatten(1)
+        when Symbol, String
+          [[obj]]
+        else
+          raise "delve_paths cannot descend into #{obj.class.name}"
       end
     end
   end

--- a/lib/jsonapi/request_parser.rb
+++ b/lib/jsonapi/request_parser.rb
@@ -339,6 +339,7 @@ module JSONAPI
         source_klass: @source_klass,
         source_id: @source_id,
         filters: @source_klass.verify_filters(@filters, @context),
+        include_directives: @include_directives,
         sort_criteria: @sort_criteria,
         paginator: @paginator,
         fields: @fields,

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -1071,6 +1071,36 @@ module JSONAPI
         resources.values
       end
 
+      def find_records(filters, options = {})
+        context = options[:context]
+
+        records = filter_records(filters, options)
+
+        sort_criteria = options.fetch(:sort_criteria) { [] }
+        order_options = construct_order_options(sort_criteria)
+        records = sort_records(records, order_options, context)
+
+        records = apply_pagination(records, options[:paginator], order_options)
+
+        records
+      end
+
+      def cached_resources_for(records, serializer, options)
+        if records.is_a?(Array) && records.all?{|rec| rec.is_a?(JSONAPI::Resource)}
+          resources = records.map{|r| [r.id, r] }.to_h
+        elsif self.caching?
+          t = _model_class.arel_table
+          cache_ids = pluck_arel_attributes(records, t[_primary_key], t[_cache_field])
+          resources = CachedResourceFragment.fetch_fragments(self, serializer, options[:context], cache_ids)
+        else
+          resources = resources_for(records, options).map{|r| [r.id, r] }.to_h
+        end
+
+        preload_included_fragments(resources, records, serializer, options)
+
+        resources.values
+      end
+
       def check_reserved_resource_name(type, name)
         if [:ids, :types, :hrefs, :links].include?(type)
           warn "[NAME COLLISION] `#{name}` is a reserved resource name."

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -36,6 +36,10 @@ module JSONAPI
       _model.public_send(self.class._primary_key)
     end
 
+    def cache_id
+      [id, _model.public_send(self.class._cache_field)]
+    end
+
     def is_new?
       id.nil?
     end
@@ -163,6 +167,11 @@ module JSONAPI
     # the _options hash will contain the serializer and the serialization_options
     def custom_links(_options)
       {}
+    end
+
+    def preloaded_fragments
+      # A hash of hashes
+      @preloaded_fragments ||= Hash.new
     end
 
     private
@@ -399,6 +408,7 @@ module JSONAPI
       def inherited(subclass)
         subclass.abstract(false)
         subclass.immutable(false)
+        subclass.caching(false)
         subclass._attributes = (_attributes || {}).dup
         subclass._model_hints = (_model_hints || {}).dup
 
@@ -450,7 +460,8 @@ module JSONAPI
         end
       end
 
-      attr_accessor :_attributes, :_relationships, :_allowed_filters, :_type, :_paginator, :_model_hints
+      attr_accessor :_attributes, :_relationships, :_type, :_model_hints
+      attr_writer :_allowed_filters, :_paginator
 
       def create(context)
         new(create_model, context)
@@ -557,13 +568,17 @@ module JSONAPI
         @_primary_key = key.to_sym
       end
 
+      def cache_field(field)
+        @_cache_field = field.to_sym
+      end
+
       # TODO: remove this after the createable_fields and updateable_fields are phased out
       # :nocov:
       def method_missing(method, *args)
-        if method.to_s.match /createable_fields/
+        if method.to_s.match(/createable_fields/)
           ActiveSupport::Deprecation.warn('`createable_fields` is deprecated, please use `creatable_fields` instead')
           creatable_fields(*args)
-        elsif method.to_s.match /updateable_fields/
+        elsif method.to_s.match(/updateable_fields/)
           ActiveSupport::Deprecation.warn('`updateable_fields` is deprecated, please use `updatable_fields` instead')
           updatable_fields(*args)
         else
@@ -727,19 +742,8 @@ module JSONAPI
         count_records(filter_records(filters, options))
       end
 
-      # Override this method if you have more complex requirements than this basic find method provides
       def find(filters, options = {})
-        context = options[:context]
-
-        records = filter_records(filters, options)
-
-        sort_criteria = options.fetch(:sort_criteria) { [] }
-        order_options = construct_order_options(sort_criteria)
-        records = sort_records(records, order_options, context)
-
-        records = apply_pagination(records, options[:paginator], order_options)
-
-        resources_for(records, context)
+        resources_for(find_records(filters, options), options[:context])
       end
 
       def resources_for(records, context)
@@ -759,17 +763,39 @@ module JSONAPI
         end
       end
 
+      def find_serialized_with_caching(filters_or_source, serializer, options = {})
+        if filters_or_source.is_a?(ActiveRecord::Relation)
+          records = filters_or_source
+        elsif _model_class.respond_to?(:all) && _model_class.respond_to?(:arel_table)
+          records = find_records(filters_or_source, options.except(:include_directives))
+        else
+          records = find(filters_or_source, options)
+        end
+        cached_resources_for(records, serializer, options)
+      end
+
       def find_by_key(key, options = {})
         context = options[:context]
-        records = records(options)
-        records = apply_includes(records, options)
-        model = records.where({_primary_key => key}).first
+        records = find_records({_primary_key => key}, options.except(:paginator, :sort_criteria))
+        model = records.first
         fail JSONAPI::Exceptions::RecordNotFound.new(key) if model.nil?
         self.resource_for_model(model).new(model, context)
       end
 
+      def find_by_key_serialized_with_caching(key, serializer, options = {})
+        if _model_class.respond_to?(:all) && _model_class.respond_to?(:arel_table)
+          results = find_serialized_with_caching({_primary_key => key}, serializer, options)
+          result = results.first
+          fail JSONAPI::Exceptions::RecordNotFound.new(key) if result.nil?
+          return result
+        else
+          resource = find_by_key(key, options)
+          return cached_resources_for([resource], serializer, options).first
+        end
+      end
+
       # Override this method if you want to customize the relation for
-      # finder methods (find, find_by_key)
+      # finder methods (find, find_by_key, find_serialized_with_caching)
       def records(_options = {})
         _model_class.all
       end
@@ -880,11 +906,22 @@ module JSONAPI
       end
 
       def _model_name
-        _abstract ? '' : @_model_name ||= name.demodulize.sub(/Resource$/, '')
+        if _abstract
+          return ''
+        else
+          return @_model_name if defined?(@_model_name)
+          class_name = self.name
+          return '' if class_name.nil?
+          return @_model_name = class_name.demodulize.sub(/Resource$/, '')
+        end
       end
 
       def _primary_key
         @_primary_key ||= _model_class.respond_to?(:primary_key) ? _model_class.primary_key : :id
+      end
+
+      def _cache_field
+        @_cache_field ||= JSONAPI.configuration.default_resource_cache_field
       end
 
       def _table_name
@@ -896,7 +933,7 @@ module JSONAPI
       end
 
       def _allowed_filters
-        !@_allowed_filters.nil? ? @_allowed_filters : { id: {} }
+        defined?(@_allowed_filters) ? @_allowed_filters : { id: {} }
       end
 
       def _paginator
@@ -927,10 +964,27 @@ module JSONAPI
         !@immutable
       end
 
+      def caching(val = true)
+        @caching = val
+      end
+
+      def _caching
+        @caching
+      end
+
+      def caching?
+        @caching && !JSONAPI.configuration.resource_cache.nil?
+      end
+
+      def attribute_caching_context(context)
+        nil
+      end
+
       def _model_class
         return nil if _abstract
 
-        return @model if @model
+        return @model if defined?(@model)
+        return nil if self.name.to_s.blank? && _model_name.to_s.blank?
         @model = _model_name.to_s.safe_constantize
         warn "[MODEL NOT FOUND] Model could not be found for #{self.name}. If this a base Resource declare it as abstract." if @model.nil?
         @model
@@ -987,6 +1041,36 @@ module JSONAPI
 
       private
 
+      def find_records(filters, options = {})
+        context = options[:context]
+
+        records = filter_records(filters, options)
+
+        sort_criteria = options.fetch(:sort_criteria) { [] }
+        order_options = construct_order_options(sort_criteria)
+        records = sort_records(records, order_options, context)
+
+        records = apply_pagination(records, options[:paginator], order_options)
+
+        records
+      end
+
+      def cached_resources_for(records, serializer, options)
+        if records.is_a?(Array) && records.all?{|rec| rec.is_a?(JSONAPI::Resource)}
+          resources = records.map{|r| [r.id, r] }.to_h
+        elsif self.caching?
+          t = _model_class.arel_table
+          cache_ids = pluck_arel_attributes(records, t[_primary_key], t[_cache_field])
+          resources = CachedResourceFragment.fetch_fragments(self, serializer, options[:context], cache_ids)
+        else
+          resources = resources_for(records, options).map{|r| [r.id, r] }.to_h
+        end
+
+        preload_included_fragments(resources, records, serializer, options)
+
+        resources.values
+      end
+
       def check_reserved_resource_name(type, name)
         if [:ids, :types, :hrefs, :links].include?(type)
           warn "[NAME COLLISION] `#{name}` is a reserved resource name."
@@ -1018,6 +1102,126 @@ module JSONAPI
         if _attributes.include?(name.to_sym)
           warn "[DUPLICATE ATTRIBUTE] `#{name}` has already been defined in #{_resource_name_from_type(_type)}."
         end
+      end
+
+      def preload_included_fragments(resources, records, serializer, options)
+        return if resources.empty?
+        res_ids = resources.keys
+
+        include_directives = options[:include_directives]
+        return unless include_directives
+
+        relevant_options = options.except(:include_directives, :order, :paginator)
+        context = options[:context]
+
+        # For each association, including indirect associations, find the target record ids.
+        # Even if a target class doesn't have caching enabled, we still have to look up
+        # and match the target ids here, because we can't use ActiveRecord#includes.
+        #
+        # Note that `paths` returns partial paths before complete paths, so e.g. the partial
+        # fragments for posts.comments will exist before we start working with posts.comments.author
+        target_resources = {}
+        include_directives.paths.each do |path|
+          # If path is [:posts, :comments, :author], then...
+          pluck_attrs = [] # [posts.id, comments.id, authors.id, authors.updated_at]
+          pluck_attrs << self._model_class.arel_table[self._primary_key]
+
+          relation = records
+            .except(:limit, :offset, :order)
+            .where({_primary_key => res_ids})
+
+          # These are updated as we iterate through the association path; afterwards they will
+          # refer to the final resource on the path, i.e. the actual resource to find in the cache.
+          # So e.g. if path is [:posts, :comments, :author], then after iteration...
+          parent_klass = nil # Comment
+          klass = self # Person
+          relationship = nil # JSONAPI::Relationship::ToOne for CommentResource.author
+          table = nil # people
+          assocs_path = [] # [ :posts, :approved_comments, :author ]
+          ar_hash = nil # { :posts => { :approved_comments => :author } }
+
+          # For each step on the path, figure out what the actual table name/alias in the join
+          # will be, and include the primary key of that table in our list of fields to select
+          path.each do |elem|
+            relationship = klass._relationships[elem]
+            assocs_path << relationship.relation_name(options).to_sym
+            # Converts [:a, :b, :c] to Rails-style { :a => { :b => :c }}
+            ar_hash = assocs_path.reverse.reduce{|memo, step| { step => memo } }
+            # We can't just look up the table name from the resource class, because Arel could
+            # have used a table alias if the relation includes a self-reference.
+            table = relation.joins(ar_hash).arel.source.right.last.left
+            parent_klass = klass
+            klass = relationship.resource_klass
+            pluck_attrs << table[klass._primary_key]
+          end
+
+          # Pre-fill empty hashes for each resource up to the end of the path.
+          # This allows us to later distinguish between a preload that returned nothing
+          # vs. a preload that never ran.
+          prefilling_resources = resources.values
+          path.each do |rel_name|
+            rel_name = serializer.key_formatter.format(rel_name)
+            prefilling_resources.map! do |res|
+              res.preloaded_fragments[rel_name] ||= {}
+              res.preloaded_fragments[rel_name].values
+            end
+            prefilling_resources.flatten!(1)
+          end
+
+          pluck_attrs << table[klass._cache_field] if klass.caching?
+          relation = relation.joins(ar_hash)
+          if relationship.is_a?(JSONAPI::Relationship::ToMany)
+            # Rails doesn't include order clauses in `joins`, so we have to add that manually here.
+            # FIXME Should find a better way to reflect on relationship ordering. :-(
+            relation = relation.order(parent_klass._model_class.new.send(assocs_path.last).arel.orders)
+          end
+
+          # [[post id, comment id, author id, author updated_at], ...]
+          id_rows = pluck_arel_attributes(relation.joins(ar_hash), *pluck_attrs)
+
+          target_resources[klass.name] ||= {}
+
+          if klass.caching?
+            sub_cache_ids = id_rows
+              .map{|row| row.last(2) }
+              .reject{|row| target_resources[klass.name].has_key?(row.first) }
+              .uniq
+            target_resources[klass.name].merge! CachedResourceFragment.fetch_fragments(
+              klass, serializer, context, sub_cache_ids
+            )
+          else
+            sub_res_ids = id_rows
+              .map(&:last)
+              .reject{|id| target_resources[klass.name].has_key?(id) }
+              .uniq
+            found = klass.find({klass._primary_key => sub_res_ids}, relevant_options)
+            target_resources[klass.name].merge! found.map{|r| [r.id, r] }.to_h
+          end
+
+          id_rows.each do |row|
+            res = resources[row.first]
+            path.each_with_index do |rel_name, index|
+              rel_name = serializer.key_formatter.format(rel_name)
+              rel_id = row[index+1]
+              assoc_rels = res.preloaded_fragments[rel_name]
+              if index == path.length - 1
+                assoc_rels[rel_id] = target_resources[klass.name].fetch(rel_id)
+              else
+                res = assoc_rels[rel_id]
+              end
+            end
+          end
+        end
+      end
+
+      def pluck_arel_attributes(relation, *attrs)
+        conn = relation.connection
+        quoted_attrs = attrs.map do |attr|
+          quoted_table = conn.quote_table_name(attr.relation.table_alias || attr.relation.name)
+          quoted_column = conn.quote_column_name(attr.name)
+          "#{quoted_table}.#{quoted_column}"
+        end
+        relation.pluck(*quoted_attrs)
       end
     end
   end

--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -179,7 +179,7 @@ module JSONAPI
 
     def supplying_attribute_fields(resource_klass)
       @_supplying_attribute_fields.fetch resource_klass do
-        attrs = Set.new(resource_klass._attributes.keys)
+        attrs = Set.new(resource_klass._attributes.keys.map(&:to_sym))
         cur = resource_klass
         while cur != JSONAPI::Resource
           if @fields.has_key?(cur._type)
@@ -194,7 +194,7 @@ module JSONAPI
 
     def supplying_relationship_fields(resource_klass)
       @_supplying_relationship_fields.fetch resource_klass do
-        relationships = Set.new(resource_klass._relationships.keys)
+        relationships = Set.new(resource_klass._relationships.keys.map(&:to_sym))
         cur = resource_klass
         while cur != JSONAPI::Resource
           if @fields.has_key?(cur._type)

--- a/lib/jsonapi/response_document.rb
+++ b/lib/jsonapi/response_document.rb
@@ -1,7 +1,8 @@
 module JSONAPI
   class ResponseDocument
-    def initialize(operation_results, options = {})
+    def initialize(operation_results, serializer, options = {})
       @operation_results = operation_results
+      @serializer = serializer
       @options = options
 
       @key_formatter = @options.fetch(:key_formatter, JSONAPI.configuration.key_formatter)
@@ -29,18 +30,6 @@ module JSONAPI
 
     private
 
-    def serializer
-      @serializer ||= @options.fetch(:resource_serializer_klass, JSONAPI::ResourceSerializer).new(
-        @options.fetch(:primary_resource_klass),
-        include_directives: @options[:include_directives],
-        fields: @options[:fields],
-        base_url: @options.fetch(:base_url, ''),
-        key_formatter: @key_formatter,
-        route_formatter: @options.fetch(:route_formatter, JSONAPI.configuration.route_formatter),
-        serialization_options: @options.fetch(:serialization_options, {})
-      )
-    end
-
     # Rolls up the top level meta data from the base_meta, the set of operations,
     # and the result of each operation. The keys are then formatted.
     def top_level_meta
@@ -60,7 +49,7 @@ module JSONAPI
         end
       end
 
-      meta.deep_transform_keys { |key| @key_formatter.format(key) }
+      meta.as_json.deep_transform_keys { |key| @key_formatter.format(key) }
     end
 
     # Rolls up the top level links from the base_links, the set of operations,
@@ -78,9 +67,9 @@ module JSONAPI
             result.pagination_params.each_pair do |link_name, params|
               if result.is_a?(JSONAPI::RelatedResourcesOperationResult)
                 relationship = result.source_resource.class._relationships[result._type.to_sym]
-                links[link_name] = serializer.link_builder.relationships_related_link(result.source_resource, relationship, query_params(params))
+                links[link_name] = @serializer.link_builder.relationships_related_link(result.source_resource, relationship, query_params(params))
               else
-                links[link_name] = serializer.query_link(query_params(params))
+                links[link_name] = @serializer.query_link(query_params(params))
               end
             end
         end
@@ -117,11 +106,11 @@ module JSONAPI
 
           case result
           when JSONAPI::ResourceOperationResult
-            serializer.serialize_to_hash(result.resource)
+            @serializer.serialize_to_hash(result.resource)
           when JSONAPI::ResourcesOperationResult
-            serializer.serialize_to_hash(result.resources)
+            @serializer.serialize_to_hash(result.resources)
           when JSONAPI::LinksObjectOperationResult
-            serializer.serialize_to_links_hash(result.parent_resource,
+            @serializer.serialize_to_links_hash(result.parent_resource,
                                                result.relationship)
           when JSONAPI::OperationResult
             {}
@@ -138,7 +127,7 @@ module JSONAPI
             end
           end
 
-          serializer.serialize_to_hash(resources)
+          @serializer.serialize_to_hash(resources)
         end
       end
     end

--- a/test/benchmark/request_benchmark.rb
+++ b/test/benchmark/request_benchmark.rb
@@ -2,15 +2,22 @@ require File.expand_path('../../test_helper', __FILE__)
 
 class RequestBenchmark < IntegrationBenchmark
   def setup
+    super
     $test_user = Person.find(1)
   end
 
-  def bench_large_index_request
+  def bench_large_index_request_uncached
     10.times do
-      get '/api/v2/books?include=bookComments,bookComments.author', headers: {
-        'Accept' => JSONAPI::MEDIA_TYPE
-      }
-      assert_jsonapi_response 200
+      assert_jsonapi_get '/api/v2/books?include=bookComments,bookComments.author'
+    end
+  end
+
+  def bench_large_index_request_caching
+    cache = ActiveSupport::Cache::MemoryStore.new
+    with_resource_caching(cache) do
+      10.times do
+        assert_jsonapi_get '/api/v2/books?include=bookComments,bookComments.author'
+      end
     end
   end
 end

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -10,7 +10,7 @@ class PostsControllerTest < ActionController::TestCase
   end
 
   def test_index
-    get :index
+    assert_cacheable_get :index
     assert_response :success
     assert json_response['data'].is_a?(Array)
   end
@@ -18,7 +18,7 @@ class PostsControllerTest < ActionController::TestCase
   def test_accept_header_missing
     @request.headers['Accept'] = nil
 
-    get :index
+    assert_cacheable_get :index
     assert_response :success
   end
 
@@ -26,14 +26,14 @@ class PostsControllerTest < ActionController::TestCase
     @request.headers['Accept'] =
       "#{JSONAPI::MEDIA_TYPE},#{JSONAPI::MEDIA_TYPE};charset=test"
 
-    get :index
+    assert_cacheable_get :index
     assert_response :success
   end
 
   def test_accept_header_jsonapi_modified
     @request.headers['Accept'] = "#{JSONAPI::MEDIA_TYPE};charset=test"
 
-    get :index
+    assert_cacheable_get :index
     assert_response 406
     assert_equal 'Not acceptable', json_response['errors'][0]['title']
     assert_equal "All requests must use the '#{JSONAPI::MEDIA_TYPE}' Accept without media type parameters. This request specified '#{@request.headers['Accept']}'.", json_response['errors'][0]['detail']
@@ -43,7 +43,7 @@ class PostsControllerTest < ActionController::TestCase
     @request.headers['Accept'] =
       "#{JSONAPI::MEDIA_TYPE};charset=test,#{JSONAPI::MEDIA_TYPE};charset=test"
 
-    get :index
+    assert_cacheable_get :index
     assert_response 406
     assert_equal 'Not acceptable', json_response['errors'][0]['title']
     assert_equal "All requests must use the '#{JSONAPI::MEDIA_TYPE}' Accept without media type parameters. This request specified '#{@request.headers['Accept']}'.", json_response['errors'][0]['detail']
@@ -52,34 +52,35 @@ class PostsControllerTest < ActionController::TestCase
   def test_accept_header_all
     @request.headers['Accept'] = "*/*"
 
-    get :index
+    assert_cacheable_get :index
     assert_response :success
   end
 
   def test_accept_header_not_jsonapi
     @request.headers['Accept'] = 'text/plain'
 
-    get :index
+    assert_cacheable_get :index
     assert_response 406
     assert_equal 'Not acceptable', json_response['errors'][0]['title']
     assert_equal "All requests must use the '#{JSONAPI::MEDIA_TYPE}' Accept without media type parameters. This request specified '#{@request.headers['Accept']}'.", json_response['errors'][0]['detail']
   end
 
   def test_exception_class_whitelist
-    original_config = JSONAPI.configuration.dup
+    original_whitelist = JSONAPI.configuration.exception_class_whitelist.dup
     $PostProcessorRaisesErrors = true
     # test that the operations dispatcher rescues the error when it
     # has not been added to the exception_class_whitelist
-    get :index
+    assert_cacheable_get :index
     assert_response 500
+
     # test that the operations dispatcher does not rescue the error when it
     # has been added to the exception_class_whitelist
     JSONAPI.configuration.exception_class_whitelist << PostsController::SpecialError
-    get :index
+    assert_cacheable_get :index
     assert_response 403
   ensure
     $PostProcessorRaisesErrors = false
-    JSONAPI.configuration = original_config
+    JSONAPI.configuration.exception_class_whitelist = original_whitelist
   end
 
   def test_on_server_error_block_callback_with_exception
@@ -92,7 +93,7 @@ class PostsControllerTest < ActionController::TestCase
       @controller.class.instance_variable_set(:@callback_message, "Sent from block")
     end
 
-    get :index
+    assert_cacheable_get :index
     assert_equal @controller.class.instance_variable_get(:@callback_message), "Sent from block"
 
     # test that it renders the default server error response
@@ -112,7 +113,7 @@ class PostsControllerTest < ActionController::TestCase
     @controller.class.on_server_error :set_callback_message, :a_bogus_method
     @controller.class.instance_variable_set(:@callback_message, "none")
 
-    get :index
+    assert_cacheable_get :index
     assert_equal @controller.class.instance_variable_get(:@callback_message), "Sent from method"
 
     # test that it renders the default server error response
@@ -128,7 +129,7 @@ class PostsControllerTest < ActionController::TestCase
     @controller.class.on_server_error callback
     @controller.class.instance_variable_set(:@callback_message, "none")
 
-    get :index
+    assert_cacheable_get :index
     assert_equal @controller.class.instance_variable_get(:@callback_message), "none"
 
     # test that it does not render error
@@ -138,49 +139,49 @@ class PostsControllerTest < ActionController::TestCase
   end
 
   def test_index_filter_with_empty_result
-    get :index, params: {filter: {title: 'post that does not exist'}}
+    assert_cacheable_get :index, params: {filter: {title: 'post that does not exist'}}
     assert_response :success
     assert json_response['data'].is_a?(Array)
     assert_equal 0, json_response['data'].size
   end
 
   def test_index_filter_by_id
-    get :index, params: {filter: {id: '1'}}
+    assert_cacheable_get :index, params: {filter: {id: '1'}}
     assert_response :success
     assert json_response['data'].is_a?(Array)
     assert_equal 1, json_response['data'].size
   end
 
   def test_index_filter_by_title
-    get :index, params: {filter: {title: 'New post'}}
+    assert_cacheable_get :index, params: {filter: {title: 'New post'}}
     assert_response :success
     assert json_response['data'].is_a?(Array)
     assert_equal 1, json_response['data'].size
   end
 
   def test_index_filter_with_hash_values
-    get :index, params: {filter: {search: {title: 'New post'}}}
+    assert_cacheable_get :index, params: {filter: {search: {title: 'New post'}}}
     assert_response :success
     assert json_response['data'].is_a?(Array)
     assert_equal 1, json_response['data'].size
   end
 
   def test_index_filter_by_ids
-    get :index, params: {filter: {ids: '1,2'}}
+    assert_cacheable_get :index, params: {filter: {ids: '1,2'}}
     assert_response :success
     assert json_response['data'].is_a?(Array)
     assert_equal 2, json_response['data'].size
   end
 
   def test_index_filter_by_ids_and_include_related
-    get :index, params: {filter: {id: '2'}, include: 'comments'}
+    assert_cacheable_get :index, params: {filter: {id: '2'}, include: 'comments'}
     assert_response :success
     assert_equal 1, json_response['data'].size
     assert_equal 1, json_response['included'].size
   end
 
   def test_index_filter_by_ids_and_include_related_different_type
-    get :index, params: {filter: {id: '1,2'}, include: 'author'}
+    assert_cacheable_get :index, params: {filter: {id: '1,2'}, include: 'author'}
     assert_response :success
     assert_equal 2, json_response['data'].size
     assert_equal 1, json_response['included'].size
@@ -188,30 +189,28 @@ class PostsControllerTest < ActionController::TestCase
 
   def test_index_filter_not_allowed
     JSONAPI.configuration.allow_filter = false
-    get :index, params: {filter: {id: '1'}}
+    assert_cacheable_get :index, params: {filter: {id: '1'}}
     assert_response :bad_request
   ensure
     JSONAPI.configuration.allow_filter = true
   end
 
   def test_index_include_one_level_query_count
-    count_queries do
-      get :index, params: {include: 'author'}
+    assert_query_count(2) do
+      assert_cacheable_get :index, params: {include: 'author'}
     end
     assert_response :success
-    assert_query_count(2)
   end
 
   def test_index_include_two_levels_query_count
-    count_queries do
-      get :index, params: {include: 'author,author.comments'}
+    assert_query_count(3) do
+      assert_cacheable_get :index, params: {include: 'author,author.comments'}
     end
     assert_response :success
-    assert_query_count(3)
   end
 
   def test_index_filter_by_ids_and_fields
-    get :index, params: {filter: {id: '1,2'}, fields: {posts: 'id,title,author'}}
+    assert_cacheable_get :index, params: {filter: {id: '1,2'}, fields: {posts: 'id,title,author'}}
     assert_response :success
     assert_equal 2, json_response['data'].size
 
@@ -224,7 +223,7 @@ class PostsControllerTest < ActionController::TestCase
   end
 
   def test_index_filter_by_ids_and_fields_specify_type
-    get :index, params: {filter: {id: '1,2'}, 'fields' => {'posts' => 'id,title,author'}}
+    assert_cacheable_get :index, params: {filter: {id: '1,2'}, 'fields' => {'posts' => 'id,title,author'}}
     assert_response :success
     assert_equal 2, json_response['data'].size
 
@@ -237,13 +236,13 @@ class PostsControllerTest < ActionController::TestCase
   end
 
   def test_index_filter_by_ids_and_fields_specify_unrelated_type
-    get :index, params: {filter: {id: '1,2'}, 'fields' => {'currencies' => 'code'}}
+    assert_cacheable_get :index, params: {filter: {id: '1,2'}, 'fields' => {'currencies' => 'code'}}
     assert_response :bad_request
     assert_match /currencies is not a valid resource./, json_response['errors'][0]['detail']
   end
 
   def test_index_filter_by_ids_and_fields_2
-    get :index, params: {filter: {id: '1,2'}, fields: {posts: 'author'}}
+    assert_cacheable_get :index, params: {filter: {id: '1,2'}, fields: {posts: 'author'}}
     assert_response :success
     assert_equal 2, json_response['data'].size
 
@@ -255,10 +254,9 @@ class PostsControllerTest < ActionController::TestCase
   end
 
   def test_filter_relationship_single
-    count_queries do
-      get :index, params: {filter: {tags: '5,1'}}
+    assert_query_count(1) do
+      assert_cacheable_get :index, params: {filter: {tags: '5,1'}}
     end
-    assert_query_count(1)
     assert_response :success
     assert_equal 3, json_response['data'].size
     assert_match /New post/, response.body
@@ -267,91 +265,90 @@ class PostsControllerTest < ActionController::TestCase
   end
 
   def test_filter_relationships_multiple
-    count_queries do
-      get :index, params: {filter: {tags: '5,1', comments: '3'}}
+    assert_query_count(1) do
+      assert_cacheable_get :index, params: {filter: {tags: '5,1', comments: '3'}}
     end
-    assert_query_count(1)
     assert_response :success
     assert_equal 1, json_response['data'].size
     assert_match /JR Solves your serialization woes!/, response.body
   end
 
   def test_filter_relationships_multiple_not_found
-    get :index, params: {filter: {tags: '1', comments: '3'}}
+    assert_cacheable_get :index, params: {filter: {tags: '1', comments: '3'}}
     assert_response :success
     assert_equal 0, json_response['data'].size
   end
 
   def test_bad_filter
-    get :index, params: {filter: {post_ids: '1,2'}}
+    assert_cacheable_get :index, params: {filter: {post_ids: '1,2'}}
     assert_response :bad_request
     assert_match /post_ids is not allowed/, response.body
   end
 
   def test_bad_filter_value_not_integer_array
-    get :index, params: {filter: {id: 'asdfg'}}
+    assert_cacheable_get :index, params: {filter: {id: 'asdfg'}}
     assert_response :bad_request
     assert_match /asdfg is not a valid value for id/, response.body
   end
 
   def test_bad_filter_value_not_integer
-    get :index, params: {filter: {id: 'asdfg'}}
+    assert_cacheable_get :index, params: {filter: {id: 'asdfg'}}
     assert_response :bad_request
     assert_match /asdfg is not a valid value for id/, response.body
   end
 
   def test_bad_filter_value_not_found_array
-    get :index, params: {filter: {id: '5412333'}}
+    assert_cacheable_get :index, params: {filter: {id: '5412333'}}
     assert_response :not_found
     assert_match /5412333 could not be found/, response.body
   end
 
   def test_bad_filter_value_not_found
-    get :index, params: {filter: {id: '5412333'}}
+    assert_cacheable_get :index, params: {filter: {id: '5412333'}}
     assert_response :not_found
     assert_match /5412333 could not be found/, json_response['errors'][0]['detail']
   end
 
   def test_field_not_supported
-    get :index, params: {filter: {id: '1,2'}, 'fields' => {'posts' => 'id,title,rank,author'}}
+    assert_cacheable_get :index, params: {filter: {id: '1,2'}, 'fields' => {'posts' => 'id,title,rank,author'}}
     assert_response :bad_request
     assert_match /rank is not a valid field for posts./, json_response['errors'][0]['detail']
   end
 
   def test_resource_not_supported
-    get :index, params: {filter: {id: '1,2'}, 'fields' => {'posters' => 'id,title'}}
+    assert_cacheable_get :index, params: {filter: {id: '1,2'}, 'fields' => {'posters' => 'id,title'}}
     assert_response :bad_request
     assert_match /posters is not a valid resource./, json_response['errors'][0]['detail']
   end
 
   def test_index_filter_on_relationship
-    get :index, params: {filter: {author: '1'}}
+    assert_cacheable_get :index, params: {filter: {author: '1'}}
     assert_response :success
     assert_equal 3, json_response['data'].size
   end
 
   def test_sorting_blank
-    get :index, params: {sort: ''}
+    assert_cacheable_get :index, params: {sort: ''}
 
     assert_response :success
   end
 
   def test_sorting_asc
-    get :index, params: {sort: 'title'}
+    assert_cacheable_get :index, params: {sort: 'title'}
 
     assert_response :success
     assert_equal "A First Post", json_response['data'][0]['attributes']['title']
   end
 
   def test_sorting_desc
-    get :index, params: {sort: '-title'}
+    assert_cacheable_get :index, params: {sort: '-title'}
 
     assert_response :success
     assert_equal "Update This Later - Multiple", json_response['data'][0]['attributes']['title']
   end
 
   def test_sorting_by_multiple_fields
-    get :index, params: {sort: 'title,body'}
+    assert_cacheable_get :index, params: {sort: 'title,body'}
 
     assert_response :success
     assert_equal '14', json_response['data'][0]['id']
@@ -364,7 +361,7 @@ class PostsControllerTest < ActionController::TestCase
 
   def test_sorting_by_relationship_field
     post  = create_alphabetically_first_user_and_post
-    get :index, params: {sort: 'author.name'}
+    assert_cacheable_get :index, params: {sort: 'author.name'}
 
     assert_response :success
     assert json_response['data'].length > 10, 'there are enough recordsto show sort'
@@ -374,7 +371,7 @@ class PostsControllerTest < ActionController::TestCase
 
   def test_desc_sorting_by_relationship_field
     post  = create_alphabetically_first_user_and_post
-    get :index, params: {sort: '-author.name'}
+    assert_cacheable_get :index, params: {sort: '-author.name'}
 
     assert_response :success
     assert json_response['data'].length > 10, 'there are enough records to show sort'
@@ -383,7 +380,7 @@ class PostsControllerTest < ActionController::TestCase
   end
 
   def test_invalid_sort_param
-    get :index, params: {sort: 'asdfg'}
+    assert_cacheable_get :index, params: {sort: 'asdfg'}
 
     assert_response :bad_request
     assert_match /asdfg is not a valid sort criteria for post/, response.body
@@ -391,21 +388,21 @@ class PostsControllerTest < ActionController::TestCase
 
   def test_show_single_with_sort_disallowed
     JSONAPI.configuration.allow_sort = false
-    get :index, params: {sort: 'title,body'}
+    assert_cacheable_get :index, params: {sort: 'title,body'}
     assert_response :bad_request
   ensure
     JSONAPI.configuration.allow_sort = true
   end
 
   def test_excluded_sort_param
-    get :index, params: {sort: 'id'}
+    assert_cacheable_get :index, params: {sort: 'id'}
 
     assert_response :bad_request
     assert_match /id is not a valid sort criteria for post/, response.body
   end
 
   def test_show_single
-    get :show, params: {id: '1'}
+    assert_cacheable_get :show, params: {id: '1'}
     assert_response :success
     assert json_response['data'].is_a?(Hash)
     assert_equal 'New post', json_response['data']['attributes']['title']
@@ -415,7 +412,7 @@ class PostsControllerTest < ActionController::TestCase
 
   def test_show_does_not_include_records_count_in_meta
     JSONAPI.configuration.top_level_meta_include_record_count = true
-    get :show, params: { id: Post.first.id }
+    assert_cacheable_get :show, params: { id: Post.first.id }
     assert_response :success
     assert_equal json_response['meta'], nil
   ensure
@@ -424,7 +421,7 @@ class PostsControllerTest < ActionController::TestCase
 
   def test_show_does_not_include_pages_count_in_meta
     JSONAPI.configuration.top_level_meta_include_page_count = true
-    get :show, params: { id: Post.first.id }
+    assert_cacheable_get :show, params: { id: Post.first.id }
     assert_response :success
     assert_equal json_response['meta'], nil
   ensure
@@ -432,7 +429,7 @@ class PostsControllerTest < ActionController::TestCase
   end
 
   def test_show_single_with_includes
-    get :show, params: {id: '1', include: 'comments'}
+    assert_cacheable_get :show, params: {id: '1', include: 'comments'}
     assert_response :success
     assert json_response['data'].is_a?(Hash)
     assert_equal 'New post', json_response['data']['attributes']['title']
@@ -445,45 +442,45 @@ class PostsControllerTest < ActionController::TestCase
 
   def test_show_single_with_include_disallowed
     JSONAPI.configuration.allow_include = false
-    get :show, params: {id: '1', include: 'comments'}
+    assert_cacheable_get :show, params: {id: '1', include: 'comments'}
     assert_response :bad_request
   ensure
     JSONAPI.configuration.allow_include = true
   end
 
   def test_show_single_with_fields
-    get :show, params: {id: '1', fields: {posts: 'author'}}
+    assert_cacheable_get :show, params: {id: '1', fields: {posts: 'author'}}
     assert_response :success
     assert json_response['data'].is_a?(Hash)
     assert_nil json_response['data']['attributes']
   end
 
   def test_show_single_with_fields_string
-    get :show, params: {id: '1', fields: 'author'}
+    assert_cacheable_get :show, params: {id: '1', fields: 'author'}
     assert_response :bad_request
     assert_match /Fields must specify a type./, json_response['errors'][0]['detail']
   end
 
   def test_show_single_invalid_id_format
-    get :show, params: {id: 'asdfg'}
+    assert_cacheable_get :show, params: {id: 'asdfg'}
     assert_response :bad_request
     assert_match /asdfg is not a valid value for id/, response.body
   end
 
   def test_show_single_missing_record
-    get :show, params: {id: '5412333'}
+    assert_cacheable_get :show, params: {id: '5412333'}
     assert_response :not_found
     assert_match /record identified by 5412333 could not be found/, response.body
   end
 
   def test_show_malformed_fields_not_list
-    get :show, params: {id: '1', 'fields' => ''}
+    assert_cacheable_get :show, params: {id: '1', 'fields' => ''}
     assert_response :bad_request
     assert_match /Fields must specify a type./, json_response['errors'][0]['detail']
   end
 
   def test_show_malformed_fields_type_not_list
-    get :show, params: {id: '1', 'fields' => {'posts' => ''}}
+    assert_cacheable_get :show, params: {id: '1', 'fields' => {'posts' => ''}}
     assert_response :bad_request
     assert_match /nil is not a valid field for posts./, json_response['errors'][0]['detail']
   end
@@ -1009,6 +1006,8 @@ class PostsControllerTest < ActionController::TestCase
   end
 
   def test_update_remove_links
+    orig_controller = @controller.dup
+
     set_content_type_header!
     put :update, params:
       {
@@ -1028,6 +1027,13 @@ class PostsControllerTest < ActionController::TestCase
       }
 
     assert_response :success
+
+    # FIXME Resetting the controller because ActionController::TestCase only allows you
+    # to test a single controller action per test method; really, this test should be in
+    # an Integration Test instead.
+    @controller = orig_controller
+    setup_controller_request_and_response
+    set_content_type_header!
 
     put :update, params:
       {
@@ -1469,7 +1475,7 @@ class PostsControllerTest < ActionController::TestCase
     assert_equal [], p.tag_ids
   end
 
-  def test_update_mismatched_keys
+  def test_update_mismatch_single_key
     set_content_type_header!
     javascript = Section.find_by(name: 'javascript')
 
@@ -1746,7 +1752,7 @@ class PostsControllerTest < ActionController::TestCase
     assert_match /A key is required/, response.body
   end
 
-  def test_update_mismatch_keys
+  def test_update_mismatch_multiple_keys
     set_content_type_header!
     javascript = Section.find_by(name: 'javascript')
 
@@ -1891,7 +1897,7 @@ class PostsControllerTest < ActionController::TestCase
   end
 
   def test_show_to_one_relationship
-    get :show_relationship, params: {post_id: '1', relationship: 'author'}
+    assert_cacheable_get :show_relationship, params: {post_id: '1', relationship: 'author'}
     assert_response :success
     assert_hash_equals json_response,
                        {data: {
@@ -1906,7 +1912,7 @@ class PostsControllerTest < ActionController::TestCase
   end
 
   def test_show_to_many_relationship
-    get :show_relationship, params: {post_id: '2', relationship: 'tags'}
+    assert_cacheable_get :show_relationship, params: {post_id: '2', relationship: 'tags'}
     assert_response :success
     assert_hash_equals json_response,
                        {
@@ -1921,13 +1927,13 @@ class PostsControllerTest < ActionController::TestCase
   end
 
   def test_show_to_many_relationship_invalid_id
-    get :show_relationship, params: {post_id: '2,1', relationship: 'tags'}
+    assert_cacheable_get :show_relationship, params: {post_id: '2,1', relationship: 'tags'}
     assert_response :bad_request
     assert_match /2,1 is not a valid value for id/, response.body
   end
 
   def test_show_to_one_relationship_nil
-    get :show_relationship, params: {post_id: '17', relationship: 'author'}
+    assert_cacheable_get :show_relationship, params: {post_id: '17', relationship: 'author'}
     assert_response :success
     assert_hash_equals json_response,
                        {
@@ -1942,32 +1948,32 @@ end
 
 class TagsControllerTest < ActionController::TestCase
   def test_tags_index
-    get :index, params: {filter: {id: '6,7,8,9'}, include: 'posts.tags,posts.author.posts'}
+    assert_cacheable_get :index, params: {filter: {id: '6,7,8,9'}, include: 'posts.tags,posts.author.posts'}
     assert_response :success
     assert_equal 4, json_response['data'].size
     assert_equal 3, json_response['included'].size
   end
 
   def test_tags_show_multiple
-    get :show, params: {id: '6,7,8,9'}
+    assert_cacheable_get :show, params: {id: '6,7,8,9'}
     assert_response :bad_request
     assert_match /6,7,8,9 is not a valid value for id/, response.body
   end
 
   def test_tags_show_multiple_with_include
-    get :show, params: {id: '6,7,8,9', include: 'posts.tags,posts.author.posts'}
+    assert_cacheable_get :show, params: {id: '6,7,8,9', include: 'posts.tags,posts.author.posts'}
     assert_response :bad_request
     assert_match /6,7,8,9 is not a valid value for id/, response.body
   end
 
   def test_tags_show_multiple_with_nonexistent_ids
-    get :show, params: {id: '6,99,9,100'}
+    assert_cacheable_get :show, params: {id: '6,99,9,100'}
     assert_response :bad_request
     assert_match /6,99,9,100 is not a valid value for id/, response.body
   end
 
   def test_tags_show_multiple_with_nonexistent_ids_at_the_beginning
-    get :show, params: {id: '99,9,100'}
+    assert_cacheable_get :show, params: {id: '99,9,100'}
     assert_response :bad_request
     assert_match /99,9,100 is not a valid value for id/, response.body
   end
@@ -1980,7 +1986,7 @@ class ExpenseEntriesControllerTest < ActionController::TestCase
 
   def test_text_error
     JSONAPI.configuration.use_text_errors = true
-    get :index, params: {sort: 'not_in_record'}
+    assert_cacheable_get :index, params: {sort: 'not_in_record'}
     assert_response 400
     assert_equal 'INVALID_SORT_CRITERIA', json_response['errors'][0]['code']
   ensure
@@ -1988,48 +1994,48 @@ class ExpenseEntriesControllerTest < ActionController::TestCase
   end
 
   def test_expense_entries_index
-    get :index
+    assert_cacheable_get :index
     assert_response :success
     assert json_response['data'].is_a?(Array)
     assert_equal 2, json_response['data'].size
   end
 
   def test_expense_entries_show
-    get :show, params: {id: 1}
+    assert_cacheable_get :show, params: {id: 1}
     assert_response :success
     assert json_response['data'].is_a?(Hash)
   end
 
   def test_expense_entries_show_include
-    get :show, params: {id: 1, include: 'isoCurrency,employee'}
+    assert_cacheable_get :show, params: {id: 1, include: 'isoCurrency,employee'}
     assert_response :success
     assert json_response['data'].is_a?(Hash)
     assert_equal 2, json_response['included'].size
   end
 
   def test_expense_entries_show_bad_include_missing_relationship
-    get :show, params: {id: 1, include: 'isoCurrencies,employees'}
+    assert_cacheable_get :show, params: {id: 1, include: 'isoCurrencies,employees'}
     assert_response :bad_request
     assert_match /isoCurrencies is not a valid relationship of expenseEntries/, json_response['errors'][0]['detail']
     assert_match /employees is not a valid relationship of expenseEntries/, json_response['errors'][1]['detail']
   end
 
   def test_expense_entries_show_bad_include_missing_sub_relationship
-    get :show, params: {id: 1, include: 'isoCurrency,employee.post'}
+    assert_cacheable_get :show, params: {id: 1, include: 'isoCurrency,employee.post'}
     assert_response :bad_request
     assert_match /post is not a valid relationship of people/, json_response['errors'][0]['detail']
   end
 
   def test_expense_entries_show_fields
-    get :show, params: {id: 1, include: 'isoCurrency,employee', 'fields' => {'expenseEntries' => 'transactionDate'}}
+    assert_cacheable_get :show, params: {id: 1, include: 'isoCurrency,employee', 'fields' => {'expenseEntries' => 'transactionDate'}}
     assert_response :success
     assert json_response['data'].is_a?(Hash)
-    assert json_response['data']['attributes'].key?('transactionDate')
+    assert_equal ['transactionDate'], json_response['data']['attributes'].keys
     assert_equal 2, json_response['included'].size
   end
 
   def test_expense_entries_show_fields_type_many
-    get :show, params: {id: 1, include: 'isoCurrency,employee', 'fields' => {'expenseEntries' => 'transactionDate',
+    assert_cacheable_get :show, params: {id: 1, include: 'isoCurrency,employee', 'fields' => {'expenseEntries' => 'transactionDate',
                                                                              'isoCurrencies' => 'id,name'}}
     assert_response :success
     assert json_response['data'].is_a?(Hash)
@@ -2146,7 +2152,7 @@ class IsoCurrenciesControllerTest < ActionController::TestCase
   end
 
   def test_currencies_show
-    get :show, params: {id: 'USD'}
+    assert_cacheable_get :show, params: {id: 'USD'}
     assert_response :success
     assert json_response['data'].is_a?(Hash)
   end
@@ -2182,7 +2188,7 @@ class IsoCurrenciesControllerTest < ActionController::TestCase
   end
 
   def test_currencies_primary_key_sort
-    get :index, params: {sort: 'id'}
+    assert_cacheable_get :index, params: {sort: 'id'}
     assert_response :success
     assert_equal 3, json_response['data'].size
     assert_equal 'CAD', json_response['data'][0]['id']
@@ -2191,14 +2197,14 @@ class IsoCurrenciesControllerTest < ActionController::TestCase
   end
 
   def test_currencies_code_sort
-    get :index, params: {sort: 'code'}
+    assert_cacheable_get :index, params: {sort: 'code'}
     assert_response :bad_request
   end
 
   def test_currencies_json_key_underscored_sort
     original_config = JSONAPI.configuration.dup
     JSONAPI.configuration.json_key_format = :underscored_key
-    get :index, params: {sort: 'country_name'}
+    assert_cacheable_get :index, params: {sort: 'country_name'}
     assert_response :success
     assert_equal 3, json_response['data'].size
     assert_equal 'Canada', json_response['data'][0]['attributes']['country_name']
@@ -2206,7 +2212,7 @@ class IsoCurrenciesControllerTest < ActionController::TestCase
     assert_equal 'United States', json_response['data'][2]['attributes']['country_name']
 
     # reverse sort
-    get :index, params: {sort: '-country_name'}
+    assert_cacheable_get :index, params: {sort: '-country_name'}
     assert_response :success
     assert_equal 3, json_response['data'].size
     assert_equal 'United States', json_response['data'][0]['attributes']['country_name']
@@ -2219,7 +2225,7 @@ class IsoCurrenciesControllerTest < ActionController::TestCase
   def test_currencies_json_key_dasherized_sort
     original_config = JSONAPI.configuration.dup
     JSONAPI.configuration.json_key_format = :dasherized_key
-    get :index, params: {sort: 'country-name'}
+    assert_cacheable_get :index, params: {sort: 'country-name'}
     assert_response :success
     assert_equal 3, json_response['data'].size
     assert_equal 'Canada', json_response['data'][0]['attributes']['country-name']
@@ -2227,7 +2233,7 @@ class IsoCurrenciesControllerTest < ActionController::TestCase
     assert_equal 'United States', json_response['data'][2]['attributes']['country-name']
 
     # reverse sort
-    get :index, params: {sort: '-country-name'}
+    assert_cacheable_get :index, params: {sort: '-country-name'}
     assert_response :success
     assert_equal 3, json_response['data'].size
     assert_equal 'United States', json_response['data'][0]['attributes']['country-name']
@@ -2240,7 +2246,7 @@ class IsoCurrenciesControllerTest < ActionController::TestCase
   def test_currencies_json_key_custom_json_key_sort
     original_config = JSONAPI.configuration.dup
     JSONAPI.configuration.json_key_format = :upper_camelized_key
-    get :index, params: {sort: 'CountryName'}
+    assert_cacheable_get :index, params: {sort: 'CountryName'}
     assert_response :success
     assert_equal 3, json_response['data'].size
     assert_equal 'Canada', json_response['data'][0]['attributes']['CountryName']
@@ -2248,7 +2254,7 @@ class IsoCurrenciesControllerTest < ActionController::TestCase
     assert_equal 'United States', json_response['data'][2]['attributes']['CountryName']
 
     # reverse sort
-    get :index, params: {sort: '-CountryName'}
+    assert_cacheable_get :index, params: {sort: '-CountryName'}
     assert_response :success
     assert_equal 3, json_response['data'].size
     assert_equal 'United States', json_response['data'][0]['attributes']['CountryName']
@@ -2261,7 +2267,7 @@ class IsoCurrenciesControllerTest < ActionController::TestCase
   def test_currencies_json_key_underscored_filter
     original_config = JSONAPI.configuration.dup
     JSONAPI.configuration.json_key_format = :underscored_key
-    get :index, params: {filter: {country_name: 'Canada'}}
+    assert_cacheable_get :index, params: {filter: {country_name: 'Canada'}}
     assert_response :success
     assert_equal 1, json_response['data'].size
     assert_equal 'Canada', json_response['data'][0]['attributes']['country_name']
@@ -2272,7 +2278,7 @@ class IsoCurrenciesControllerTest < ActionController::TestCase
   def test_currencies_json_key_camelized_key_filter
     original_config = JSONAPI.configuration.dup
     JSONAPI.configuration.json_key_format = :camelized_key
-    get :index, params: {filter: {'countryName' => 'Canada'}}
+    assert_cacheable_get :index, params: {filter: {'countryName' => 'Canada'}}
     assert_response :success
     assert_equal 1, json_response['data'].size
     assert_equal 'Canada', json_response['data'][0]['attributes']['countryName']
@@ -2283,7 +2289,7 @@ class IsoCurrenciesControllerTest < ActionController::TestCase
   def test_currencies_json_key_custom_json_key_filter
     original_config = JSONAPI.configuration.dup
     JSONAPI.configuration.json_key_format = :upper_camelized_key
-    get :index, params: {filter: {'CountryName' => 'Canada'}}
+    assert_cacheable_get :index, params: {filter: {'CountryName' => 'Canada'}}
     assert_response :success
     assert_equal 1, json_response['data'].size
     assert_equal 'Canada', json_response['data'][0]['attributes']['CountryName']
@@ -2387,12 +2393,12 @@ class PeopleControllerTest < ActionController::TestCase
   end
 
   def test_invalid_filter_value
-    get :index, params: {filter: {name: 'L'}}
+    assert_cacheable_get :index, params: {filter: {name: 'L'}}
     assert_response :bad_request
   end
 
   def test_valid_filter_value
-    get :index, params: {filter: {name: 'Joe Author'}}
+    assert_cacheable_get :index, params: {filter: {name: 'Joe Author'}}
     assert_response :success
     assert_equal json_response['data'].size, 1
     assert_equal json_response['data'][0]['id'], '1'
@@ -2403,7 +2409,7 @@ class PeopleControllerTest < ActionController::TestCase
     original_config = JSONAPI.configuration.dup
     JSONAPI.configuration.json_key_format = :dasherized_key
     JSONAPI.configuration.route_format = :underscored_key
-    get :get_related_resource, params: {post_id: '2', relationship: 'author', source:'posts'}
+    assert_cacheable_get :get_related_resource, params: {post_id: '2', relationship: 'author', source:'posts'}
     assert_response :success
     assert_hash_equals(
       {
@@ -2459,7 +2465,7 @@ class PeopleControllerTest < ActionController::TestCase
   end
 
   def test_get_related_resource_nil
-    get :get_related_resource, params: {post_id: '17', relationship: 'author', source:'posts'}
+    assert_cacheable_get :get_related_resource, params: {post_id: '17', relationship: 'author', source:'posts'}
     assert_response :success
     assert_hash_equals json_response,
                        {
@@ -2472,7 +2478,7 @@ end
 class BooksControllerTest < ActionController::TestCase
   def test_books_include_correct_type
     $test_user = Person.find(1)
-    get :index, params: {filter: {id: '1'}, include: 'authors'}
+    assert_cacheable_get :index, params: {filter: {id: '1'}, include: 'authors'}
     assert_response :success
     assert_equal 'authors', json_response['included'][0]['type']
   end
@@ -2505,7 +2511,7 @@ end
 
 class Api::V5::AuthorsControllerTest < ActionController::TestCase
   def test_get_person_as_author
-    get :index, params: {filter: {id: '1'}}
+    assert_cacheable_get :index, params: {filter: {id: '1'}}
     assert_response :success
     assert_equal 1, json_response['data'].size
     assert_equal '1', json_response['data'][0]['id']
@@ -2515,7 +2521,7 @@ class Api::V5::AuthorsControllerTest < ActionController::TestCase
   end
 
   def test_show_person_as_author
-    get :show, params: {id: '1'}
+    assert_cacheable_get :show, params: {id: '1'}
     assert_response :success
     assert_equal '1', json_response['data']['id']
     assert_equal 'authors', json_response['data']['type']
@@ -2524,7 +2530,7 @@ class Api::V5::AuthorsControllerTest < ActionController::TestCase
   end
 
   def test_get_person_as_author_by_name_filter
-    get :index, params: {filter: {name: 'thor'}}
+    assert_cacheable_get :index, params: {filter: {name: 'thor'}}
     assert_response :success
     assert_equal 3, json_response['data'].size
     assert_equal '1', json_response['data'][0]['id']
@@ -2545,7 +2551,7 @@ class Api::V5::AuthorsControllerTest < ActionController::TestCase
       end
     end
 
-    get :show, params: {id: '1'}
+    assert_cacheable_get :show, params: {id: '1'}
     assert_response :success
     assert_equal '1', json_response['data']['id']
     assert_equal 'Hardcoded value', json_response['data']['meta']['fixed']
@@ -2580,7 +2586,7 @@ class Api::V5::AuthorsControllerTest < ActionController::TestCase
       end
     end
 
-    get :show, params: {id: '1'}
+    assert_cacheable_get :show, params: {id: '1'}
     assert_response :success
     assert_equal '1', json_response['data']['id']
     assert_equal 'Hardcoded value', json_response['data']['meta']['custom_hash']['fixed']
@@ -2604,14 +2610,14 @@ class BreedsControllerTest < ActionController::TestCase
   # Note: Breed names go through the TitleValueFormatter
 
   def test_poro_index
-    get :index
+    assert_cacheable_get :index
     assert_response :success
     assert_equal '0', json_response['data'][0]['id']
     assert_equal 'Persian', json_response['data'][0]['attributes']['name']
   end
 
   def test_poro_show
-    get :show, params: {id: '0'}
+    assert_cacheable_get :show, params: {id: '0'}
     assert_response :success
     assert json_response['data'].is_a?(Hash)
     assert_equal '0', json_response['data']['id']
@@ -2619,7 +2625,7 @@ class BreedsControllerTest < ActionController::TestCase
   end
 
   def test_poro_show_multiple
-    get :show, params: {id: '0,2'}
+    assert_cacheable_get :show, params: {id: '0,2'}
 
     assert_response :bad_request
     assert_match /0,2 is not a valid value for id/, response.body
@@ -2702,7 +2708,7 @@ end
 
 class Api::V2::PreferencesControllerTest < ActionController::TestCase
   def test_show_singleton_resource_without_id
-    get :show
+    assert_cacheable_get :show
     assert_response :success
   end
 
@@ -2722,13 +2728,13 @@ end
 
 class Api::V1::PostsControllerTest < ActionController::TestCase
   def test_show_post_namespaced
-    get :show, params: {id: '1'}
+    assert_cacheable_get :show, params: {id: '1'}
     assert_response :success
     assert_equal 'http://test.host/api/v1/posts/1/relationships/writer', json_response['data']['relationships']['writer']['links']['self']
   end
 
   def test_show_post_namespaced_include
-    get :show, params: {id: '1', include: 'writer'}
+    assert_cacheable_get :show, params: {id: '1', include: 'writer'}
     assert_response :success
     assert_equal '1', json_response['data']['relationships']['writer']['data']['id']
     assert_nil json_response['data']['relationships']['tags']
@@ -2738,13 +2744,13 @@ class Api::V1::PostsControllerTest < ActionController::TestCase
   end
 
   def test_index_filter_on_relationship_namespaced
-    get :index, params: {filter: {writer: '1'}}
+    assert_cacheable_get :index, params: {filter: {writer: '1'}}
     assert_response :success
     assert_equal 3, json_response['data'].size
   end
 
   def test_sorting_desc_namespaced
-    get :index, params: {sort: '-title'}
+    assert_cacheable_get :index, params: {sort: '-title'}
 
     assert_response :success
     assert_equal "Update This Later - Multiple", json_response['data'][0]['attributes']['title']
@@ -2779,16 +2785,16 @@ class FactsControllerTest < ActionController::TestCase
   def test_type_formatting
     original_config = JSONAPI.configuration.dup
     JSONAPI.configuration.json_key_format = :camelized_key
-    get :show, params: {id: '1'}
+    assert_cacheable_get :show, params: {id: '1'}
     assert_response :success
     assert json_response['data'].is_a?(Hash)
     assert_equal 'Jane Author', json_response['data']['attributes']['spouseName']
     assert_equal 'First man to run across Antartica.', json_response['data']['attributes']['bio']
     assert_equal 23.89/45.6, json_response['data']['attributes']['qualityRating']
     assert_equal '47000.56', json_response['data']['attributes']['salary']
-    assert_equal '2013-08-07T20:25:00Z', json_response['data']['attributes']['dateTimeJoined']
+    assert_equal '2013-08-07T20:25:00.000Z', json_response['data']['attributes']['dateTimeJoined']
     assert_equal '1965-06-30', json_response['data']['attributes']['birthday']
-    assert_equal '2000-01-01T20:00:00Z', json_response['data']['attributes']['bedtime']
+    assert_equal '2000-01-01T20:00:00.000Z', json_response['data']['attributes']['bedtime']
     assert_equal 'abc', json_response['data']['attributes']['photo']
     assert_equal false, json_response['data']['attributes']['cool']
   ensure
@@ -2846,7 +2852,7 @@ class Api::V2::BooksControllerTest < ActionController::TestCase
   def test_books_offset_pagination_no_params
     Api::V2::BookResource.paginator :offset
 
-    get :index
+    assert_cacheable_get :index
     assert_response :success
     assert_equal 10, json_response['data'].size
     assert_equal 'Book 0', json_response['data'][0]['attributes']['title']
@@ -2855,7 +2861,7 @@ class Api::V2::BooksControllerTest < ActionController::TestCase
   def test_books_record_count_in_meta
     Api::V2::BookResource.paginator :offset
     JSONAPI.configuration.top_level_meta_include_record_count = true
-    get :index, params: {include: 'book-comments'}
+    assert_cacheable_get :index, params: {include: 'book-comments'}
     JSONAPI.configuration.top_level_meta_include_record_count = false
 
     assert_response :success
@@ -2867,7 +2873,7 @@ class Api::V2::BooksControllerTest < ActionController::TestCase
   def test_books_page_count_in_meta
     Api::V2::BookResource.paginator :paged
     JSONAPI.configuration.top_level_meta_include_page_count = true
-    get :index, params: {include: 'book-comments'}
+    assert_cacheable_get :index, params: {include: 'book-comments'}
     JSONAPI.configuration.top_level_meta_include_page_count = false
 
     assert_response :success
@@ -2881,7 +2887,7 @@ class Api::V2::BooksControllerTest < ActionController::TestCase
     JSONAPI.configuration.top_level_meta_include_record_count = true
     JSONAPI.configuration.top_level_meta_record_count_key = 'total_records'
 
-    get :index, params: {include: 'book-comments'}
+    assert_cacheable_get :index, params: {include: 'book-comments'}
     JSONAPI.configuration.top_level_meta_include_record_count = false
     JSONAPI.configuration.top_level_meta_record_count_key = :record_count
 
@@ -2896,7 +2902,7 @@ class Api::V2::BooksControllerTest < ActionController::TestCase
     JSONAPI.configuration.top_level_meta_include_page_count = true
     JSONAPI.configuration.top_level_meta_page_count_key = 'total_pages'
 
-    get :index, params: {include: 'book-comments'}
+    assert_cacheable_get :index, params: {include: 'book-comments'}
     JSONAPI.configuration.top_level_meta_include_page_count = false
     JSONAPI.configuration.top_level_meta_page_count_key = :page_count
 
@@ -2909,31 +2915,29 @@ class Api::V2::BooksControllerTest < ActionController::TestCase
   def test_books_offset_pagination_no_params_includes_query_count_one_level
     Api::V2::BookResource.paginator :offset
 
-    count_queries do
-      get :index, params: {include: 'book-comments'}
+    assert_query_count(3) do
+      assert_cacheable_get :index, params: {include: 'book-comments'}
     end
     assert_response :success
     assert_equal 10, json_response['data'].size
     assert_equal 'Book 0', json_response['data'][0]['attributes']['title']
-    assert_query_count(3)
   end
 
   def test_books_offset_pagination_no_params_includes_query_count_two_levels
     Api::V2::BookResource.paginator :offset
 
-    count_queries do
-      get :index, params: {include: 'book-comments,book-comments.author'}
+    assert_query_count(4) do
+      assert_cacheable_get :index, params: {include: 'book-comments,book-comments.author'}
     end
     assert_response :success
     assert_equal 10, json_response['data'].size
     assert_equal 'Book 0', json_response['data'][0]['attributes']['title']
-    assert_query_count(4)
   end
 
   def test_books_offset_pagination
     Api::V2::BookResource.paginator :offset
 
-    get :index, params: {page: {offset: 50, limit: 12}}
+    assert_cacheable_get :index, params: {page: {offset: 50, limit: 12}}
     assert_response :success
     assert_equal 12, json_response['data'].size
     assert_equal 'Book 50', json_response['data'][0]['attributes']['title']
@@ -2942,7 +2946,7 @@ class Api::V2::BooksControllerTest < ActionController::TestCase
   def test_books_offset_pagination_bad_page_param
     Api::V2::BookResource.paginator :offset
 
-    get :index, params: {page: {offset_bad: 50, limit: 12}}
+    assert_cacheable_get :index, params: {page: {offset_bad: 50, limit: 12}}
     assert_response :bad_request
     assert_match /offset_bad is not an allowed page parameter./, json_response['errors'][0]['detail']
   end
@@ -2950,7 +2954,7 @@ class Api::V2::BooksControllerTest < ActionController::TestCase
   def test_books_offset_pagination_bad_param_value_limit_to_large
     Api::V2::BookResource.paginator :offset
 
-    get :index, params: {page: {offset: 50, limit: 1000}}
+    assert_cacheable_get :index, params: {page: {offset: 50, limit: 1000}}
     assert_response :bad_request
     assert_match /Limit exceeds maximum page size of 20./, json_response['errors'][0]['detail']
   end
@@ -2958,7 +2962,7 @@ class Api::V2::BooksControllerTest < ActionController::TestCase
   def test_books_offset_pagination_bad_param_value_limit_too_small
     Api::V2::BookResource.paginator :offset
 
-    get :index, params: {page: {offset: 50, limit: -1}}
+    assert_cacheable_get :index, params: {page: {offset: 50, limit: -1}}
     assert_response :bad_request
     assert_match /-1 is not a valid value for limit page parameter./, json_response['errors'][0]['detail']
   end
@@ -2966,7 +2970,7 @@ class Api::V2::BooksControllerTest < ActionController::TestCase
   def test_books_offset_pagination_bad_param_offset_less_than_zero
     Api::V2::BookResource.paginator :offset
 
-    get :index, params: {page: {offset: -1, limit: 20}}
+    assert_cacheable_get :index, params: {page: {offset: -1, limit: 20}}
     assert_response :bad_request
     assert_match /-1 is not a valid value for offset page parameter./, json_response['errors'][0]['detail']
   end
@@ -2974,7 +2978,7 @@ class Api::V2::BooksControllerTest < ActionController::TestCase
   def test_books_offset_pagination_invalid_page_format
     Api::V2::BookResource.paginator :offset
 
-    get :index, params: {page: 50}
+    assert_cacheable_get :index, params: {page: 50}
     assert_response :bad_request
     assert_match /Invalid Page Object./, json_response['errors'][0]['detail']
   end
@@ -2982,7 +2986,7 @@ class Api::V2::BooksControllerTest < ActionController::TestCase
   def test_books_paged_pagination_no_params
     Api::V2::BookResource.paginator :paged
 
-    get :index
+    assert_cacheable_get :index
     assert_response :success
     assert_equal 10, json_response['data'].size
     assert_equal 'Book 0', json_response['data'][0]['attributes']['title']
@@ -2991,7 +2995,7 @@ class Api::V2::BooksControllerTest < ActionController::TestCase
   def test_books_paged_pagination_no_page
     Api::V2::BookResource.paginator :paged
 
-    get :index, params: {page: {size: 12}}
+    assert_cacheable_get :index, params: {page: {size: 12}}
     assert_response :success
     assert_equal 12, json_response['data'].size
     assert_equal 'Book 0', json_response['data'][0]['attributes']['title']
@@ -3000,7 +3004,7 @@ class Api::V2::BooksControllerTest < ActionController::TestCase
   def test_books_paged_pagination
     Api::V2::BookResource.paginator :paged
 
-    get :index, params: {page: {number: 3, size: 12}}
+    assert_cacheable_get :index, params: {page: {number: 3, size: 12}}
     assert_response :success
     assert_equal 12, json_response['data'].size
     assert_equal 'Book 24', json_response['data'][0]['attributes']['title']
@@ -3009,7 +3013,7 @@ class Api::V2::BooksControllerTest < ActionController::TestCase
   def test_books_paged_pagination_bad_page_param
     Api::V2::BookResource.paginator :paged
 
-    get :index, params: {page: {number_bad: 50, size: 12}}
+    assert_cacheable_get :index, params: {page: {number_bad: 50, size: 12}}
     assert_response :bad_request
     assert_match /number_bad is not an allowed page parameter./, json_response['errors'][0]['detail']
   end
@@ -3017,7 +3021,7 @@ class Api::V2::BooksControllerTest < ActionController::TestCase
   def test_books_paged_pagination_bad_param_value_limit_to_large
     Api::V2::BookResource.paginator :paged
 
-    get :index, params: {page: {number: 50, size: 1000}}
+    assert_cacheable_get :index, params: {page: {number: 50, size: 1000}}
     assert_response :bad_request
     assert_match /size exceeds maximum page size of 20./, json_response['errors'][0]['detail']
   end
@@ -3025,7 +3029,7 @@ class Api::V2::BooksControllerTest < ActionController::TestCase
   def test_books_paged_pagination_bad_param_value_limit_too_small
     Api::V2::BookResource.paginator :paged
 
-    get :index, params: {page: {number: 50, size: -1}}
+    assert_cacheable_get :index, params: {page: {number: 50, size: -1}}
     assert_response :bad_request
     assert_match /-1 is not a valid value for size page parameter./, json_response['errors'][0]['detail']
   end
@@ -3033,7 +3037,7 @@ class Api::V2::BooksControllerTest < ActionController::TestCase
   def test_books_paged_pagination_invalid_page_format_incorrect
     Api::V2::BookResource.paginator :paged
 
-    get :index, params: {page: 'qwerty'}
+    assert_cacheable_get :index, params: {page: 'qwerty'}
     assert_response :bad_request
     assert_match /0 is not a valid value for number page parameter./, json_response['errors'][0]['detail']
   end
@@ -3041,7 +3045,7 @@ class Api::V2::BooksControllerTest < ActionController::TestCase
   def test_books_paged_pagination_invalid_page_format_interpret_int
     Api::V2::BookResource.paginator :paged
 
-    get :index, params: {page: 3}
+    assert_cacheable_get :index, params: {page: 3}
     assert_response :success
     assert_equal 10, json_response['data'].size
     assert_equal 'Book 20', json_response['data'][0]['attributes']['title']
@@ -3050,27 +3054,25 @@ class Api::V2::BooksControllerTest < ActionController::TestCase
   def test_books_included_paged
     Api::V2::BookResource.paginator :offset
 
-    count_queries do
-      get :index, params: {filter: {id: '0'}, include: 'book-comments'}
+    assert_query_count(3) do
+      assert_cacheable_get :index, params: {filter: {id: '0'}, include: 'book-comments'}
     end
     assert_response :success
     assert_equal 1, json_response['data'].size
     assert_equal 'Book 0', json_response['data'][0]['attributes']['title']
-    assert_query_count(3)
   end
 
   def test_books_banned_non_book_admin
     $test_user = Person.find(1)
     Api::V2::BookResource.paginator :offset
     JSONAPI.configuration.top_level_meta_include_record_count = true
-    count_queries do
-      get :index, params: {page: {offset: 50, limit: 12}}
+    assert_query_count(2) do
+      assert_cacheable_get :index, params: {page: {offset: 50, limit: 12}}
     end
     assert_response :success
     assert_equal 12, json_response['data'].size
     assert_equal 'Book 50', json_response['data'][0]['attributes']['title']
     assert_equal 901, json_response['meta']['record-count']
-    assert_query_count(2)
   ensure
     JSONAPI.configuration.top_level_meta_include_record_count = false
   end
@@ -3079,8 +3081,8 @@ class Api::V2::BooksControllerTest < ActionController::TestCase
     $test_user = Person.find(1)
     Api::V2::BookResource.paginator :offset
     JSONAPI.configuration.top_level_meta_include_record_count = true
-    count_queries do
-      get :index, params: {page: {offset: 0, limit: 12}, include: 'book-comments'}
+    assert_query_count(3) do
+      assert_cacheable_get :index, params: {page: {offset: 0, limit: 12}, include: 'book-comments'}
     end
 
     assert_response :success
@@ -3090,7 +3092,6 @@ class Api::V2::BooksControllerTest < ActionController::TestCase
     assert_equal 26, json_response['data'][0]['relationships']['book-comments']['data'].size
     assert_equal 'book-comments', json_response['included'][0]['type']
     assert_equal 901, json_response['meta']['record-count']
-    assert_query_count(3)
   ensure
     JSONAPI.configuration.top_level_meta_include_record_count = false
   end
@@ -3099,15 +3100,14 @@ class Api::V2::BooksControllerTest < ActionController::TestCase
     $test_user = Person.find(1)
     JSONAPI.configuration.top_level_meta_include_record_count = true
     Api::V2::BookResource.paginator :offset
-    count_queries do
-      get :index, params: {page: {offset: 0, limit: 12}, include: 'book-comments.author'}
+    assert_query_count(4) do
+      assert_cacheable_get :index, params: {page: {offset: 0, limit: 12}, include: 'book-comments.author'}
     end
     assert_response :success
     assert_equal 12, json_response['data'].size
-    assert_equal 131, json_response['included'].size
+    assert_equal 132, json_response['included'].size
     assert_equal 'Book 0', json_response['data'][0]['attributes']['title']
     assert_equal 901, json_response['meta']['record-count']
-    assert_query_count(4)
   ensure
     JSONAPI.configuration.top_level_meta_include_record_count = false
   end
@@ -3116,14 +3116,13 @@ class Api::V2::BooksControllerTest < ActionController::TestCase
     $test_user = Person.find(5)
     Api::V2::BookResource.paginator :offset
     JSONAPI.configuration.top_level_meta_include_record_count = true
-    count_queries do
-      get :index, params: {page: {offset: 50, limit: 12}, filter: {banned: 'true'}}
+    assert_query_count(2) do
+      assert_cacheable_get :index, params: {page: {offset: 50, limit: 12}, filter: {banned: 'true'}}
     end
     assert_response :success
     assert_equal 12, json_response['data'].size
     assert_equal 'Book 651', json_response['data'][0]['attributes']['title']
     assert_equal 99, json_response['meta']['record-count']
-    assert_query_count(2)
   ensure
     JSONAPI.configuration.top_level_meta_include_record_count = false
   end
@@ -3132,14 +3131,13 @@ class Api::V2::BooksControllerTest < ActionController::TestCase
     $test_user = Person.find(5)
     Api::V2::BookResource.paginator :offset
     JSONAPI.configuration.top_level_meta_include_record_count = true
-    count_queries do
-      get :index, params: {page: {offset: 50, limit: 12}, filter: {banned: 'false'}, fields: {books: 'id,title'}}
+    assert_query_count(2) do
+      assert_cacheable_get :index, params: {page: {offset: 50, limit: 12}, filter: {banned: 'false'}, fields: {books: 'id,title'}}
     end
     assert_response :success
     assert_equal 12, json_response['data'].size
     assert_equal 'Book 50', json_response['data'][0]['attributes']['title']
     assert_equal 901, json_response['meta']['record-count']
-    assert_query_count(2)
   ensure
     JSONAPI.configuration.top_level_meta_include_record_count = false
   end
@@ -3148,14 +3146,13 @@ class Api::V2::BooksControllerTest < ActionController::TestCase
     $test_user = Person.find(1)
     Api::V2::BookResource.paginator :offset
     JSONAPI.configuration.top_level_meta_include_record_count = true
-    count_queries do
-      get :index, params: {page: {offset: 590, limit: 20}}
+    assert_query_count(2) do
+      assert_cacheable_get :index, params: {page: {offset: 590, limit: 20}}
     end
     assert_response :success
     assert_equal 20, json_response['data'].size
     assert_equal 'Book 590', json_response['data'][0]['attributes']['title']
     assert_equal 901, json_response['meta']['record-count']
-    assert_query_count(2)
   ensure
     JSONAPI.configuration.top_level_meta_include_record_count = false
   end
@@ -3164,22 +3161,21 @@ class Api::V2::BooksControllerTest < ActionController::TestCase
     $test_user = Person.find(1)
     Api::V2::BookResource.paginator :none
 
-    count_queries do
-      get :index, params: {filter: {id: '0,1,2,3,4'}, include: 'book-comments'}
+    assert_query_count(2) do
+      assert_cacheable_get :index, params: {filter: {id: '0,1,2,3,4'}, include: 'book-comments'}
     end
     assert_response :success
     assert_equal 5, json_response['data'].size
     assert_equal 'Book 0', json_response['data'][0]['attributes']['title']
     assert_equal 130, json_response['included'].size
     assert_equal 26, json_response['data'][0]['relationships']['book-comments']['data'].size
-    assert_query_count(2)
   end
 
   def test_books_included_all_comments_for_admin
     $test_user = Person.find(5)
     Api::V2::BookResource.paginator :none
 
-    get :index, params: {filter: {id: '0,1,2,3,4'}, include: 'book-comments'}
+    assert_cacheable_get :index, params: {filter: {id: '0,1,2,3,4'}, include: 'book-comments'}
     assert_response :success
     assert_equal 5, json_response['data'].size
     assert_equal 'Book 0', json_response['data'][0]['attributes']['title']
@@ -3189,14 +3185,14 @@ class Api::V2::BooksControllerTest < ActionController::TestCase
 
   def test_books_filter_by_book_comment_id_limited_user
     $test_user = Person.find(1)
-    get :index, params: {filter: {book_comments: '0,52' }}
+    assert_cacheable_get :index, params: {filter: {book_comments: '0,52' }}
     assert_response :success
     assert_equal 1, json_response['data'].size
   end
 
   def test_books_filter_by_book_comment_id_admin_user
     $test_user = Person.find(5)
-    get :index, params: {filter: {book_comments: '0,52' }}
+    assert_cacheable_get :index, params: {filter: {book_comments: '0,52' }}
     assert_response :success
     assert_equal 2, json_response['data'].size
   end
@@ -3272,32 +3268,29 @@ class Api::V2::BookCommentsControllerTest < ActionController::TestCase
 
   def test_book_comments_all_for_admin
     $test_user = Person.find(5)
-    count_queries do
-      get :index
+    assert_query_count(1) do
+      assert_cacheable_get :index
     end
     assert_response :success
     assert_equal 255, json_response['data'].size
-    assert_query_count(1)
   end
 
   def test_book_comments_unapproved_context_based
     $test_user = Person.find(5)
-    count_queries do
-      get :index, params: {filter: {approved: 'false'}}
+    assert_query_count(1) do
+      assert_cacheable_get :index, params: {filter: {approved: 'false'}}
     end
     assert_response :success
     assert_equal 125, json_response['data'].size
-    assert_query_count(1)
   end
 
   def test_book_comments_exclude_unapproved_context_based
     $test_user = Person.find(1)
-    count_queries do
-      get :index
+    assert_query_count(1) do
+      assert_cacheable_get :index
     end
     assert_response :success
     assert_equal 130, json_response['data'].size
-    assert_query_count(1)
   end
 end
 
@@ -3309,7 +3302,7 @@ class Api::V4::BooksControllerTest < ActionController::TestCase
   def test_books_offset_pagination_meta
     original_config = JSONAPI.configuration.dup
     Api::V4::BookResource.paginator :offset
-    get :index, params: {page: {offset: 50, limit: 12}}
+    assert_cacheable_get :index, params: {page: {offset: 50, limit: 12}}
     assert_response :success
     assert_equal 12, json_response['data'].size
     assert_equal 'Book 50', json_response['data'][0]['attributes']['title']
@@ -3321,7 +3314,7 @@ class Api::V4::BooksControllerTest < ActionController::TestCase
   def test_books_operation_links
     original_config = JSONAPI.configuration.dup
     Api::V4::BookResource.paginator :offset
-    get :index, params: {page: {offset: 50, limit: 12}}
+    assert_cacheable_get :index, params: {page: {offset: 50, limit: 12}}
     assert_response :success
     assert_equal 12, json_response['data'].size
     assert_equal 'Book 50', json_response['data'][0]['attributes']['title']
@@ -3334,14 +3327,14 @@ end
 
 class CategoriesControllerTest < ActionController::TestCase
   def test_index_default_filter
-    get :index
+    assert_cacheable_get :index
     assert_response :success
     assert json_response['data'].is_a?(Array)
     assert_equal 3, json_response['data'].size
   end
 
   def test_index_default_filter_override
-    get :index, params: { filter: { status: 'inactive' } }
+    assert_cacheable_get :index, params: { filter: { status: 'inactive' } }
     assert_response :success
     assert json_response['data'].is_a?(Array)
     assert_equal 4, json_response['data'].size
@@ -3387,7 +3380,7 @@ end
 
 class Api::V1::MoonsControllerTest < ActionController::TestCase
   def test_get_related_resource
-    get :get_related_resource, params: {crater_id: 'S56D', relationship: 'moon', source: "api/v1/craters"}
+    assert_cacheable_get :get_related_resource, params: {crater_id: 'S56D', relationship: 'moon', source: "api/v1/craters"}
     assert_response :success
     assert_hash_equals({
                          data: {
@@ -3407,7 +3400,7 @@ class Api::V1::MoonsControllerTest < ActionController::TestCase
     original_config = JSONAPI.configuration.dup
     JSONAPI.configuration.top_level_meta_include_record_count = true
     JSONAPI.configuration.json_key_format = :dasherized_key
-    get :get_related_resources, params: {planet_id: '1', relationship: 'moons', source: 'api/v1/planets'}
+    assert_cacheable_get :get_related_resources, params: {planet_id: '1', relationship: 'moons', source: 'api/v1/planets'}
     assert_response :success
     assert_equal 1, json_response['meta']['record-count']
   ensure
@@ -3417,7 +3410,7 @@ end
 
 class Api::V1::CratersControllerTest < ActionController::TestCase
   def test_show_single
-    get :show, params: {id: 'S56D'}
+    assert_cacheable_get :show, params: {id: 'S56D'}
     assert_response :success
     assert json_response['data'].is_a?(Hash)
     assert_equal 'S56D', json_response['data']['attributes']['code']
@@ -3426,7 +3419,7 @@ class Api::V1::CratersControllerTest < ActionController::TestCase
   end
 
   def test_get_related_resources
-    get :get_related_resources, params: {moon_id: '1', relationship: 'craters', source: "api/v1/moons"}
+    assert_cacheable_get :get_related_resources, params: {moon_id: '1', relationship: 'craters', source: "api/v1/moons"}
     assert_response :success
     assert_hash_equals({
                          data: [
@@ -3449,7 +3442,7 @@ class Api::V1::CratersControllerTest < ActionController::TestCase
   end
 
   def test_show_relationship
-    get :show_relationship, params: {crater_id: 'S56D', relationship: 'moon'}
+    assert_cacheable_get :show_relationship, params: {crater_id: 'S56D', relationship: 'moon'}
 
     assert_response :success
     assert_equal "moons", json_response['data']['type']
@@ -3527,7 +3520,7 @@ end
 
 class Api::V7::ClientsControllerTest < ActionController::TestCase
   def test_get_namespaced_model_not_matching_resource_using_model_hint
-    get :index
+    assert_cacheable_get :index
     assert_response :success
     assert_equal 'clients', json_response['data'][0]['type']
   ensure
@@ -3536,7 +3529,7 @@ class Api::V7::ClientsControllerTest < ActionController::TestCase
 
   def test_get_namespaced_model_not_matching_resource_not_using_model_hint
     Api::V7::ClientResource._model_hints.delete('api/v7/customer')
-    get :index
+    assert_cacheable_get :index
     assert_response :success
     assert_equal 'customers', json_response['data'][0]['type']
   ensure
@@ -3546,7 +3539,7 @@ end
 
 class Api::V7::CustomersControllerTest < ActionController::TestCase
   def test_get_namespaced_model_matching_resource
-    get :index
+    assert_cacheable_get :index
     assert_response :success
     assert_equal 'customers', json_response['data'][0]['type']
   end
@@ -3555,7 +3548,7 @@ end
 class Api::V7::CategoriesControllerTest < ActionController::TestCase
   def test_uncaught_error_in_controller_translated_to_internal_server_error
 
-    get :show, params: {id: '1'}
+    assert_cacheable_get :show, params: {id: '1'}
     assert_response 500
     assert_match /Internal Server Error/, json_response['errors'][0]['detail']
   end
@@ -3563,7 +3556,7 @@ class Api::V7::CategoriesControllerTest < ActionController::TestCase
   def test_not_whitelisted_error_in_controller
     original_config = JSONAPI.configuration.dup
     JSONAPI.configuration.exception_class_whitelist = []
-    get :show, params: {id: '1'}
+    assert_cacheable_get :show, params: {id: '1'}
     assert_response 500
     assert_match /Internal Server Error/, json_response['errors'][0]['detail']
   ensure
@@ -3575,7 +3568,7 @@ class Api::V7::CategoriesControllerTest < ActionController::TestCase
     $PostProcessorRaisesErrors = true
     JSONAPI.configuration.exception_class_whitelist = [PostsController::SubSpecialError]
     assert_raises PostsController::SubSpecialError do
-      get :show, params: {id: '1'}
+      assert_cacheable_get :show, params: {id: '1'}
     end
   ensure
     JSONAPI.configuration = original_config

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -3577,13 +3577,15 @@ class Api::V7::CategoriesControllerTest < ActionController::TestCase
 end
 
 class Api::V6::PostsControllerTest < ActionController::TestCase
-  def test_with_sql_fragment
-    get :index, params: {include: 'section'}
+  def test_caching_with_join_from_resource_with_sql_fragment
+    assert_cacheable_get :index, params: {include: 'section'}
     assert_response :success
   end
+end
 
-  def test_caching_with_sql_fragment
-    assert_cacheable_get :index, params: {include: 'section'}
+class Api::V6::SectionsControllerTest < ActionController::TestCase
+  def test_caching_with_join_to_resource_with_sql_fragment
+    assert_cacheable_get :index, params: {include: 'posts'}
     assert_response :success
   end
 end

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -3575,3 +3575,15 @@ class Api::V7::CategoriesControllerTest < ActionController::TestCase
     $PostProcessorRaisesErrors = false
   end
 end
+
+class Api::V6::PostsControllerTest < ActionController::TestCase
+  def test_with_sql_fragment
+    get :index, params: {include: 'section'}
+    assert_response :success
+  end
+
+  def test_caching_with_sql_fragment
+    assert_cacheable_get :index, params: {include: 'section'}
+    assert_response :success
+  end
+end

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -49,6 +49,7 @@ ActiveRecord::Schema.define do
 
   create_table :tags, force: true do |t|
     t.string :name
+    t.timestamps null: false
   end
 
   create_table :sections, force: true do |t|
@@ -83,6 +84,7 @@ ActiveRecord::Schema.define do
     t.integer :employee_id, null: false
     t.decimal :cost, precision: 12, scale: 4, null: false
     t.date :transaction_date
+    t.timestamps null: false
   end
 
   create_table :planets, force: true do |t|
@@ -104,17 +106,20 @@ ActiveRecord::Schema.define do
     t.string  :name
     t.string  :description
     t.integer :planet_id
+    t.timestamps null: false
   end
 
   create_table :craters, id: false, force: true do |t|
     t.string  :code
     t.string  :description
     t.integer :moon_id
+    t.timestamps null: false
   end
 
   create_table :preferences, force: true do |t|
     t.integer :person_id
     t.boolean :advanced_mode, default: false
+    t.timestamps null: false
   end
 
   create_table :facts, force: true do |t|
@@ -128,12 +133,14 @@ ActiveRecord::Schema.define do
     t.time     :bedtime
     t.binary   :photo, limit: 1.kilobyte
     t.boolean  :cool
+    t.timestamps null: false
   end
 
   create_table :books, force: true do |t|
     t.string :title
     t.string :isbn
     t.boolean :banned, default: false
+    t.timestamps null: false
   end
 
   create_table :book_authors, force: true do |t|
@@ -151,6 +158,7 @@ ActiveRecord::Schema.define do
 
   create_table :customers, force: true do |t|
     t.string   :name
+    t.timestamps null: false
   end
 
   create_table :purchase_orders, force: true do |t|
@@ -199,6 +207,7 @@ ActiveRecord::Schema.define do
   create_table :categories, force: true do |t|
     t.string :name
     t.string :status, limit: 10
+    t.timestamps null: false
   end
 
   create_table :pictures, force: true do |t|
@@ -226,27 +235,33 @@ ActiveRecord::Schema.define do
     t.string :drive_layout
     t.string :serial_number
     t.integer :person_id
+    t.timestamps null: false
   end
 
   create_table :makes, force: true do |t|
     t.string :model
+    t.timestamps null: false
   end
 
   # special cases - fields that look like they should be reserved names
   create_table :hrefs, force: true do |t|
     t.string :name
+    t.timestamps null: false
   end
 
   create_table :links, force: true do |t|
     t.string :name
+    t.timestamps null: false
   end
 
   create_table :web_pages, force: true do |t|
     t.string :href
     t.string :link
+    t.timestamps null: false
   end
 
   create_table :questionables, force: true do |t|
+    t.timestamps null: false
   end
   # special cases
 end
@@ -374,7 +389,7 @@ class Planet < ActiveRecord::Base
         return false
       end
       # :nocov:
-   end
+    end
   end
 end
 
@@ -972,7 +987,7 @@ class PostResource < JSONAPI::Resource
   def self.sortable_fields(context)
     super(context) - [:id] + [:"author.name"]
   end
- 
+
   def self.verify_key(key, context = nil)
     super(key)
     raise JSONAPI::Exceptions::RecordNotFound.new(key) unless find_by_key(key, context: context)
@@ -1039,7 +1054,7 @@ class PlanetResource < JSONAPI::Resource
 
   has_many :tags, acts_as_set: true
 
-  def records_for_moons
+  def records_for_moons(opts = {})
     Moon.joins(:craters).select('moons.*, craters.code').distinct
   end
 end
@@ -1079,8 +1094,8 @@ class PreferencesResource < JSONAPI::Resource
 
   has_one :author, :foreign_key_on => :related
 
-  def self.find_by_key(key, options = {})
-    new(Preferences.first, nil)
+  def self.find_records(filters, options = {})
+    Preferences.limit(1)
   end
 end
 
@@ -1290,6 +1305,8 @@ module Api
       attribute :title
       attributes :isbn, :banned
 
+      has_many :authors
+
       has_many :book_comments, relation_name: -> (options = {}) {
         context = options[:context]
         current_user = context ? context[:current_user] : nil
@@ -1408,24 +1425,16 @@ module Api
 
       filter :name
 
-      def self.find_by_key(key, options = {})
-        context = options[:context]
-        records = records(options)
-        records = apply_includes(records, options)
-        model = records.where({_primary_key => key}).first
-        fail JSONAPI::Exceptions::RecordNotFound.new(key) if model.nil?
-        self.new(model, context)
-      end
-
-      def self.find(filters, options = {})
-        resources = []
-
+      def self.find_records(filters, options = {})
+        rel = _model_class
         filters.each do |attr, filter|
-          _model_class.where("\"#{attr}\" LIKE \"%#{filter[0]}%\"").each do |model|
-            resources.push self.new(model, options[:context])
+          if attr.to_s == "id"
+            rel = rel.where(id: filter)
+          else
+            rel = rel.where("\"#{attr}\" LIKE \"%#{filter[0]}%\"")
           end
         end
-        return resources
+        rel
       end
 
       def fetchable_fields

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -54,6 +54,7 @@ ActiveRecord::Schema.define do
 
   create_table :sections, force: true do |t|
     t.string :name
+    t.timestamps null: false
   end
 
   create_table :posts_tags, force: true do |t|
@@ -343,6 +344,7 @@ class Tag < ActiveRecord::Base
 end
 
 class Section < ActiveRecord::Base
+  has_many :posts
 end
 
 class HairCut < ActiveRecord::Base
@@ -756,6 +758,9 @@ module Api
 
   module V6
     class PostsController < JSONAPI::ResourceController
+    end
+
+    class SectionsController < JSONAPI::ResourceController
     end
 
     class CustomersController < JSONAPI::ResourceController
@@ -1464,7 +1469,11 @@ module Api
   module V6
     class PersonResource < PersonResource; end
     class TagResource < TagResource; end
-    class SectionResource < SectionResource; end
+
+    class SectionResource < SectionResource
+      has_many :posts
+    end
+
     class CommentResource < CommentResource; end
 
     class PostResource < PostResource

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -755,6 +755,9 @@ module Api
   end
 
   module V6
+    class PostsController < JSONAPI::ResourceController
+    end
+
     class CustomersController < JSONAPI::ResourceController
     end
 
@@ -1459,6 +1462,18 @@ end
 
 module Api
   module V6
+    class PersonResource < PersonResource; end
+    class TagResource < TagResource; end
+    class SectionResource < SectionResource; end
+    class CommentResource < CommentResource; end
+
+    class PostResource < PostResource
+      # Test caching with SQL fragments
+      def self.records(options = {})
+        super.joins('INNER JOIN people on people.id = author_id')
+      end
+    end
+
     class CustomerResource < JSONAPI::Resource
       attribute :name
 

--- a/test/fixtures/people.yml
+++ b/test/fixtures/people.yml
@@ -29,3 +29,9 @@ e:
   email: lib@xyz.fake
   date_joined: <%= DateTime.parse('2013-11-30 4:20:00 UTC +00:00') %>
   book_admin: true
+
+x:
+  id: 0
+  name: The Shadow
+  email: nobody@nowhere.comment_num
+  date_joined: <%= DateTime.parse('1970-01-01 20:25:00 UTC +00:00') %>

--- a/test/helpers/configuration_helpers.rb
+++ b/test/helpers/configuration_helpers.rb
@@ -1,0 +1,70 @@
+module Helpers
+  module ConfigurationHelpers
+    def with_jsonapi_config(new_config_options)
+      original_config = JSONAPI.configuration.dup # TODO should be a deep dup
+      begin
+        new_config_options.each do |k, v|
+          JSONAPI.configuration.send(:"#{k}=", v)
+        end
+        return yield
+      ensure
+        JSONAPI.configuration = original_config
+      end
+    end
+
+    def with_resource_caching(cache, classes = :all)
+      results = {total: {hits: 0, misses: 0}}
+      new_config_options = {
+        resource_cache: cache,
+        resource_cache_usage_report_function: Proc.new do |name, hits, misses|
+          [name.to_sym, :total].each do |key|
+            results[key] ||= {hits: 0, misses: 0}
+            results[key][:hits] += hits
+            results[key][:misses] += misses
+          end
+        end
+      }
+
+      with_jsonapi_config(new_config_options) do
+        if classes == :all or (classes.is_a?(Hash) && classes.keys == [:except])
+          resource_classes = ObjectSpace.each_object(Class).select do |klass|
+            if klass < JSONAPI::Resource
+              # Not using Resource#_model_class to avoid tripping the warning early, which could
+              # cause ResourceTest#test_nil_model_class to fail.
+              model_class = klass._model_name.to_s.safe_constantize
+              if model_class && model_class.respond_to?(:arel_table)
+                next true
+              end
+            end
+            next false
+          end
+
+          if classes.is_a?(Hash)
+            classes.values.first.each do |excluded|
+              deleted = resource_classes.delete(excluded)
+              raise "Can't find #{excluded} among AR-based Resource classes" if deleted.nil?
+            end
+          end
+
+          classes = resource_classes
+        end
+
+        begin
+          classes.each do |klass|
+            raise "#{klass.name} already caching!" if klass.caching?
+            klass.caching
+            raise "Couldn't enable caching for #{klass.name}" unless klass.caching?
+          end
+
+          yield
+        ensure
+          classes.each do |klass|
+            klass.caching(false)
+          end
+        end
+      end
+
+      return results
+    end
+  end
+end

--- a/test/integration/requests/namespaced_model_test.rb
+++ b/test/integration/requests/namespaced_model_test.rb
@@ -6,8 +6,7 @@ class NamedspacedModelTest < ActionDispatch::IntegrationTest
   end
 
   def test_get_flat_posts
-    get '/flat_posts', headers: { 'Accept' => JSONAPI::MEDIA_TYPE }
-    assert_equal 200, status
+    assert_cacheable_jsonapi_get '/flat_posts'
     assert_equal "flat_posts", json_response["data"].first["type"]
   end
 end

--- a/test/integration/requests/request_test.rb
+++ b/test/integration/requests/request_test.rb
@@ -4,46 +4,42 @@ class RequestTest < ActionDispatch::IntegrationTest
   def setup
     JSONAPI.configuration.json_key_format = :underscored_key
     JSONAPI.configuration.route_format = :underscored_route
+    Api::V2::BookResource.paginator :offset
     $test_user = Person.find(1)
   end
 
   def after_teardown
-    Api::V2::BookResource.paginator :offset
     JSONAPI.configuration.route_format = :underscored_route
   end
 
   def test_get
-    get '/posts', headers: { 'Accept' => JSONAPI::MEDIA_TYPE }
-    assert_jsonapi_response 200
+    assert_cacheable_jsonapi_get '/posts'
+  end
+
+  def test_large_get
+    assert_cacheable_jsonapi_get '/api/v2/books?include=book_comments,book_comments.author'
   end
 
   def test_get_inflected_resource
-    get '/api/v8/numeros_telefone', headers: { 'Accept' => JSONAPI::MEDIA_TYPE }
-    assert_jsonapi_response 200
+    assert_cacheable_jsonapi_get '/api/v8/numeros_telefone'
   end
 
   def test_get_nested_to_one
-    get '/posts/1/author', headers: { 'Accept' => JSONAPI::MEDIA_TYPE }
-    assert_jsonapi_response 200
+    assert_cacheable_jsonapi_get '/posts/1/author'
   end
 
   def test_get_nested_to_many
-    get '/posts/1/comments', headers: { 'Accept' => JSONAPI::MEDIA_TYPE }
-    assert_jsonapi_response 200
+    assert_cacheable_jsonapi_get '/posts/1/comments'
   end
 
   def test_get_nested_to_many_bad_param
-    get '/posts/1/comments?relationship=books', headers: {
-      'Accept' => JSONAPI::MEDIA_TYPE
-    }
-    assert_jsonapi_response 200
+    assert_cacheable_jsonapi_get '/posts/1/comments?relationship=books'
   end
 
   def test_get_underscored_key
     original_config = JSONAPI.configuration.dup
     JSONAPI.configuration.json_key_format = :underscored_key
-    get '/iso_currencies', headers: { 'Accept' => JSONAPI::MEDIA_TYPE }
-    assert_jsonapi_response 200
+    assert_cacheable_jsonapi_get '/iso_currencies'
     assert_equal 3, json_response['data'].size
   ensure
     JSONAPI.configuration = original_config
@@ -52,10 +48,7 @@ class RequestTest < ActionDispatch::IntegrationTest
   def test_get_underscored_key_filtered
     original_config = JSONAPI.configuration.dup
     JSONAPI.configuration.json_key_format = :underscored_key
-    get '/iso_currencies?filter[country_name]=Canada', headers: {
-      'Accept' => JSONAPI::MEDIA_TYPE
-    }
-    assert_jsonapi_response 200
+    assert_cacheable_jsonapi_get '/iso_currencies?filter[country_name]=Canada'
     assert_equal 1, json_response['data'].size
     assert_equal 'Canada', json_response['data'][0]['attributes']['country_name']
   ensure
@@ -65,10 +58,7 @@ class RequestTest < ActionDispatch::IntegrationTest
   def test_get_camelized_key_filtered
     original_config = JSONAPI.configuration.dup
     JSONAPI.configuration.json_key_format = :camelized_key
-    get '/iso_currencies?filter[countryName]=Canada', headers: {
-      'Accept' => JSONAPI::MEDIA_TYPE
-    }
-    assert_jsonapi_response 200
+    assert_cacheable_jsonapi_get '/iso_currencies?filter[countryName]=Canada'
     assert_equal 1, json_response['data'].size
     assert_equal 'Canada', json_response['data'][0]['attributes']['countryName']
   ensure
@@ -78,10 +68,7 @@ class RequestTest < ActionDispatch::IntegrationTest
   def test_get_camelized_route_and_key_filtered
     original_config = JSONAPI.configuration.dup
     JSONAPI.configuration.json_key_format = :camelized_key
-    get '/api/v4/isoCurrencies?filter[countryName]=Canada', headers: {
-      'Accept' => JSONAPI::MEDIA_TYPE
-    }
-    assert_jsonapi_response 200
+    assert_cacheable_jsonapi_get '/api/v4/isoCurrencies?filter[countryName]=Canada'
     assert_equal 1, json_response['data'].size
     assert_equal 'Canada', json_response['data'][0]['attributes']['countryName']
   ensure
@@ -92,10 +79,7 @@ class RequestTest < ActionDispatch::IntegrationTest
     original_config = JSONAPI.configuration.dup
     JSONAPI.configuration.json_key_format = :camelized_key
     JSONAPI.configuration.route_format = :camelized_route
-    get '/api/v4/expenseEntries/1/relationships/isoCurrency', headers: {
-      'Accept' => JSONAPI::MEDIA_TYPE
-    }
-    assert_jsonapi_response 200
+    assert_cacheable_jsonapi_get '/api/v4/expenseEntries/1/relationships/isoCurrency'
     assert_hash_equals({'links' => {
                          'self' => 'http://www.example.com/api/v4/expenseEntries/1/relationships/isoCurrency',
                          'related' => 'http://www.example.com/api/v4/expenseEntries/1/isoCurrency'
@@ -325,12 +309,12 @@ class RequestTest < ActionDispatch::IntegrationTest
   end
 
   def test_index_content_type
-    get '/posts', headers: { 'Accept' => JSONAPI::MEDIA_TYPE }
+    assert_cacheable_jsonapi_get '/posts'
     assert_match JSONAPI::MEDIA_TYPE, headers['Content-Type']
   end
 
   def test_get_content_type
-    get '/posts/3', headers: { 'Accept' => JSONAPI::MEDIA_TYPE }
+    assert_cacheable_jsonapi_get '/posts/3'
     assert_match JSONAPI::MEDIA_TYPE, headers['Content-Type']
   end
 
@@ -421,35 +405,27 @@ class RequestTest < ActionDispatch::IntegrationTest
 
   def test_pagination_none
     Api::V2::BookResource.paginator :none
-    get '/api/v2/books', headers: { 'Accept' => JSONAPI::MEDIA_TYPE }
-    assert_jsonapi_response 200
+    assert_cacheable_jsonapi_get '/api/v2/books'
     assert_equal 901, json_response['data'].size
   end
 
   def test_pagination_offset_style
     Api::V2::BookResource.paginator :offset
-    get '/api/v2/books', headers: { 'Accept' => JSONAPI::MEDIA_TYPE }
-    assert_jsonapi_response 200
+    assert_cacheable_jsonapi_get '/api/v2/books'
     assert_equal JSONAPI.configuration.default_page_size, json_response['data'].size
     assert_equal 'Book 0', json_response['data'][0]['attributes']['title']
   end
 
   def test_pagination_offset_style_offset
     Api::V2::BookResource.paginator :offset
-    get '/api/v2/books?page[offset]=50', headers: {
-      'Accept' => JSONAPI::MEDIA_TYPE
-    }
-    assert_jsonapi_response 200
+    assert_cacheable_jsonapi_get '/api/v2/books?page[offset]=50'
     assert_equal JSONAPI.configuration.default_page_size, json_response['data'].size
     assert_equal 'Book 50', json_response['data'][0]['attributes']['title']
   end
 
   def test_pagination_offset_style_offset_limit
     Api::V2::BookResource.paginator :offset
-    get '/api/v2/books?page[offset]=50&page[limit]=20', headers: {
-      'Accept' => JSONAPI::MEDIA_TYPE
-    }
-    assert_jsonapi_response 200
+    assert_cacheable_jsonapi_get '/api/v2/books?page[offset]=50&page[limit]=20'
     assert_equal 20, json_response['data'].size
     assert_equal 'Book 50', json_response['data'][0]['attributes']['title']
   end
@@ -464,10 +440,7 @@ class RequestTest < ActionDispatch::IntegrationTest
 
   def test_pagination_related_resources_link
     Api::V2::BookResource.paginator :offset
-    get '/api/v2/books?page[limit]=2', headers: {
-      'Accept' => JSONAPI::MEDIA_TYPE
-    }
-    assert_jsonapi_response 200
+    assert_cacheable_jsonapi_get '/api/v2/books?page[limit]=2'
     assert_equal 2, json_response['data'].size
     assert_equal 'http://www.example.com/api/v2/books/1/book_comments',
                  json_response['data'][1]['relationships']['book_comments']['links']['related']
@@ -476,10 +449,7 @@ class RequestTest < ActionDispatch::IntegrationTest
   def test_pagination_related_resources_data
     Api::V2::BookResource.paginator :offset
     Api::V2::BookCommentResource.paginator :offset
-    get '/api/v2/books/1/book_comments?page[limit]=10', headers: {
-      'Accept' => JSONAPI::MEDIA_TYPE
-    }
-    assert_jsonapi_response 200
+    assert_cacheable_jsonapi_get '/api/v2/books/1/book_comments?page[limit]=10'
     assert_equal 10, json_response['data'].size
     assert_equal 'This is comment 18 on book 1.', json_response['data'][9]['attributes']['body']
   end
@@ -487,9 +457,7 @@ class RequestTest < ActionDispatch::IntegrationTest
   def test_pagination_related_resources_links
     Api::V2::BookResource.paginator :offset
     Api::V2::BookCommentResource.paginator :offset
-    get '/api/v2/books/1/book_comments?page[limit]=10', headers: {
-      'Accept' => JSONAPI::MEDIA_TYPE
-    }
+    assert_cacheable_jsonapi_get '/api/v2/books/1/book_comments?page[limit]=10'
     assert_equal 'http://www.example.com/api/v2/books/1/book_comments?page%5Blimit%5D=10&page%5Boffset%5D=0', json_response['links']['first']
     assert_equal 'http://www.example.com/api/v2/books/1/book_comments?page%5Blimit%5D=10&page%5Boffset%5D=10', json_response['links']['next']
     assert_equal 'http://www.example.com/api/v2/books/1/book_comments?page%5Blimit%5D=10&page%5Boffset%5D=16', json_response['links']['last']
@@ -499,9 +467,7 @@ class RequestTest < ActionDispatch::IntegrationTest
     Api::V2::BookResource.paginator :offset
     Api::V2::BookCommentResource.paginator :offset
     JSONAPI.configuration.top_level_meta_include_record_count = true
-    get '/api/v2/books/1/book_comments?page[limit]=10', headers: {
-      'Accept' => JSONAPI::MEDIA_TYPE
-    }
+    assert_cacheable_jsonapi_get '/api/v2/books/1/book_comments?page[limit]=10'
     assert_equal 26, json_response['meta']['record_count']
     assert_equal 'http://www.example.com/api/v2/books/1/book_comments?page%5Blimit%5D=10&page%5Boffset%5D=0', json_response['links']['first']
     assert_equal 'http://www.example.com/api/v2/books/1/book_comments?page%5Blimit%5D=10&page%5Boffset%5D=10', json_response['links']['next']
@@ -513,13 +479,9 @@ class RequestTest < ActionDispatch::IntegrationTest
   def test_filter_related_resources
     Api::V2::BookCommentResource.paginator :offset
     JSONAPI.configuration.top_level_meta_include_record_count = true
-    get '/api/v2/books/1/book_comments?filter[book]=2', headers: {
-      'Accept' => JSONAPI::MEDIA_TYPE
-    }
+    assert_cacheable_jsonapi_get '/api/v2/books/1/book_comments?filter[book]=2'
     assert_equal 0, json_response['meta']['record_count']
-    get '/api/v2/books/1/book_comments?filter[book]=1&page[limit]=20', headers: {
-      'Accept' => JSONAPI::MEDIA_TYPE
-    }
+    assert_cacheable_jsonapi_get '/api/v2/books/1/book_comments?filter[book]=1&page[limit]=20'
     assert_equal 26, json_response['meta']['record_count']
   ensure
     JSONAPI.configuration.top_level_meta_include_record_count = false
@@ -548,10 +510,7 @@ class RequestTest < ActionDispatch::IntegrationTest
   def test_pagination_related_resources_without_related
     Api::V2::BookResource.paginator :offset
     Api::V2::BookCommentResource.paginator :offset
-    get '/api/v2/books/10/book_comments', headers: {
-      'Accept' => JSONAPI::MEDIA_TYPE
-    }
-    assert_jsonapi_response 200
+    assert_cacheable_jsonapi_get '/api/v2/books/10/book_comments'
     assert_nil json_response['links']['next']
     assert_equal 'http://www.example.com/api/v2/books/10/book_comments?page%5Blimit%5D=10&page%5Boffset%5D=0', json_response['links']['first']
     assert_equal 'http://www.example.com/api/v2/books/10/book_comments?page%5Blimit%5D=10&page%5Boffset%5D=0', json_response['links']['last']
@@ -562,10 +521,7 @@ class RequestTest < ActionDispatch::IntegrationTest
     JSONAPI.configuration.default_paginator = :paged
     JSONAPI.configuration.top_level_meta_include_record_count = true
 
-    get '/api/v2/books/1/aliased_comments', headers: {
-      'Accept' => JSONAPI::MEDIA_TYPE
-    }
-    assert_jsonapi_response 200
+    assert_cacheable_jsonapi_get '/api/v2/books/1/aliased_comments'
     assert_equal 26, json_response['meta']['record_count']
   ensure
     JSONAPI.configuration = original_config
@@ -574,10 +530,8 @@ class RequestTest < ActionDispatch::IntegrationTest
   def test_pagination_related_resources_data_includes
     Api::V2::BookResource.paginator :offset
     Api::V2::BookCommentResource.paginator :offset
-    get '/api/v2/books/1/book_comments?page[limit]=10&include=author,book', headers: {
-      'Accept' => JSONAPI::MEDIA_TYPE
-    }
-    assert_jsonapi_response 200
+    assert_cacheable_jsonapi_get '/api/v2/books/1/book_comments?page[limit]=10&include=author,book'
+    assert_equal "1", json_response['data'].first['relationships']['book']['data']['id']
     assert_equal 10, json_response['data'].size
     assert_equal 'This is comment 18 on book 1.', json_response['data'][9]['attributes']['body']
   end
@@ -585,10 +539,7 @@ class RequestTest < ActionDispatch::IntegrationTest
   def test_pagination_empty_results
     Api::V2::BookResource.paginator :offset
     Api::V2::BookCommentResource.paginator :offset
-    get '/api/v2/books?filter[id]=2000&page[limit]=10', headers: {
-      'Accept' => JSONAPI::MEDIA_TYPE
-    }
-    assert_jsonapi_response 200
+    assert_cacheable_jsonapi_get '/api/v2/books?filter[id]=2000&page[limit]=10'
     assert_equal 0, json_response['data'].size
     assert_nil json_response['links']['next']
     assert_equal 'http://www.example.com/api/v2/books?filter%5Bid%5D=2000&page%5Blimit%5D=10&page%5Boffset%5D=0', json_response['links']['first']
@@ -598,32 +549,25 @@ class RequestTest < ActionDispatch::IntegrationTest
   # def test_pagination_related_resources_data_includes
   #   Api::V2::BookResource.paginator :none
   #   Api::V2::BookCommentResource.paginator :none
-  #   get '/api/v2/books?filter[]'
-  #   assert_jsonapi_response 200
+  #   assert_cacheable_jsonapi_get '/api/v2/books?filter[]'
   #   assert_equal 10, json_response['data'].size
   #   assert_equal 'This is comment 18 on book 1.', json_response['data'][9]['attributes']['body']
   # end
 
 
   def test_flow_self
-    get '/posts', headers: { 'Accept' => JSONAPI::MEDIA_TYPE }
-    assert_jsonapi_response 200
+    assert_cacheable_jsonapi_get '/posts'
     post_1 = json_response['data'][0]
 
-    get post_1['links']['self'], headers: { 'Accept' => JSONAPI::MEDIA_TYPE }
-    assert_jsonapi_response 200
+    assert_cacheable_jsonapi_get post_1['links']['self']
     assert_hash_equals post_1, json_response['data']
   end
 
   def test_flow_link_to_one_self_link
-    get '/posts', headers: { 'Accept' => JSONAPI::MEDIA_TYPE }
-    assert_jsonapi_response 200
+    assert_cacheable_jsonapi_get '/posts'
     post_1 = json_response['data'][0]
 
-    get post_1['relationships']['author']['links']['self'], headers: {
-      'Accept' => JSONAPI::MEDIA_TYPE
-    }
-    assert_jsonapi_response 200
+    assert_cacheable_jsonapi_get post_1['relationships']['author']['links']['self']
     assert_hash_equals(json_response, {
                                       'links' => {
                                         'self' => 'http://www.example.com/posts/1/relationships/author',
@@ -634,14 +578,10 @@ class RequestTest < ActionDispatch::IntegrationTest
   end
 
   def test_flow_link_to_many_self_link
-    get '/posts', headers: { 'Accept' => JSONAPI::MEDIA_TYPE }
-    assert_jsonapi_response 200
+    assert_cacheable_jsonapi_get '/posts'
     post_1 = json_response['data'][0]
 
-    get post_1['relationships']['tags']['links']['self'], headers: {
-      'Accept' => JSONAPI::MEDIA_TYPE
-    }
-    assert_jsonapi_response 200
+    assert_cacheable_jsonapi_get post_1['relationships']['tags']['links']['self']
     assert_hash_equals(json_response,
                        {
                          'links' => {
@@ -657,8 +597,7 @@ class RequestTest < ActionDispatch::IntegrationTest
   end
 
   def test_flow_link_to_many_self_link_put
-    get '/posts', headers: { 'Accept' => JSONAPI::MEDIA_TYPE }
-    assert_jsonapi_response 200
+    assert_cacheable_jsonapi_get '/posts'
     post_1 = json_response['data'][4]
 
     post post_1['relationships']['tags']['links']['self'], params:
@@ -670,10 +609,7 @@ class RequestTest < ActionDispatch::IntegrationTest
 
     assert_equal 204, status
 
-    get post_1['relationships']['tags']['links']['self'], headers: {
-      'Accept' => JSONAPI::MEDIA_TYPE
-    }
-    assert_jsonapi_response 200
+    assert_cacheable_jsonapi_get post_1['relationships']['tags']['links']['self']
     assert_hash_equals(json_response,
                        {
                          'links' => {
@@ -690,13 +626,11 @@ class RequestTest < ActionDispatch::IntegrationTest
     original_config = JSONAPI.configuration.dup
     JSONAPI.configuration.route_format = :dasherized_route
     JSONAPI.configuration.json_key_format = :dasherized_key
-    get '/api/v6/purchase-orders', headers: { 'Accept' => JSONAPI::MEDIA_TYPE }
-    assert_jsonapi_response 200
+    assert_cacheable_jsonapi_get '/api/v6/purchase-orders'
     po_1 = json_response['data'][0]
     assert_equal 'purchase-orders', json_response['data'][0]['type']
 
-    get po_1['links']['self'], headers: { 'Accept' => JSONAPI::MEDIA_TYPE }
-    assert_jsonapi_response 200
+    assert_cacheable_jsonapi_get po_1['links']['self']
     assert_hash_equals po_1, json_response['data']
   ensure
     JSONAPI.configuration = original_config
@@ -706,14 +640,12 @@ class RequestTest < ActionDispatch::IntegrationTest
     original_config = JSONAPI.configuration.dup
     JSONAPI.configuration.route_format = :underscored_route
     JSONAPI.configuration.json_key_format = :dasherized_key
-    get '/api/v7/purchase_orders', headers: { 'Accept' => JSONAPI::MEDIA_TYPE }
-    assert_jsonapi_response 200
+    assert_cacheable_jsonapi_get '/api/v7/purchase_orders'
     assert_equal 'purchase-orders', json_response['data'][0]['type']
 
     po_1 = json_response['data'][0]
 
-    get po_1['links']['self'], headers: { 'Accept' => JSONAPI::MEDIA_TYPE }
-    assert_jsonapi_response 200
+    assert_cacheable_jsonapi_get po_1['links']['self']
     assert_hash_equals po_1, json_response['data']
   ensure
     JSONAPI.configuration = original_config
@@ -723,14 +655,12 @@ class RequestTest < ActionDispatch::IntegrationTest
     original_config = JSONAPI.configuration.dup
     JSONAPI.configuration.route_format = :underscored_route
     JSONAPI.configuration.json_key_format = :underscored_key
-    get '/api/v7/purchase_orders', headers: { 'Accept' => JSONAPI::MEDIA_TYPE }
-    assert_jsonapi_response 200
+    assert_cacheable_jsonapi_get '/api/v7/purchase_orders'
     assert_equal 'purchase_orders', json_response['data'][0]['type']
 
     po_1 = json_response['data'][0]
 
-    get po_1['links']['self'], headers: { 'Accept' => JSONAPI::MEDIA_TYPE }
-    assert_jsonapi_response 200
+    assert_cacheable_jsonapi_get po_1['links']['self']
     assert_hash_equals po_1, json_response['data']
   ensure
     JSONAPI.configuration = original_config
@@ -1061,10 +991,7 @@ class RequestTest < ActionDispatch::IntegrationTest
   end
 
   def test_include_parameter_allowed
-    get '/api/v2/books/1/book_comments?include=author', headers: {
-      'Accept' => JSONAPI::MEDIA_TYPE
-    }
-    assert_jsonapi_response 200
+    assert_cacheable_jsonapi_get '/api/v2/books/1/book_comments?include=author'
   end
 
   def test_include_parameter_not_allowed
@@ -1096,15 +1023,13 @@ class RequestTest < ActionDispatch::IntegrationTest
   end
 
   def test_getting_different_resources_when_sti
-    get '/vehicles', headers: { 'Accept' => JSONAPI::MEDIA_TYPE }
-    assert_jsonapi_response 200
+    assert_cacheable_jsonapi_get '/vehicles'
     types = json_response['data'].map{|r| r['type']}.sort
     assert_array_equals ['boats', 'cars'], types
   end
 
   def test_getting_resource_with_correct_type_when_sti
-    get '/vehicles/1', headers: { 'Accept' => JSONAPI::MEDIA_TYPE }
-    assert_jsonapi_response 200
+    assert_cacheable_jsonapi_get '/vehicles/1'
     assert_equal 'cars', json_response['data']['type']
   end
 end

--- a/test/integration/sti_fields_test.rb
+++ b/test/integration/sti_fields_test.rb
@@ -2,9 +2,10 @@ require File.expand_path("../../test_helper", __FILE__)
 
 class StiFieldsTest < ActionDispatch::IntegrationTest
   def test_index_fields_when_resource_does_not_match_relationship
-    get "/posts", params: { filter: { id: "1,2" },
-                  include: "author",
-                  fields: { posts: "author", people: "email" } },
+    get "/posts", params: {
+                    filter: { id: "1,2" },
+                    include: "author",
+                    fields: { posts: "author", people: "email" } },
                   headers: { 'Accept' => JSONAPI::MEDIA_TYPE }
     assert_response :success
     assert_equal 2, json_response["data"].size

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -322,6 +322,7 @@ TestApp.routes.draw do
     JSONAPI.configuration.route_format = :dasherized_route
     namespace :v6 do
       jsonapi_resources :posts
+      jsonapi_resources :sections
       jsonapi_resources :customers
       jsonapi_resources :purchase_orders
       jsonapi_resources :line_items

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,6 +27,7 @@ require 'pry'
 require File.expand_path('../helpers/value_matchers', __FILE__)
 require File.expand_path('../helpers/assertions', __FILE__)
 require File.expand_path('../helpers/functional_helpers', __FILE__)
+require File.expand_path('../helpers/configuration_helpers', __FILE__)
 
 Rails.env = 'test'
 
@@ -52,9 +53,6 @@ class TestApp < Rails::Application
   config.active_record.schema_format = :none
   config.active_support.test_order = :random
 
-  # Turn off millisecond precision to maintain Rails 4.0 and 4.1 compatibility in test results
-  ActiveSupport::JSON::Encoding.time_precision = 0 if Rails::VERSION::MAJOR >= 4 && Rails::VERSION::MINOR >= 1
-
   if Rails::VERSION::MAJOR >= 5
     config.active_support.halt_callback_chains_on_return_false = false
     config.active_record.time_zone_aware_types = [:time, :datetime]
@@ -64,21 +62,6 @@ end
 module MyEngine
   class Engine < ::Rails::Engine
     isolate_namespace MyEngine
-  end
-end
-
-# Patch RAILS 4.0 to not use millisecond precision
-if Rails::VERSION::MAJOR >= 4 && Rails::VERSION::MINOR < 1
-  module ActiveSupport
-    class TimeWithZone
-      def as_json(options = nil)
-        if ActiveSupport::JSON::Encoding.use_standard_json_time_format
-          xmlschema
-        else
-          %(#{time.strftime("%Y/%m/%d %H:%M:%S")} #{formatted_offset(false)})
-        end
-      end
-    end
   end
 end
 
@@ -104,7 +87,7 @@ if Rails::VERSION::MAJOR < 5
       if args[2] && args[2][:params]
         args[2] = args[2][:params]
       end
-      super *args
+      super
     end
   end
   class ActionController::TestCase
@@ -197,24 +180,14 @@ if Rails::VERSION::MAJOR >= 5
   end
 end
 
-def count_queries(&block)
-  @query_count = 0
+def assert_query_count(expected, msg = nil, &block)
   @queries = []
-  ActiveSupport::Notifications.subscribe('sql.active_record') do |name, started, finished, unique_id, payload|
-    @query_count = @query_count + 1
-    @queries.push payload[:sql]
-  end
-  yield block
-  ActiveSupport::Notifications.unsubscribe('sql.active_record')
-  @query_count
-end
+  callback = lambda {|_, _, _, _, payload| @queries.push payload[:sql] }
+  ActiveSupport::Notifications.subscribed(callback, 'sql.active_record', &block)
 
-def assert_query_count(expected, msg = nil)
-  msg = message(msg) {
-    "Expected #{expected} queries, ran #{@query_count} queries"
-  }
-  show_queries unless expected == @query_count
-  assert expected == @query_count, msg
+  show_queries unless expected == @queries.size
+  assert expected == @queries.size, "Expected #{expected} queries, ran #{@queries.size} queries"
+  @queries = nil
 end
 
 def show_queries
@@ -416,6 +389,7 @@ class Minitest::Test
   include Helpers::Assertions
   include Helpers::ValueMatchers
   include Helpers::FunctionalHelpers
+  include Helpers::ConfigurationHelpers
   include ActiveRecord::TestFixtures
 
   def run_in_transaction?
@@ -438,9 +412,160 @@ class ActionDispatch::IntegrationTest
   self.fixture_path = "#{Rails.root}/fixtures"
   fixtures :all
 
-  def assert_jsonapi_response(expected_status)
+  def assert_jsonapi_response(expected_status, msg = nil)
     assert_equal JSONAPI::MEDIA_TYPE, response.content_type
-    assert_equal expected_status, status
+    if status != expected_status && status >= 400
+      pp json_response rescue nil
+    end
+    assert_equal expected_status, status, msg
+  end
+
+  def assert_jsonapi_get(url, msg = "GET response must be 200")
+    get url, headers: { 'Accept' => JSONAPI::MEDIA_TYPE }
+    assert_jsonapi_response 200, msg
+  end
+
+  # Perform a GET request, make sure it returns 200, then try it again with caching enabled
+  # to make sure that doesn't affect the output.
+  def assert_cacheable_jsonapi_get(url, cached_classes = :all)
+    assert_nil JSONAPI.configuration.resource_cache
+
+    assert_jsonapi_get url
+    non_caching_response = json_response.dup
+
+    cache = ActiveSupport::Cache::MemoryStore.new
+
+    warmup = with_resource_caching(cache, cached_classes) do
+      assert_jsonapi_get url, "Cache warmup GET response must be 200"
+    end
+
+    assert_equal(
+      non_caching_response.pretty_inspect,
+      json_response.pretty_inspect,
+      "Cache warmup response must match normal response"
+    )
+
+    cached = with_resource_caching(cache, cached_classes) do
+      assert_jsonapi_get url, "Cached GET response must be 200"
+    end
+
+    assert_equal(
+      non_caching_response.pretty_inspect,
+      json_response.pretty_inspect,
+      "Cached response must match normal response"
+    )
+    assert_equal 0, cached[:total][:misses], "Cached response must not cause any cache misses"
+    assert_equal warmup[:total][:misses], cached[:total][:hits], "Cached response must use cache"
+  end
+end
+
+class ActionController::TestCase
+  def assert_cacheable_get(action, *args)
+    assert_nil JSONAPI.configuration.resource_cache
+
+    normal_queries = []
+    normal_query_callback = lambda {|_, _, _, _, payload| normal_queries.push payload[:sql] }
+    ActiveSupport::Notifications.subscribed(normal_query_callback, 'sql.active_record') do
+      get action, *args
+    end
+    non_caching_response = json_response_sans_backtraces
+    non_caching_status = response.status
+
+    # Don't let all the cache-testing requests mess with assert_query_count
+    orig_queries = @queries.try(:dup)
+    orig_request_headers = @request.headers.dup
+
+    ar_resource_klass = nil
+    modes = {none: [], all: :all}
+    if @controller.class.included_modules.include?(JSONAPI::ActsAsResourceController)
+      ar_resource_klass = @controller.send(:resource_klass)
+      if ar_resource_klass._model_class.respond_to?(:arel_table)
+        modes[:root_only] = [ar_resource_klass]
+        modes[:all_but_root] = {except: [ar_resource_klass]}
+      else
+        ar_resource_klass = nil
+      end
+    end
+
+    modes.each do |mode, cached_resources|
+      cache = ActiveSupport::Cache::MemoryStore.new
+      cache_activity = {}
+
+      [:warmup, :lookup].each do |phase|
+        begin
+          cache_queries = []
+          cache_query_callback = lambda {|_, _, _, _, payload| cache_queries.push payload[:sql] }
+          cache_activity[phase] = with_resource_caching(cache, cached_resources) do
+            ActiveSupport::Notifications.subscribed(cache_query_callback, 'sql.active_record') do
+              @controller = nil
+              setup_controller_request_and_response
+              @request.headers.merge!(orig_request_headers.dup)
+              get action, *args
+            end
+          end
+        rescue Exception
+          puts "Exception raised during cache (mode: #{mode}) #{phase}"
+          raise
+        end
+
+        if response.status != non_caching_status
+          pp json_response rescue nil
+        end
+        assert_equal(
+          non_caching_status,
+          response.status,
+          "Cache (mode: #{mode}) #{phase} response status must match normal response"
+        )
+        assert_equal(
+          non_caching_response.pretty_inspect,
+          json_response_sans_backtraces.pretty_inspect,
+          "Cache (mode: #{mode}) #{phase} response body must match normal response"
+        )
+        assert_operator(
+          cache_queries.size,
+          :<=,
+          normal_queries.size*2, # Allow up to double the number of queries as the uncached action
+          "Cache (mode: #{mode}) #{phase} action made too many queries:\n#{cache_queries.pretty_inspect}"
+        )
+      end
+
+      if mode == :all
+        # TODO Should also be caching :show_related_resource (non-plural) action
+        if [:index, :show, :show_related_resources].include?(action)
+          if ar_resource_klass && response.status == 200 && json_response["data"].try(:size) > 0
+            assert_operator(
+              cache_activity[:warmup][:total][:misses],
+              :>,
+              0,
+              "Cache (mode: #{mode}) warmup response with non-empty data must cause cache misses"
+            )
+          end
+        end
+
+        assert_equal 0, cache_activity[:lookup][:total][:misses],
+                     "Cache (mode: #{mode}) lookup response must not cause any cache misses"
+        assert_operator(
+          cache_activity[:lookup][:total][:hits],
+          :>=,
+          cache_activity[:warmup][:total][:misses],
+         "Cache (mode: #{mode}) lookup response must use cache entries created by warmup"
+        )
+      end
+    end
+
+    @queries = orig_queries
+  end
+
+  private
+
+  def json_response_sans_backtraces
+    return nil if response.body.to_s.strip.empty?
+
+    r = json_response.dup
+    (r["errors"] || []).each do |err|
+      err["meta"].delete("backtrace") if err.has_key?("meta")
+    end
+    return r
   end
 end
 
@@ -450,11 +575,12 @@ class IntegrationBenchmark < ActionDispatch::IntegrationTest
   end
 
   def self.run_one_method(klass, method_name, reporter)
-    Benchmark.bm(method_name.length) do |job|
+    Benchmark.bmbm(method_name.length) do |job|
       job.report(method_name) do
         super(klass, method_name, reporter)
       end
     end
+    puts
   end
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -321,6 +321,7 @@ TestApp.routes.draw do
 
     JSONAPI.configuration.route_format = :dasherized_route
     namespace :v6 do
+      jsonapi_resources :posts
       jsonapi_resources :customers
       jsonapi_resources :purchase_orders
       jsonapi_resources :line_items

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -181,7 +181,7 @@ class ResourceTest < ActiveSupport::TestCase
   end
 
   def test_nil_abstract_model_class
-    assert_output nil, '' do
+    assert_silent do
       assert_nil NoMatchAbstractResource._model_class
     end
   end

--- a/test/unit/serializer/response_document_test.rb
+++ b/test/unit/serializer/response_document_test.rb
@@ -11,6 +11,7 @@ class ResponseDocumentTest < ActionDispatch::IntegrationTest
   def create_response_document(operation_results, resource_klass)
     JSONAPI::ResponseDocument.new(
       operation_results,
+      JSONAPI::ResourceSerializer.new(resource_klass),
       {
         primary_resource_klass: resource_klass
       }

--- a/test/unit/serializer/serializer_test.rb
+++ b/test/unit/serializer/serializer_test.rb
@@ -536,7 +536,7 @@ class SerializerTest < ActionDispatch::IntegrationTest
     serialized_data = JSONAPI::ResourceSerializer.new(
       ParentApi::PostResource,
       include: ['parent_post'],
-      base_url: 'http://example.com').serialize_to_hash(ordered_posts.map {|p| ParentApi::PostResource.new(p, nil)} 
+      base_url: 'http://example.com').serialize_to_hash(ordered_posts.map {|p| ParentApi::PostResource.new(p, nil)}
     )[:data]
 
     assert_equal(3, serialized_data.length)
@@ -545,7 +545,7 @@ class SerializerTest < ActionDispatch::IntegrationTest
     assert_equal("3", serialized_data[2]["id"])
   end
 
- 
+
   def test_serializer_different_foreign_key
     serialized = JSONAPI::ResourceSerializer.new(
       PersonResource,
@@ -1435,7 +1435,7 @@ class SerializerTest < ActionDispatch::IntegrationTest
           id: '1',
           attributes: {
             transactionDate: '04/15/2014',
-            cost: 12.05
+            cost: '12.05'
           },
           links: {
             self: '/expenseEntries/1'
@@ -1680,10 +1680,10 @@ class SerializerTest < ActionDispatch::IntegrationTest
             spouse_name: 'Jane Author',
             bio: 'First man to run across Antartica.',
             quality_rating: 23.89/45.6,
-            salary: BigDecimal('47000.56', 30),
-            date_time_joined: DateTime.parse('2013-08-07 20:25:00 UTC +00:00'),
-            birthday: Date.parse('1965-06-30'),
-            bedtime: Time.parse('2000-01-01 20:00:00 UTC +00:00'), #DB seems to set the date to 2001-01-01 for time types
+            salary: BigDecimal('47000.56', 30).as_json,
+            date_time_joined: DateTime.parse('2013-08-07 20:25:00 UTC +00:00').in_time_zone('UTC').as_json,
+            birthday: Date.parse('1965-06-30').as_json,
+            bedtime: Time.parse('2000-01-01 20:00:00 UTC +00:00').as_json, #DB seems to set the date to 2000-01-01 for time types
             photo: "abc",
             cool: false
           },
@@ -2143,7 +2143,7 @@ class SerializerTest < ActionDispatch::IntegrationTest
             title: "New post",
             body: "A body!!!",
             subject: "New post",
-            createdAt: post_created_at
+            createdAt: post_created_at.as_json
           },
         links: {
           self: "http://example.com/customLinkWithLambdas/1",
@@ -2178,7 +2178,7 @@ class SerializerTest < ActionDispatch::IntegrationTest
   def test_includes_two_relationships_with_same_foreign_key
     serialized_resource = JSONAPI::ResourceSerializer
       .new(PersonWithEvenAndOddPostsResource, include: ['even_posts','odd_posts'])
-      .serialize_to_hash(PersonWithEvenAndOddPostsResource.new(Person.first, nil))
+      .serialize_to_hash(PersonWithEvenAndOddPostsResource.new(Person.find(1), nil))
 
     assert_hash_equals(
       {
@@ -2338,6 +2338,62 @@ class SerializerTest < ActionDispatch::IntegrationTest
       },
       serialized_resource
     )
+  end
+
+  def test_config_keys_stable
+    (serializer_a, serializer_b) = 2.times.map do
+      JSONAPI::ResourceSerializer.new(
+        PostResource,
+        include: ['comments', 'author', 'comments.tags', 'author.posts'],
+        fields: {
+          people: [:email, :comments],
+          posts: [:title],
+          tags: [:name],
+          comments: [:body, :post]
+        }
+      )
+    end
+
+    assert_equal serializer_a.config_key(PostResource), serializer_b.config_key(PostResource)
+  end
+
+  def test_config_keys_vary_with_relevant_config_changes
+    serializer_a = JSONAPI::ResourceSerializer.new(
+      PostResource,
+      fields: { posts: [:title] }
+    )
+    serializer_b = JSONAPI::ResourceSerializer.new(
+      PostResource,
+      fields: { posts: [:title, :body] }
+    )
+
+    assert_not_equal serializer_a.config_key(PostResource), serializer_b.config_key(PostResource)
+  end
+
+  def test_config_keys_stable_with_irrelevant_config_changes
+    serializer_a = JSONAPI::ResourceSerializer.new(
+      PostResource,
+      fields: { posts: [:title, :body], people: [:name, :email] }
+    )
+    serializer_b = JSONAPI::ResourceSerializer.new(
+      PostResource,
+      fields: { posts: [:title, :body], people: [:name] }
+    )
+
+    assert_equal serializer_a.config_key(PostResource), serializer_b.config_key(PostResource)
+  end
+
+  def test_config_keys_stable_with_different_primary_resource
+    serializer_a = JSONAPI::ResourceSerializer.new(
+      PostResource,
+      fields: { posts: [:title, :body], people: [:name, :email] }
+    )
+    serializer_b = JSONAPI::ResourceSerializer.new(
+      PersonResource,
+      fields: { posts: [:title, :body], people: [:name, :email] }
+    )
+
+    assert_equal serializer_a.config_key(PostResource), serializer_b.config_key(PostResource)
   end
 
 end


### PR DESCRIPTION
This PR is a **request for review**, it works well but I don't think it's clean or well-tested enough to be merged just yet.

I've written a fragment caching feature for jsonapi-resources, which saves individual serialized resources to a cache and, on future requests for the same resource with the same serialization settings, can pull the serialized data back out from the cache without instantiating ActiveRecord or Resource, and (except for the 'relationships' sub-hash) without even re-generating the JSON strings. This provides substantial speed benefits:

```
                                         user     system      total        real
bench_large_index_request_uncached .  4.180000   0.020000   4.200000 (  4.200144)
                                        user     system      total        real
bench_large_index_request_caching .  1.280000   0.020000   1.300000 (  1.302931)
```

Caching is enabled on a Resource-by-Resource basis, because some Resources may (for whatever reason) be difficult to keep properly synced with the cache via changes to `updated_at`.

Various implications:
- I switched from using ActiveSupport's JSON to using the JSON gem directly. This adds a 20% or so speed increase to normal operations without caching, and also provides the benefit of allowing JR to cache and use pre-generated JSON substrings (class `JSONAPI::CompiledJson`) within larger JSON objects. There were a number of places where JR was implicitly relying on ActiveSupport's `as_json` behavior, which now must be handled explicitly in ValueFormatter.
- OperationsProcessor now accepts an `options` hash, which is used for now only to tell it about caching settings.
- ResourceSerializer now has a `config_key` method, which must return a different value if serialization settings are different. This is included in cache keys, which means that different representations of a resource are cached separately. If any additional settings are added to ResourceSerializer in the future, they must also be included in the `config_key` method!
- Options for filtering, sorting, and pagination can now be passed to the associated records method generated for relationships (e.g. `records_for_comments`).
- When caching is enabled, it is not safe to override instance-level association methods on Resource classes, because these methods are not called when recovering associations to or through cached resources. However, using a lambda for the association name is still OK.

I'm currently testing the caching behavior with a test helper method called `assert_jsonapi_cacheable_get`, which is used in all request tests that previously just called `get` and expected 200s back. This method issues the get request normally once, then issues it again with caching enabled to make sure that the caching system didn't affect the response, and then issues the request a third time and asserts that the response is still the same and that the cache was hit.

The request tests are a pretty good measure of the caching system, but I also want to do a similar thing for controller tests before I'm confident I've covered the edge cases. Additionally, I need to add tests on when caching is enabled on only a subset of Resource classes.
