### PR TITLE
Don't call link_builder when custom link is provided

### DIFF
--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -230,9 +230,9 @@ module JSONAPI
     end
 
     def links_hash(source)
-      {
-        self: link_builder.self_link(source)
-      }.merge(custom_links_hash(source)).compact
+      links = custom_links_hash(source)
+      links[:self] = link_builder.self_link(source) unless links.key?(:self)
+      links.compact
     end
 
     def custom_links_hash(source)


### PR DESCRIPTION
So I wan't to override `self` link using `custom_links` (make it nil since I don't need it for embedded relationship). However, for current implementation link builder is being called anyway and I need to define route which is never used, and it make the serialization slower as the route generation is not the fastest thing in rails.
