### PR TITLE
Refactor Resource._add_relationship into builder class

### DIFF
--- a/lib/jsonapi/relationship_builder.rb
+++ b/lib/jsonapi/relationship_builder.rb
@@ -1,152 +1,157 @@
-require 'pry'
-
 module JSONAPI
   class RelationshipBuilder
-    attr_reader :_model_class, :options
+    attr_reader :model_class, :options, :relationship_class
+    delegate :register_relationship, to: :@resource_class
 
-    class DefinitionProxy
-      def initialize(target)
-        @target = target
-      end
-
-      def define_method(name, &body)
-        @target.inject_class_method(name, body)
-      end
-
-      def method_defined?(name)
-        @target.method_defined?(name)
-      end
-    end
-
-    def initialize(relationship_class, options, model_class, resource_relationships, resource_klass)
+    def initialize(relationship_class, model_class, options)
       @relationship_class = relationship_class
-      @options = options
-      @_model_class = model_class
-      @_relationships = resource_relationships
-      @resource_klass = resource_klass
+      @model_class        = model_class
+      @resource_class     = options[:parent_resource]
+      @options            = options
     end
 
-    #TODO change reference in code once refactor is complete
-    def klass
-      @relationship_class
+    def define_relationship_methods(relationship_name)
+      # Initialize from an ActiveRecord model's properties
+      if model_class && model_class.ancestors.collect{|ancestor| ancestor.name}.include?('ActiveRecord::Base')
+        model_association = model_class.reflect_on_association(relationship_name)
+        if model_association
+          options[:class_name] ||= model_association.class_name
+        end
+      end
+
+      relationship = register_relationship(
+        relationship_name,
+        relationship_class.new(relationship_name, options)
+      )
+
+      foreign_key = define_foreign_key_setter(relationship.foreign_key)
+
+      case relationship
+      when JSONAPI::Relationship::ToOne
+        associated = define_resource_relationship_accessor(:one, relationship_name)
+        args = [relationship, foreign_key, associated, relationship_name]
+
+        relationship.belongs_to? ? build_belongs_to(*args) : build_has_one(*args)
+      when JSONAPI::Relationship::ToMany
+        associated = define_resource_relationship_accessor(:many, relationship_name)
+
+        build_to_many(relationship, foreign_key, associated, relationship_name)
+      end
     end
 
-    def target_resource
-      @proxy ||= DefinitionProxy.new(@resource_klass)
+    def define_foreign_key_setter(foreign_key)
+      define_on_resource "#{foreign_key}=" do |value|
+        @model.method("#{foreign_key}=").call(value)
+      end
+      foreign_key
     end
 
-    def build_relationship(attrs)
-        attrs.each do |attr|
-          relationship_name = attr.to_sym
+    def define_resource_relationship_accessor(type, relationship_name)
+      associated_records_method_name = {
+        one:  "record_for_#{relationship_name}",
+        many: "records_for_#{relationship_name}"
+      }
+      .fetch(type)
 
-          @resource_klass.check_reserved_relationship_name(relationship_name)
+      define_on_resource associated_records_method_name do
+        relationship = self.class._relationships[relationship_name]
+        relation_name = relationship.relation_name(context: @context)
+        records_for(relation_name)
+      end
 
-          # Initialize from an ActiveRecord model's properties
-          if _model_class && _model_class.ancestors.collect{|ancestor| ancestor.name}.include?('ActiveRecord::Base')
-            model_association = _model_class.reflect_on_association(relationship_name)
-            if model_association
-              options[:class_name] ||= model_association.class_name
-            end
-          end
+      associated_records_method_name
+    end
 
-          @_relationships[relationship_name] = relationship = klass.new(relationship_name, options)
+    def build_belongs_to(relationship, foreign_key, associated_records_method_name, relationship_name)
+      # Calls method matching foreign key name on model instance
+      define_on_resource foreign_key do
+        @model.method(foreign_key).call
+      end
 
-          associated_records_method_name = case relationship
-                                           when JSONAPI::Relationship::ToOne then "record_for_#{relationship_name}"
-                                           when JSONAPI::Relationship::ToMany then "records_for_#{relationship_name}"
-                                           end
+      # Returns instantiated related resource object or nil
+      define_on_resource relationship_name do |options = {}|
+        relationship = self.class._relationships[relationship_name]
 
