### PR TITLE
Fix code example for relationship specific method definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -735,11 +735,13 @@ class PostResource < JSONAPI::Resource
   has_many :comments
 
   # def record_for_author
+  #   relationship = self.class._relationship(:author)
   #   relation_name = relationship.relation_name(context: @context)
   #   records_for(relation_name)
   # end
 
   # def records_for_comments
+  #   relationship = self.class._relationship(:comments)
   #   relation_name = relationship.relation_name(context: @context)
   #   records_for(relation_name)
   # end


### PR DESCRIPTION
There is no such method or variable as `relationship` defined in the
special record_for_#{relationship} method. For the commented-out code
to actually work, we first need to fetch the relationship object before
we can ask for the relation name.

We could also discuss whether these special methods could somehow also have the `relationship` already available to them, so that changes like these wouldn't be necessary.
