### PR TITLE
Making sure we return the right path for a rails engine that doesn't have additional namespaces

### DIFF
--- a/lib/jsonapi/link_builder.rb
+++ b/lib/jsonapi/link_builder.rb
@@ -95,7 +95,12 @@ module JSONAPI
       scopes         = module_scopes_from_class(klass)[1..-1]
       base_path_name = scopes.map { |scope| scope.underscore }.join("_")
       end_path_name  = klass._type.to_s
-      "#{ base_path_name }_#{ end_path_name }_path"
+
+      if base_path_name.blank?
+        "#{ end_path_name }_path"
+      else
+        "#{ base_path_name }_#{ end_path_name }_path"
+      end
     end
 
     def format_route(route)

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -1623,6 +1623,11 @@ module MyEngine
   end
 end
 
+module ApiV2Engine
+  class PersonResource < JSONAPI::Resource
+  end
+end
+
 module Legacy
   class FlatPost < ActiveRecord::Base
     self.table_name = "posts"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -65,6 +65,12 @@ module MyEngine
   end
 end
 
+module ApiV2Engine
+  class Engine < ::Rails::Engine
+    isolate_namespace ApiV2Engine
+  end
+end
+
 # Monkeypatch ActionController::TestCase to delete the RAW_POST_DATA on subsequent calls in the same test.
 if Rails::VERSION::MAJOR >= 5
   module ClearRawPostHeader
@@ -362,6 +368,7 @@ TestApp.routes.draw do
   end
 
   mount MyEngine::Engine => "/boomshaka", as: :my_engine
+  mount ApiV2Engine::Engine => "/api_v2", as: :api_v2_engine
 end
 
 MyEngine::Engine.routes.draw do
@@ -382,6 +389,10 @@ MyEngine::Engine.routes.draw do
       jsonapi_resources :people
     end
   end
+end
+
+ApiV2Engine::Engine.routes.draw do
+  jsonapi_resources :people
 end
 
 # Ensure backward compatibility with Minitest 4

--- a/test/unit/serializer/link_builder_test.rb
+++ b/test/unit/serializer/link_builder_test.rb
@@ -19,6 +19,10 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
       primary_resource_klass: MyEngine::Api::V1::PersonResource
     ).engine?, "MyEngine should be considered an Engine"
 
+    assert JSONAPI::LinkBuilder.new(
+      primary_resource_klass: ApiV2Engine::PersonResource
+    ).engine?, "ApiV2 shouldn't be considered an Engine"
+
     refute JSONAPI::LinkBuilder.new(
       primary_resource_klass: Api::V1::PersonResource
     ).engine?, "Api shouldn't be considered an Engine"
@@ -28,6 +32,11 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
     assert_equal MyEngine::Engine,
       JSONAPI::LinkBuilder.new(
         primary_resource_klass: MyEngine::Api::V1::PersonResource
+    ).engine_name
+
+    assert_equal ApiV2Engine::Engine,
+      JSONAPI::LinkBuilder.new(
+        primary_resource_klass: ApiV2Engine::PersonResource
     ).engine_name
 
     assert_equal nil,
@@ -53,6 +62,22 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
   end
 
   def test_self_link_with_engine_app
+    primary_resource_klass = ApiV2Engine::PersonResource
+
+    config = {
+      base_url: @base_url,
+      route_formatter: @route_formatter,
+      primary_resource_klass: primary_resource_klass,
+    }
+
+    builder = JSONAPI::LinkBuilder.new(config)
+    source  = primary_resource_klass.new(@steve, nil)
+    expected_link = "#{ @base_url }/api_v2/people/#{ source.id }"
+
+    assert_equal expected_link, builder.self_link(source)
+  end
+
+  def test_self_link_with_engine_namespaced_app
     primary_resource_klass = MyEngine::Api::V1::PersonResource
 
     config = {
@@ -101,6 +126,19 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
     config = {
       base_url: @base_url,
       route_formatter: @route_formatter,
+      primary_resource_klass: ApiV2Engine::PersonResource
+    }
+
+    builder = JSONAPI::LinkBuilder.new(config)
+    expected_link = "#{ @base_url }/api_v2/people"
+
+    assert_equal expected_link, builder.primary_resources_url
+  end
+
+  def test_primary_resources_url_for_namespaced_engine
+    config = {
+      base_url: @base_url,
+      route_formatter: @route_formatter,
       primary_resource_klass: MyEngine::Api::V1::PersonResource
     }
 
@@ -127,6 +165,22 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
   end
 
   def test_relationships_self_link_for_engine
+    config = {
+      base_url: @base_url,
+      route_formatter: @route_formatter,
+      primary_resource_klass: ApiV2Engine::PersonResource
+    }
+
+    builder       = JSONAPI::LinkBuilder.new(config)
+    source        = ApiV2Engine::PersonResource.new(@steve, nil)
+    relationship  = JSONAPI::Relationship::ToMany.new("posts", {})
+    expected_link = "#{ @base_url }/api_v2/people/#{ @steve.id }/relationships/posts"
+
+    assert_equal expected_link,
+      builder.relationships_self_link(source, relationship)
+  end
+
+  def test_relationships_self_link_for_namespaced_engine
     config = {
       base_url: @base_url,
       route_formatter: @route_formatter,
@@ -159,6 +213,22 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
   end
 
   def test_relationships_related_link_for_engine
+    config = {
+      base_url: @base_url,
+      route_formatter: @route_formatter,
+      primary_resource_klass: ApiV2Engine::PersonResource
+    }
+
+    builder       = JSONAPI::LinkBuilder.new(config)
+    source        = ApiV2Engine::PersonResource.new(@steve, nil)
+    relationship  = JSONAPI::Relationship::ToMany.new("posts", {})
+    expected_link = "#{ @base_url }/api_v2/people/#{ @steve.id }/posts"
+
+    assert_equal expected_link,
+      builder.relationships_related_link(source, relationship)
+  end
+
+  def test_relationships_related_link_for_namespaced_engine
     config = {
       base_url: @base_url,
       route_formatter: @route_formatter,
@@ -234,6 +304,20 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
   end
 
   def test_query_link_for_engine
+    config = {
+      base_url: @base_url,
+      route_formatter: @route_formatter,
+      primary_resource_klass: ApiV2Engine::PersonResource
+    }
+
+    query         = { page: { offset: 0, limit: 12 } }
+    builder       = JSONAPI::LinkBuilder.new(config)
+    expected_link = "#{ @base_url }/api_v2/people?page%5Blimit%5D=12&page%5Boffset%5D=0"
+
+    assert_equal expected_link, builder.query_link(query)
+  end
+
+  def test_query_link_for_namespaced_engine
     config = {
       base_url: @base_url,
       route_formatter: @route_formatter,


### PR DESCRIPTION
The current rails engine code makes an assumption that you will always have additional namespaces under your main Engine. _This isn't the default behavior in rails_ and I found when experimenting with putting our v2 api into an engine that it wouldn't generate the paths properly.

The main fix is in link_builder to only generate the path with `end_path_name` instead of concating `base_path_name` with it (which would of course generate `_person_path`.)

Added to the engine tests to show that it was generating properly.