-          foreign_key = relationship.foreign_key
-
-          target_resource.define_method "#{foreign_key}=" do |value|
-            @model.method("#{foreign_key}=").call(value)
-          end unless target_resource.method_defined?("#{foreign_key}=")
-
-          target_resource.define_method associated_records_method_name do
-            relationship = self.class._relationships[relationship_name]
-            relation_name = relationship.relation_name(context: @context)
-            records_for(relation_name)
-          end unless target_resource.method_defined?(associated_records_method_name)
-
-          if relationship.is_a?(JSONAPI::Relationship::ToOne)
-            if relationship.belongs_to?
-              target_resource.define_method foreign_key do
-                @model.method(foreign_key).call
-              end unless target_resource.method_defined?(foreign_key)
-
-              target_resource.define_method relationship_name do |options = {}|
-                relationship = self.class._relationships[relationship_name]
-
-                if relationship.polymorphic?
-                  associated_model = public_send(associated_records_method_name)
-                  resource_klass = self.class.resource_for_model(associated_model) if associated_model
-                  return resource_klass.new(associated_model, @context) if resource_klass
-                else
-                  resource_klass = relationship.resource_klass
-                  if resource_klass
-                    associated_model = public_send(associated_records_method_name)
-                    return associated_model ? resource_klass.new(associated_model, @context) : nil
-                  end
-                end
-              end unless target_resource.method_defined?(relationship_name)
-            else
-              target_resource.define_method foreign_key do
-                relationship = self.class._relationships[relationship_name]
-
-                record = public_send(associated_records_method_name)
-                return nil if record.nil?
-                record.public_send(relationship.resource_klass._primary_key)
-              end unless target_resource.method_defined?(foreign_key)
-
-              target_resource.define_method relationship_name do |options = {}|
-                relationship = self.class._relationships[relationship_name]
-
-                resource_klass = relationship.resource_klass
-                if resource_klass
-                  associated_model = public_send(associated_records_method_name)
-                  return associated_model ? resource_klass.new(associated_model, @context) : nil
-                end
-              end unless target_resource.method_defined?(relationship_name)
-            end
-          elsif relationship.is_a?(JSONAPI::Relationship::ToMany)
-            target_resource.define_method foreign_key do
-              records = public_send(associated_records_method_name)
-              return records.collect do |record|
-                record.public_send(relationship.resource_klass._primary_key)
-              end
-            end unless target_resource.method_defined?(foreign_key)
-
-            target_resource.define_method relationship_name do |options = {}|
-              relationship = self.class._relationships[relationship_name]
-
-              resource_klass = relationship.resource_klass
-              records = public_send(associated_records_method_name)
-
-              filters = options.fetch(:filters, {})
-              unless filters.nil? || filters.empty?
-                records = resource_klass.apply_filters(records, filters, options)
-              end
-
-              sort_criteria =  options.fetch(:sort_criteria, {})
-              unless sort_criteria.nil? || sort_criteria.empty?
-                order_options = relationship.resource_klass.construct_order_options(sort_criteria)
-                records = resource_klass.apply_sort(records, order_options, @context)
-              end
-
-              paginator = options[:paginator]
-              if paginator
-                records = resource_klass.apply_pagination(records, paginator, order_options)
-              end
-
-              return records.collect do |record|
-                if relationship.polymorphic?
-                  resource_klass = self.class.resource_for_model(record)
-                end
-                resource_klass.new(record, @context)
-              end
-            end unless target_resource.method_defined?(relationship_name)
+        if relationship.polymorphic?
+          associated_model = public_send(associated_records_method_name)
+          resource_klass = self.class.resource_for_model(associated_model) if associated_model
+          return resource_klass.new(associated_model, @context) if resource_klass
+        else
+          resource_klass = relationship.resource_klass
+          if resource_klass
+            associated_model = public_send(associated_records_method_name)
+            return associated_model ? resource_klass.new(associated_model, @context) : nil
           end
         end
