### PR TITLE
Extract Resource#find's resource transformation

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -636,6 +636,10 @@ module JSONAPI
 
         records = apply_pagination(records, options[:paginator], order_options)
 
+        resources_for(records, context)
+      end
+
+      def resources_for(records, context)
         resources = []
         resource_classes = {}
         records.each do |model|

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -611,4 +611,9 @@ LEFT JOIN people AS author_sorting ON author_sorting.id = posts.author_id", resu
     end
     assert_equal(err.error_messages[:base], ['Record is invalid'])
   end
+
+  def test_resources_for_transforms_records_into_resources
+    resources = PostResource.resources_for([Post.first], {})
+    assert_equal(PostResource, resources.first.class)
+  end
 end


### PR DESCRIPTION
Most of the behaviour of JSONAPI::Resource#find can be controlled by
reimplementing #records, #filter_record, #sort_record, etc. By moving the
resource transformation into #resources_for, we've remove one of the final bits
of logic out of the #find. All #find defines is the order of operations and in
many cases can be left as is.

My specific use case is to delegate a single class of models to different
resources. The caching behaviour in #find's transformation prevents me from
simply reimplementing Resource#resource_for.
