### PR TITLE
Default Sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,21 @@ The request will look something like:
 GET /books?include=author&sort=author.name
 ```
 
+###### Default sorting
+
+By default JR sorts ascending on the `id` of the primary resource, unless the request specifies an alternate sort order.
+To override this you may override the `self.default_sort` on a `resource`. `default_sort` should return an array of
+`sort_param` hashes. A `sort_param` hash contains a `field` and a `direction`, with `direction` being either `:asc` or
+`:desc`.
+
+For example:
+
+```ruby
+  def self.default_sort
+    [{field: 'name_last', direction: :desc}, {field: 'name_first', direction: :desc}]
+  end
+```
+
 ##### Attribute Formatting
 
 Attributes can have a `Format`. By default all attributes use the default formatter. If an attribute has the `format`

--- a/lib/jsonapi/request_parser.rb
+++ b/lib/jsonapi/request_parser.rb
@@ -16,7 +16,7 @@ module JSONAPI
       @operations = []
       @fields = {}
       @filters = {}
-      @sort_criteria = [{ field: 'id', direction: :asc }]
+      @sort_criteria = nil
       @source_klass = nil
       @source_id = nil
       @include_directives = nil

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -861,11 +861,17 @@ module JSONAPI
         end
       end
 
+      def default_sort
+        [{field: 'id', direction: :asc}]
+      end
+
       def construct_order_options(sort_params)
+        sort_params ||= default_sort
+
         return {} unless sort_params
 
         sort_params.each_with_object({}) do |sort, order_hash|
-          field = sort[:field] == 'id' ? _primary_key : sort[:field]
+          field = sort[:field].to_s == 'id' ? _primary_key : sort[:field].to_s
           order_hash[field] = sort[:direction]
         end
       end

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -1237,6 +1237,10 @@ module Api
       has_one :section
       has_many :comments, acts_as_set: false
 
+      def self.default_sort
+        [{field: 'title', direction: :asc}, {field: 'id', direction: :desc}]
+      end
+
       def subject
         @model.title
       end


### PR DESCRIPTION
Moves the setting of the default sort from the request_parser to a method on the resource, named default_sort.

This is an alternative to #752
