### PR TITLE
avoid situation where the linkage data could be partially calculated

### DIFF
--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -353,8 +353,10 @@ module JSONAPI
     end
 
     def to_one_linkage(source, relationship)
-      return unless linkage_id = foreign_key_value(source, relationship)
-      return unless linkage_type = format_key(relationship.type_for_source(source))
+      linkage_id = foreign_key_value(source, relationship)
+      linkage_type = format_key(relationship.type_for_source(source))
+      return unless linkage_id.present? && linkage_type.present?
+
       {
         type: linkage_type,
         id: linkage_id,

--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -353,16 +353,12 @@ module JSONAPI
     end
 
     def to_one_linkage(source, relationship)
-      linkage = {}
-      linkage_id = foreign_key_value(source, relationship)
-
-      if linkage_id
-        linkage[:type] = format_key(relationship.type_for_source(source))
-        linkage[:id] = linkage_id
-      else
-        linkage = nil
-      end
-      linkage
+      return unless linkage_id = foreign_key_value(source, relationship)
+      return unless linkage_type = format_key(relationship.type_for_source(source))
+      {
+        type: linkage_type,
+        id: linkage_id,
+      }
     end
 
     def to_many_linkage(source, relationship)
@@ -390,7 +386,9 @@ module JSONAPI
       end
 
       linkage_types_and_values.each do |type, value|
-        linkage.append({type: format_key(type), id: @id_formatter.format(value)})
+        if type && value
+          linkage.append({type: format_key(type), id: @id_formatter.format(value)})
+        end
       end
       linkage
     end


### PR DESCRIPTION
The existing tests pass, though I did not take the time to create a failing test case for the situation (mostly because the easiest way would have been to test the `to_one_linkage` and `to_many_linkage` methods directly, and I didn't have time to figure out how to isolate them effectively).

This fixes the situation where the current user does not have permission to access a relationship, and the library was returning a partially complete `data` object for that relationship when it was polymorphic (the `id` would be provided, but the `type` would be an empty string because of the way that `Relationship.type_for_source` works). To keep it all simple and avoid any side effects, I'm just _not_ returning a partial data object (where either the `id` or the `type` are `nil`) now.
