### PR TITLE
Get relationship id from the resource

### DIFF
--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -427,11 +427,11 @@ module JSONAPI
     def foreign_key_value(source, relationship)
       related_resource_id = if source.preloaded_fragments.has_key?(format_key(relationship.name))
         source.preloaded_fragments[format_key(relationship.name)].values.first.try(:id)
-      elsif source._model.respond_to?("#{relationship.name}_id")
+      elsif source.respond_to?("#{relationship.name}_id")
         # If you have direct access to the underlying id, you don't have to load the relationship
         # which can save quite a lot of time when loading a lot of data.
         # This does not apply to e.g. has_one :through relationships.
-        source._model.public_send("#{relationship.name}_id")
+        source.public_send("#{relationship.name}_id")
       else
         source.public_send(relationship.name).try(:id)
       end


### PR DESCRIPTION
We should avoid getting relationship id from the `model` directly to allow clients to customize how relationship ids are fetched. The resource exposes the relationship id through a method which delegates to the `model`. This way we allow clients to override the relationship id in the resource to fit their needs.

Today, by default, the resource object already delegate the relationship id method to the model:

``` ruby
class AuthorResource
end

class MessageResource
  has_one :author
end

message.author_id
=> 1
message._model.author_id
=> 1
```

This way, a client can override the relationship id method:

``` ruby
class MessageResource
  has_one :author

  def author_id
    @model.author.some_custom_id
  end
end
```
