### PR TITLE
Don't cache resource classes based on model class

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -743,9 +743,8 @@ module JSONAPI
       end
 
       def resources_for(records, context)
-        resource_classes = {}
         records.collect do |model|
-          resource_class = resource_classes[model.class] ||= self.resource_for_model(model)
+          resource_class = self.resource_for_model(model)
           resource_class.new(model, context)
         end
       end


### PR DESCRIPTION
`resource_for_model` passes the model instance, so resources can vary based on model instance.
Caching them based on model class, therefore, can wrongly use a resource that for a record that should use a different resource.

I just ran into this when choosing resource based on the type of a polymorphic relationship.
