### PR TITLE
Removes ActiveRecord dependency for #model_hint

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -550,10 +550,9 @@ module JSONAPI
       end
 
       def model_hint(model: _model_name, resource: _type)
-        model_name = ((model.is_a?(Class)) && (model < ActiveRecord::Base)) ? model.name : model
         resource_type = ((resource.is_a?(Class)) && (resource < JSONAPI::Resource)) ? resource._type : resource.to_s
 
-        _model_hints[model_name.to_s.gsub('::', '/').underscore] = resource_type.to_s
+        _model_hints[model.to_s.gsub('::', '/').underscore] = resource_type.to_s
       end
 
       def filters(*attrs)


### PR DESCRIPTION
Class.name is the same as Class.to_s

I don't see a particular reason to have the AR dependency here. Missing something?
