### PR TITLE
use resource value instead of model attribute to get relationship model id for one to many relationships

### DIFF
--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -318,8 +318,8 @@ module JSONAPI
             end
           end
         else
-          source.public_send(relationship.foreign_key).map do |value|
-            [relationship.type, @id_formatter.format(value)]
+          source.public_send(relationship.name).map do |value|
+            [relationship.type, @id_formatter.format(value.id)]
           end
         end
       end

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -263,6 +263,9 @@ class Person < ActiveRecord::Base
 
   has_and_belongs_to_many :books, join_table: :book_authors
 
+  has_many :even_posts, -> { where('posts.id % 2 = 0') }, class_name: 'Post', foreign_key: 'author_id'
+  has_many :odd_posts, -> { where('posts.id % 2 = 1') }, class_name: 'Post', foreign_key: 'author_id'
+
   ### Validations
   validates :name, presence: true
   validates :date_joined, presence: true
@@ -806,6 +809,13 @@ class PersonResource < BaseResource
     return values
   end
 
+end
+
+class PersonWithEvenAndOddPostsResource < JSONAPI::Resource
+  model_name 'Person'
+
+  has_many :even_posts, foreign_key: 'author_id', class_name: 'Post', relation_name: :even_posts
+  has_many :odd_posts, foreign_key: 'author_id', class_name: 'Post', relation_name: :odd_posts
 end
 
 class SpecialBaseResource < BaseResource

--- a/test/unit/serializer/serializer_test.rb
+++ b/test/unit/serializer/serializer_test.rb
@@ -2175,5 +2175,169 @@ class SerializerTest < ActionDispatch::IntegrationTest
     assert_hash_equals(custom_link_spec, serialized_custom_link_resource)
   end
 
+  def test_includes_two_relationships_with_same_foreign_key
+    serialized_resource = JSONAPI::ResourceSerializer
+      .new(PersonWithEvenAndOddPostsResource, include: ['even_posts','odd_posts'])
+      .serialize_to_hash(PersonWithEvenAndOddPostsResource.new(Person.first, nil))
+
+    assert_hash_equals(
+      {
+        data: {
+          id: "1",
+          type: "personWithEvenAndOddPosts",
+          links: {
+            self: "/personWithEvenAndOddPosts/1"
+          },
+          relationships: {
+            evenPosts: {
+              links: {
+                self: "/personWithEvenAndOddPosts/1/relationships/evenPosts",
+                related: "/personWithEvenAndOddPosts/1/evenPosts"
+              },
+              data: [
+                {
+                  type: "posts",
+                  id: "2"
+                }
+              ]
+            },
+            oddPosts: {
+              links: {
+                self: "/personWithEvenAndOddPosts/1/relationships/oddPosts",
+                related: "/personWithEvenAndOddPosts/1/oddPosts"
+              },
+              data:[
+                {
+                  type: "posts",
+                  id: "1"
+                },
+                {
+                  type: "posts",
+                  id: "11"
+                }
+              ]
+            }
+          }
+        },
+        included:[
+          {
+            id: "2",
+            type: "posts",
+            links: {
+              self: "/posts/2"
+            },
+            attributes: {
+              title: "JR Solves your serialization woes!",
+              body: "Use JR",
+              subject: "JR Solves your serialization woes!"
+            },
+            relationships: {
+              author: {
+                links: {
+                  self: "/posts/2/relationships/author",
+                  related: "/posts/2/author"
+                }
+              },
+              section: {
+                links: {
+                  self: "/posts/2/relationships/section",
+                  related: "/posts/2/section"
+                }
+              },
+              tags: {
+                links: {
+                  self: "/posts/2/relationships/tags",
+                  related: "/posts/2/tags"
+                }
+              },
+              comments: {
+                links: {
+                  self: "/posts/2/relationships/comments",
+                  related: "/posts/2/comments"
+                }
+              }
+            }
+          },
+          {
+            id: "1",
+            type: "posts",
+            links: {
+              self: "/posts/1"
+            },
+            attributes: {
+              title: "New post",
+              body: "A body!!!",
+              subject: "New post"
+            },
+            relationships: {
+              author: {
+                links: {
+                  self: "/posts/1/relationships/author",
+                  related: "/posts/1/author"
+                }
+              },
+              section: {
+                links: {
+                  self: "/posts/1/relationships/section",
+                  related: "/posts/1/section"
+                }
+              },
+              tags: {
+                links: {
+                  self: "/posts/1/relationships/tags",
+                  related: "/posts/1/tags"
+                }
+              },
+              comments: {
+                links: {
+                  self: "/posts/1/relationships/comments",
+                  related: "/posts/1/comments"
+                }
+              }
+            }
+          },
+          {
+            id: "11",
+            type: "posts",
+            links: {
+              self: "/posts/11"
+            },
+            attributes: {
+              title: "JR How To",
+              body: "Use JR to write API apps",
+              subject: "JR How To"
+            },
+            relationships: {
+              author: {
+                links: {
+                  self: "/posts/11/relationships/author",
+                  related: "/posts/11/author"
+                }
+              },
+              section: {
+                links: {
+                  self: "/posts/11/relationships/section",
+                  related: "/posts/11/section"
+                }
+              },
+              tags: {
+                links: {
+                  self: "/posts/11/relationships/tags",
+                  related: "/posts/11/tags"
+                }
+              },
+              comments: {
+                links: {
+                  self: "/posts/11/relationships/comments",
+                  related: "/posts/11/comments"
+                }
+              }
+            }
+          }
+        ]
+      },
+      serialized_resource
+    )
+  end
 
 end


### PR DESCRIPTION
Instead of fetching records using the foreign_key use the relationship name instead. The value stored in the map under the foreign key contains the records for the first relationship defined using that foreign
key. By contrast, using the relationship name returns the records fetched for the relationship defined with that name. I have included a test case that fails without this patch that illustrates how I discovered this issue.

This is analogous to the recently merged pull (https://github.com/cerebris/jsonapi-resources/pull/736) that does the same thing for to_one relationships.
