### PR TITLE
Fix media type matching

### DIFF
--- a/lib/jsonapi/acts_as_resource_controller.rb
+++ b/lib/jsonapi/acts_as_resource_controller.rb
@@ -2,7 +2,7 @@ require 'csv'
 
 module JSONAPI
   module ActsAsResourceController
-    MEDIA_TYPE_MATCHER = /(.+".+"[^,]*|[^,]+)/
+    MEDIA_TYPE_MATCHER = /.+".+"[^,]*|[^,]+/
     ALL_MEDIA_TYPES = '*/*'
 
     def self.included(base)
@@ -169,7 +169,7 @@ module JSONAPI
 
     def media_types_for(header)
       (request.headers[header] || '')
-        .match(MEDIA_TYPE_MATCHER)
+        .scan(MEDIA_TYPE_MATCHER)
         .to_a
         .map(&:strip)
     end

--- a/test/integration/requests/request_test.rb
+++ b/test/integration/requests/request_test.rb
@@ -93,6 +93,14 @@ class RequestTest < ActionDispatch::IntegrationTest
     JSONAPI.configuration = original_config
   end
 
+  def test_get_accepting_multiple_content_types
+    get '/posts', headers:
+      {
+        'Accept': "application/json, #{JSONAPI::MEDIA_TYPE}, */*"
+      }
+    assert_equal 200, status
+  end
+
   def test_put_single_without_content_type
     put '/posts/3', params:
       {

--- a/test/integration/requests/request_test.rb
+++ b/test/integration/requests/request_test.rb
@@ -96,7 +96,7 @@ class RequestTest < ActionDispatch::IntegrationTest
   def test_get_accepting_multiple_content_types
     get '/posts', headers:
       {
-        'Accept': "application/json, #{JSONAPI::MEDIA_TYPE}, */*"
+        'Accept' => "application/json, #{JSONAPI::MEDIA_TYPE}, */*"
       }
     assert_equal 200, status
   end


### PR DESCRIPTION
Bug: When client sends Accept header with allowed media type not in the first position, the request gets rejected. For example:

```
GET /posts
Accept: application/json, application/vnd.api+json, */*
```

Expected: HTTP 200 OK
Got: HTTP 406 Not acceptable

This happens due to incorrect header parsing in JSONAPI::ActsAsResourceController#media_types_for. The PR addresses the issue