+      end
+    end
+
+    def build_has_one(relationship, foreign_key, associated_records_method_name, relationship_name)
+      # Returns primary key name of related resource class
+      define_on_resource foreign_key do
+        relationship = self.class._relationships[relationship_name]
+
+        record = public_send(associated_records_method_name)
+        return nil if record.nil?
+        record.public_send(relationship.resource_klass._primary_key)
+      end
+
+      # Returns instantiated related resource object or nil
+      define_on_resource relationship_name do |options = {}|
+        relationship = self.class._relationships[relationship_name]
+
+        resource_klass = relationship.resource_klass
+        if resource_klass
+          associated_model = public_send(associated_records_method_name)
+          return associated_model ? resource_klass.new(associated_model, @context) : nil
+        end
+      end
+    end
+
+    def build_to_many(relationship, foreign_key, associated_records_method_name, relationship_name)
+      # Returns array of primary keys of related resource classes
+      define_on_resource foreign_key do
+        records = public_send(associated_records_method_name)
+        return records.collect do |record|
+          record.public_send(relationship.resource_klass._primary_key)
+        end
+      end
+
+      # Returns array of instantiated related resource objects
+      define_on_resource relationship_name do |options = {}|
+        relationship = self.class._relationships[relationship_name]
+
+        resource_klass = relationship.resource_klass
+        records = public_send(associated_records_method_name)
+
+        filters = options.fetch(:filters, {})
+        unless filters.nil? || filters.empty?
+          records = resource_klass.apply_filters(records, filters, options)
+        end
+
+        sort_criteria =  options.fetch(:sort_criteria, {})
+        unless sort_criteria.nil? || sort_criteria.empty?
+          order_options = relationship.resource_klass.construct_order_options(sort_criteria)
+          records = resource_klass.apply_sort(records, order_options, @context)
+        end
+
+        paginator = options[:paginator]
+        if paginator
+          records = resource_klass.apply_pagination(records, paginator, order_options)
+        end
+
+        return records.collect do |record|
+          if relationship.polymorphic?
+            resource_klass = self.class.resource_for_model(record)
+          end
+          resource_klass.new(record, @context)
+        end
+      end
+    end
+
+    def define_on_resource(method_name, &block)
+      return if @resource_class.method_defined?(method_name)
+      @resource_class.inject_method_definition(method_name, block)
     end
   end
 end

--- a/lib/jsonapi/relationship_builder.rb
+++ b/lib/jsonapi/relationship_builder.rb
@@ -1,0 +1,152 @@
+require 'pry'
+
+module JSONAPI
+  class RelationshipBuilder
+    attr_reader :_model_class, :options
+
+    class DefinitionProxy
+      def initialize(target)
+        @target = target
+      end
+
+      def define_method(name, &body)
+        @target.inject_class_method(name, body)
+      end
+
+      def method_defined?(name)
+        @target.method_defined?(name)
+      end
+    end
+
+    def initialize(relationship_class, options, model_class, resource_relationships, resource_klass)
+      @relationship_class = relationship_class
+      @options = options
+      @_model_class = model_class
+      @_relationships = resource_relationships
+      @resource_klass = resource_klass
+    end
+
+    #TODO change reference in code once refactor is complete
+    def klass
+      @relationship_class
+    end
+
+    def target_resource
+      @proxy ||= DefinitionProxy.new(@resource_klass)
+    end
+
+    def build_relationship(attrs)
+        attrs.each do |attr|
+          relationship_name = attr.to_sym
+
+          @resource_klass.check_reserved_relationship_name(relationship_name)
+
+          # Initialize from an ActiveRecord model's properties
+          if _model_class && _model_class.ancestors.collect{|ancestor| ancestor.name}.include?('ActiveRecord::Base')
+            model_association = _model_class.reflect_on_association(relationship_name)
+            if model_association
+              options[:class_name] ||= model_association.class_name
+            end
+          end
+
+          @_relationships[relationship_name] = relationship = klass.new(relationship_name, options)
+
+          associated_records_method_name = case relationship
+                                           when JSONAPI::Relationship::ToOne then "record_for_#{relationship_name}"
+                                           when JSONAPI::Relationship::ToMany then "records_for_#{relationship_name}"
+                                           end
+
+          foreign_key = relationship.foreign_key
+
+          target_resource.define_method "#{foreign_key}=" do |value|
+            @model.method("#{foreign_key}=").call(value)
+          end unless target_resource.method_defined?("#{foreign_key}=")
+
+          target_resource.define_method associated_records_method_name do
+            relationship = self.class._relationships[relationship_name]
+            relation_name = relationship.relation_name(context: @context)
+            records_for(relation_name)
+          end unless target_resource.method_defined?(associated_records_method_name)
+
+          if relationship.is_a?(JSONAPI::Relationship::ToOne)
+            if relationship.belongs_to?
+              target_resource.define_method foreign_key do
+                @model.method(foreign_key).call
+              end unless target_resource.method_defined?(foreign_key)
+
+              target_resource.define_method relationship_name do |options = {}|
+                relationship = self.class._relationships[relationship_name]
+
+                if relationship.polymorphic?
+                  associated_model = public_send(associated_records_method_name)
+                  resource_klass = self.class.resource_for_model(associated_model) if associated_model
+                  return resource_klass.new(associated_model, @context) if resource_klass
+                else
+                  resource_klass = relationship.resource_klass
+                  if resource_klass
+                    associated_model = public_send(associated_records_method_name)
+                    return associated_model ? resource_klass.new(associated_model, @context) : nil
+                  end
+                end
+              end unless target_resource.method_defined?(relationship_name)
+            else
+              target_resource.define_method foreign_key do
+                relationship = self.class._relationships[relationship_name]
+
+                record = public_send(associated_records_method_name)
+                return nil if record.nil?
+                record.public_send(relationship.resource_klass._primary_key)
+              end unless target_resource.method_defined?(foreign_key)
+
+              target_resource.define_method relationship_name do |options = {}|
+                relationship = self.class._relationships[relationship_name]
+
+                resource_klass = relationship.resource_klass
+                if resource_klass
+                  associated_model = public_send(associated_records_method_name)
+                  return associated_model ? resource_klass.new(associated_model, @context) : nil
+                end
+              end unless target_resource.method_defined?(relationship_name)
+            end
+          elsif relationship.is_a?(JSONAPI::Relationship::ToMany)
+            target_resource.define_method foreign_key do
+              records = public_send(associated_records_method_name)
+              return records.collect do |record|
+                record.public_send(relationship.resource_klass._primary_key)
+              end
+            end unless target_resource.method_defined?(foreign_key)
+
+            target_resource.define_method relationship_name do |options = {}|
+              relationship = self.class._relationships[relationship_name]
+
+              resource_klass = relationship.resource_klass
+              records = public_send(associated_records_method_name)
+
+              filters = options.fetch(:filters, {})
+              unless filters.nil? || filters.empty?
+                records = resource_klass.apply_filters(records, filters, options)
+              end
+
+              sort_criteria =  options.fetch(:sort_criteria, {})
+              unless sort_criteria.nil? || sort_criteria.empty?
+                order_options = relationship.resource_klass.construct_order_options(sort_criteria)
+                records = resource_klass.apply_sort(records, order_options, @context)
+              end
+
+              paginator = options[:paginator]
+              if paginator
+                records = resource_klass.apply_pagination(records, paginator, order_options)
+              end
+
+              return records.collect do |record|
+                if relationship.polymorphic?
+                  resource_klass = self.class.resource_for_model(record)
+                end
+                resource_klass.new(record, @context)
+              end
+            end unless target_resource.method_defined?(relationship_name)
+          end
+        end
+    end
+  end
+end

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -1,4 +1,5 @@
 require 'jsonapi/callbacks'
