### PR TITLE
Fix request tests

### DIFF
--- a/test/integration/requests/request_test.rb
+++ b/test/integration/requests/request_test.rb
@@ -93,7 +93,7 @@ class RequestTest < ActionDispatch::IntegrationTest
     JSONAPI.configuration = original_config
   end
 
-  def test_get_accepting_multiple_content_types
+  def test_get_multiple_accept_media_types
     get '/posts', headers:
       {
         'Accept' => "application/json, #{JSONAPI::MEDIA_TYPE}, */*"

--- a/test/integration/requests/request_test.rb
+++ b/test/integration/requests/request_test.rb
@@ -121,7 +121,7 @@ class RequestTest < ActionDispatch::IntegrationTest
         }
       }.to_json,
       headers: {
-        'CONTENT_TYPE' => 'application/json',
+        'CONTENT_TYPE' => nil,
         'Accept' => JSONAPI::MEDIA_TYPE
       }
 


### PR DESCRIPTION
Hi there, here are two small fixes
1. Not setting content type in `test_put_single_without_content_type` 
2. `test_get_accepting_multiple_content_types` is testing multiple accept types, suggest to rename it.
