### PR TITLE
Improve rescue_from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -770,6 +770,9 @@ class ApiController < ApplicationController
 end
 ```
 
+Note that if your controller inherits from `JSONAPI::ResourceController`,
+you will need to add `include ActionController::Rescue` to it for `rescue_from`
+to work.
 
 ###### Applying Filters
 


### PR DESCRIPTION
`rescue_from` wasn't working for me (using JSONAPI::Resources master, Rails 5.0.0.rc1), and I figured out that it was because JSONAPI::ResourceController does not include ActionController::Rescue.