+require 'jsonapi/relationship_builder'
 
 module JSONAPI
   class Resource
@@ -762,120 +763,15 @@ module JSONAPI
         options = attrs.extract_options!
         options[:parent_resource] = self
 
-        attrs.each do |attr|
-          relationship_name = attr.to_sym
+        JSONAPI::RelationshipBuilder.new(klass, options, _model_class, @_relationships, self)
+          .build_relationship(attrs)
 
-          check_reserved_relationship_name(relationship_name)
-
-          # Initialize from an ActiveRecord model's properties
-          if _model_class && _model_class.ancestors.collect{|ancestor| ancestor.name}.include?('ActiveRecord::Base')
-            model_association = _model_class.reflect_on_association(relationship_name)
-            if model_association
-              options[:class_name] ||= model_association.class_name
-            end
-          end
-
-          @_relationships[relationship_name] = relationship = klass.new(relationship_name, options)
-
-          associated_records_method_name = case relationship
-                                           when JSONAPI::Relationship::ToOne then "record_for_#{relationship_name}"
-                                           when JSONAPI::Relationship::ToMany then "records_for_#{relationship_name}"
-                                           end
-
-          foreign_key = relationship.foreign_key
-
-          define_method "#{foreign_key}=" do |value|
-            @model.method("#{foreign_key}=").call(value)
-          end unless method_defined?("#{foreign_key}=")
-
-          define_method associated_records_method_name do
-            relationship = self.class._relationships[relationship_name]
-            relation_name = relationship.relation_name(context: @context)
-            records_for(relation_name)
-          end unless method_defined?(associated_records_method_name)
-
-          if relationship.is_a?(JSONAPI::Relationship::ToOne)
-            if relationship.belongs_to?
-              define_method foreign_key do
-                @model.method(foreign_key).call
-              end unless method_defined?(foreign_key)
-
-              define_method relationship_name do |options = {}|
-                relationship = self.class._relationships[relationship_name]
-
-                if relationship.polymorphic?
-                  associated_model = public_send(associated_records_method_name)
-                  resource_klass = self.class.resource_for_model(associated_model) if associated_model
-                  return resource_klass.new(associated_model, @context) if resource_klass
-                else
-                  resource_klass = relationship.resource_klass
-                  if resource_klass
-                    associated_model = public_send(associated_records_method_name)
-                    return associated_model ? resource_klass.new(associated_model, @context) : nil
-                  end
-                end
-              end unless method_defined?(relationship_name)
-            else
-              define_method foreign_key do
-                relationship = self.class._relationships[relationship_name]
-
-                record = public_send(associated_records_method_name)
-                return nil if record.nil?
-                record.public_send(relationship.resource_klass._primary_key)
-              end unless method_defined?(foreign_key)
-
-              define_method relationship_name do |options = {}|
-                relationship = self.class._relationships[relationship_name]
-
-                resource_klass = relationship.resource_klass
-                if resource_klass
-                  associated_model = public_send(associated_records_method_name)
-                  return associated_model ? resource_klass.new(associated_model, @context) : nil
-                end
-              end unless method_defined?(relationship_name)
-            end
-          elsif relationship.is_a?(JSONAPI::Relationship::ToMany)
-            define_method foreign_key do
-              records = public_send(associated_records_method_name)
-              return records.collect do |record|
-                record.public_send(relationship.resource_klass._primary_key)
-              end
-            end unless method_defined?(foreign_key)
-
-            define_method relationship_name do |options = {}|
-              relationship = self.class._relationships[relationship_name]
-
-              resource_klass = relationship.resource_klass
-              records = public_send(associated_records_method_name)
-
-              filters = options.fetch(:filters, {})
-              unless filters.nil? || filters.empty?
-                records = resource_klass.apply_filters(records, filters, options)
-              end
-
-              sort_criteria =  options.fetch(:sort_criteria, {})
-              unless sort_criteria.nil? || sort_criteria.empty?
-                order_options = relationship.resource_klass.construct_order_options(sort_criteria)
-                records = resource_klass.apply_sort(records, order_options, @context)
-              end
-
-              paginator = options[:paginator]
-              if paginator
-                records = resource_klass.apply_pagination(records, paginator, order_options)
-              end
-
-              return records.collect do |record|
-                if relationship.polymorphic?
-                  resource_klass = self.class.resource_for_model(record)
-                end
-                resource_klass.new(record, @context)
-              end
-            end unless method_defined?(relationship_name)
-          end
-        end
       end
 
