### PR TITLE
Add note clarifying context hash usage when passing resources through the ResourceSerializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1495,6 +1495,15 @@ post = Post.find(1)
 JSONAPI::ResourceSerializer.new(PostResource).serialize_to_hash(PostResource.new(post, nil))
 ```
 
+Note: If your resource needs to access to state from a context hash, make sure to pass the context hash as the second argument of
+the resource class new method. For example:
+
+```ruby
+post = Post.find(1)
+context = { current_user: current_user }
+JSONAPI::ResourceSerializer.new(PostResource).serialize_to_hash(PostResource.new(post, context))
+```
+
 This returns results like this:
 
 ```json


### PR DESCRIPTION
**Description:**
I found the documentation to be lacking in explaining how context is passed in when using the ResourceSerializer. 

Only after playing around with the ResourceSerializer for some time that I found that the second argument for initializing a resource was the context itself. In the documentation, this second argument was simply `nil` without explanation that this was actually the context the resource initializes with:
`JSONAPI::ResourceSerializer.new(PostResource).serialize_to_hash(PostResource.new(post, nil))`

**Changes Proposed:**
- Add a note clarifying how to pass in a context hash when using the ResourceSerializer.
- Add a code example that shows how it works, building on top of the first example, which leads into the results in the ResourceSerializer section below it.

Hopefully this will help newcomers who might need context for their resource while using ResourceSerializers. Hope this helps @lgebhardt!
