### PR TITLE
Make default sort criteria blank.

### DIFF
--- a/lib/jsonapi/request_parser.rb
+++ b/lib/jsonapi/request_parser.rb
@@ -16,7 +16,7 @@ module JSONAPI
       @operations = []
       @fields = {}
       @filters = {}
-      @sort_criteria = [{ field: 'id', direction: :asc }]
+      @sort_criteria = []
       @source_klass = nil
       @source_id = nil
       @include_directives = nil

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -437,7 +437,7 @@ module JSONAPI
       def has_one(*attrs)
         _add_relationship(Relationship::ToOne, *attrs)
       end
-      
+
       def belongs_to(*attrs)
         ActiveSupport::Deprecation.warn "In #{name} you exposed a `has_one` relationship "\
                                         " using the `belongs_to` class method. We think `has_one`" \
@@ -629,6 +629,7 @@ module JSONAPI
       end
 
       def filter_records(filters, options, records = records(options))
+        records = records.all
         records = apply_filters(records, filters, options)
         apply_includes(records, options)
       end


### PR DESCRIPTION
Enable `records(options)` to know if a sort criteria was passed
by the client.

Before this change, we didn't know if the sort criteria "id ASC" passed in
the `options` hash was provided by the client or was the default one.
This would prevent us from implementing a default sort order.
