### PR TITLE
[ResourceSerializer] use resource value instead of model attribute to get relationship model id

### DIFF
--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -298,9 +298,9 @@ module JSONAPI
 
     # Extracts the foreign key value for a to_one relationship.
     def foreign_key_value(source, relationship)
-      foreign_key = relationship.foreign_key
-      value = source.public_send(foreign_key)
-      @id_formatter.format(value)
+      related_resource = source.public_send(relationship.name)
+      return nil unless related_resource
+      @id_formatter.format(related_resource.id)
     end
 
     def foreign_key_types_and_values(source, relationship)


### PR DESCRIPTION
Currently relationship id i.e. `"relationships": { data: { "type": "users", id: "ID" }` is taken from source model attributes. However, in the same time the id present `included` model is taken from the relationship resource. 
This is fine when I don't override id and use db values , but when I want need override (e..g I want to use `uuid` which is not a primary/foreign key in terms of db, because the collection was created before we started using uuid).
What needs to be fixed is to always rely on relationship resource to get its id. 
