### PR TITLE
chore: bump version to 0.8.0

### DIFF
--- a/lib/jsonapi/resources/version.rb
+++ b/lib/jsonapi/resources/version.rb
@@ -1,5 +1,5 @@
 module JSONAPI
   module Resources
-    VERSION = '0.7.0'
+    VERSION = '0.8.0'
   end
 end


### PR DESCRIPTION
Hey @lgebhardt we need to differ versions for https://github.com/venuu/jsonapi-authorization/pull/24
I've choosen to increase the minor version number as of a lot of things have changed since 0.7.0.

Also, I'm thinking that it would helps a lot to define a version number policy so that pull requests like this one aren't necessary.
