### PR TITLE
fix polymorphic_type for ToOne relationships

### DIFF
--- a/lib/jsonapi/relationship.rb
+++ b/lib/jsonapi/relationship.rb
@@ -74,7 +74,7 @@ module JSONAPI
       end
 
       def polymorphic_type
-        "#{type.to_s.singularize}_type" if polymorphic?
+        "#{name}_type" if polymorphic?
       end
     end
 

--- a/test/unit/resource/relationship_test.rb
+++ b/test/unit/resource/relationship_test.rb
@@ -1,0 +1,12 @@
+require File.expand_path('../../../test_helper', __FILE__)
+
+class HasOneRelationshipTest < ActiveSupport::TestCase
+
+  def test_polymorphic_type
+    relationship = JSONAPI::Relationship::ToOne.new("imageable",
+      polymorphic: true
+    )
+    assert_equal(relationship.polymorphic_type, "imageable_type")
+  end
+
+end


### PR DESCRIPTION
It looks like this bug was introduced with a recent change to how `type` is determined for the relationship.
