### PR TITLE
Test for update_relationship to nil.

### DIFF
--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -1075,6 +1075,19 @@ class PostsControllerTest < ActionController::TestCase
     assert_equal ruby.id, post_object.section_id
   end
 
+  def test_update_relationship_to_one_nil
+    set_content_type_header!
+    ruby = Section.find_by(name: 'ruby')
+    post_object = Post.find(4)
+    assert_not_equal ruby.id, post_object.section_id
+
+    put :update_relationship, params: {post_id: 4, relationship: 'section', data: nil}
+
+    assert_response :no_content
+    post_object = Post.find(4)
+    assert_equal nil, post_object.section_id
+  end
+
   def test_update_relationship_to_one_invalid_links_hash_keys_ids
     set_content_type_header!
     put :update_relationship, params: {post_id: 3, relationship: 'section', data: {type: 'sections', ids: 'foo'}}

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -56,6 +56,7 @@ class TestApp < Rails::Application
   if Rails::VERSION::MAJOR >= 5
     config.active_support.halt_callback_chains_on_return_false = false
     config.active_record.time_zone_aware_types = [:time, :datetime]
+    config.active_record.belongs_to_required_by_default = false
   end
 end
 


### PR DESCRIPTION
Looks like we didn't have a test for setting relationships to `nil` (as opposed to setting the `id` to nil). This adds the passing test for completeness. 

Also set `config.active_record.belongs_to_required_by_default = false` in test config to be explicit with rails 5. See #812
