### PR TITLE
Fix nested resources creating N+1 queries on includes

### DIFF
--- a/lib/jsonapi/processor.rb
+++ b/lib/jsonapi/processor.rb
@@ -141,6 +141,7 @@ module JSONAPI
       source_id = params[:source_id]
       relationship_type = params[:relationship_type]
       filters = params[:filters]
+      include_directives = params[:include_directives]
       sort_criteria = params[:sort_criteria]
       paginator = params[:paginator]
       fields = params[:fields]
@@ -149,7 +150,8 @@ module JSONAPI
 
       related_resources = source_resource.public_send(relationship_type,
                                                       context: context,
-                                                      filters:  filters,
+                                                      filters: filters,
+                                                      include_directives: include_directives,
                                                       sort_criteria: sort_criteria,
                                                       paginator: paginator,
                                                       fields: fields)

--- a/lib/jsonapi/relationship_builder.rb
+++ b/lib/jsonapi/relationship_builder.rb
@@ -129,7 +129,9 @@ module JSONAPI
           records = resource_klass.apply_filters(records, filters, options)
         end
 
-        sort_criteria =  options.fetch(:sort_criteria, {})
+        records = resource_klass.apply_includes(records, options)
+
+        sort_criteria = options.fetch(:sort_criteria, {})
         unless sort_criteria.nil? || sort_criteria.empty?
           order_options = relationship.resource_klass.construct_order_options(sort_criteria)
           records = resource_klass.apply_sort(records, order_options, @context)


### PR DESCRIPTION
Added include_directives support to resource relationships to avoid N+1 queries from includes on a nested route.

I had a route of /resource1/:id/resource2?include=resource3 and noticed it was creating N+1 queries for each resource3 access.

I've patched JSONAPI::RelationshipBuilder.build_to_many to follow the same logic JSONAPI::Resource.find