-      private
+      #added
+      def inject_class_method(name, body)
+        define_method(name, body)
+      end
 
       def check_reserved_resource_name(type, name)
         if [:ids, :types, :hrefs, :links].include?(type)

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -763,15 +763,24 @@ module JSONAPI
         options = attrs.extract_options!
         options[:parent_resource] = self
 
-        JSONAPI::RelationshipBuilder.new(klass, options, _model_class, @_relationships, self)
-          .build_relationship(attrs)
+        attrs.each do |relationship_name|
+          check_reserved_relationship_name(relationship_name)
 
+          JSONAPI::RelationshipBuilder.new(klass, _model_class, options)
+            .define_relationship_methods(relationship_name.to_sym)
+        end
       end
 
-      #added
-      def inject_class_method(name, body)
+      # Allows JSONAPI::RelationshipBuilder to access metaprogramming hooks
+      def inject_method_definition(name, body)
         define_method(name, body)
       end
+
+      def register_relationship(name, relationship_object)
+        @_relationships[name] = relationship_object
+      end
+
+      private
 
       def check_reserved_resource_name(type, name)
         if [:ids, :types, :hrefs, :links].include?(type)


### PR DESCRIPTION
I have found in the past that trying to work with relationship method overrides to deal with edge cases has led me and a trusty debugger on a challenging trip into the heart of the `Resource_add_relationship method`. I had been meaning to have a go at a refactor for a while, partly out of sport, and because I suspect that the complexity there may be discouraging to many trying to work with or understand the source.

Here is a go at it. @lgebhardt I believe this is mostly your code from the early days. I'd appreciate some feedback if you ever have time. I am happy to make further modifications if I missed anything. 

I made changes incrementally with tests passing. I didn't add new unit tests because the current test coverage seemed to very adequately demonstrate when I was breaking things. Larry, if you think there may be edge cases that deserve some close testing let me know. There might be a small performance overhear incurred for the changes at start time(I didn't benchmark) but I suspect it is minimal and worth it for maintainability.

Last thing. Someone else may want to QA this against a real project. I'm not able to run any of my apps against master until I clean up some hacks that don't work beyond 0.7.0 (thanks, I don't need them anymore it seems)
