### PR TITLE
Improve Filter docs on apply/verify + correct simple example + add a practical complex example

### DIFF
--- a/README.md
+++ b/README.md
@@ -654,10 +654,10 @@ You may customize how a filter behaves by supplying a callable to the `:apply` o
 apply that filter. The callable is passed the `records`, which is an `ActiveRecord::Relation`, the `value`, and an
 `_options` hash. It is expected to return an `ActiveRecord::Relation`.
 
-This example shows how you can implement different approaches for different filters.
-
 Note: When a filter is not supplied a `verify` callable to modify the `value` that the `apply` callable receives,
 `value` defaults to an array of the string values provided to the filter parameter.
+
+This example shows how you can implement different approaches for different filters.
 
 ```ruby
 # When given the following parameter:'filter[visibility]': 'public'

--- a/README.md
+++ b/README.md
@@ -656,9 +656,14 @@ apply that filter. The callable is passed the `records`, which is an `ActiveReco
 
 This example shows how you can implement different approaches for different filters.
 
+Note: When a filter is not supplied a `verify` callable to modify the `value` that the `apply callable recieves,
+`value` defaults to an array of the string values provided to the filter parameter.
+
 ```ruby
+# When given the following parameter:'filter[visibility]': 'public'
+
 filter :visibility, apply: ->(records, value, _options) {
-  records.where('users.publicly_visible = ?', value == :public)
+  records.where('users.publicly_visible = ?', value[0] == 'public')
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -697,13 +697,13 @@ verified value, which may be modified.
 
 ```ruby
   filter :ids,
-         verify: ->(values, context) {
-           verify_keys(values, context)
-           return values
-         },
-         apply: -> (records, value, _options) {
-           records.where('id IN (?)', value)
-         }
+    verify: ->(values, context) {
+      verify_keys(values, context)
+      return values
+    },
+    apply: -> (records, value, _options) {
+      records.where('id IN (?)', value)
+    }
 ```
 
 ##### Finders

--- a/README.md
+++ b/README.md
@@ -656,7 +656,7 @@ apply that filter. The callable is passed the `records`, which is an `ActiveReco
 
 This example shows how you can implement different approaches for different filters.
 
-Note: When a filter is not supplied a `verify` callable to modify the `value` that the `apply callable recieves,
+Note: When a filter is not supplied a `verify` callable to modify the `value` that the `apply` callable receives,
 `value` defaults to an array of the string values provided to the filter parameter.
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -679,12 +679,12 @@ def self.apply_filter(records, filter, value, options)
         value.each do |val|
           records = records.where(_model_class.arel_table[filter].matches(val))
         end
-        return records
+        records
       else
         records.where(_model_class.arel_table[filter].matches(value))
       end
     else
-      return super(records, filter, value)
+      super(records, filter, value)
   end
 end
 ```
@@ -699,7 +699,7 @@ verified value, which may be modified.
   filter :ids,
     verify: ->(values, context) {
       verify_keys(values, context)
-      return values
+      values
     },
     apply: ->(records, value, _options) {
       records.where('id IN (?)', value)
@@ -837,12 +837,12 @@ def self.apply_filter(records, filter, value, options)
         value.each do |val|
           records = records.where(_model_class.arel_table[filter].matches(val))
         end
-        return records
+        records
       else
         records.where(_model_class.arel_table[filter].matches(value))
       end
     else
-      return super(records, filter, value)
+      super(records, filter, value)
   end
 end
 ```

--- a/README.md
+++ b/README.md
@@ -701,8 +701,21 @@ verified value, which may be modified.
       verify_keys(values, context)
       return values
     },
-    apply: -> (records, value, _options) {
+    apply: ->(records, value, _options) {
       records.where('id IN (?)', value)
+    }
+```
+
+```ruby
+# A more complex example, showing how to filter for any overlap between the
+# value array and the possible_ids, using both verify and apply callables.
+
+  filter :possible_ids,
+    verify: ->(values, context) {
+      values.map {|value| value.to_i}
+    },
+    apply: ->(records, value, _options) {
+      records.where('possible_ids && ARRAY[?]', value)
     }
 ```
 


### PR DESCRIPTION
**Description**
The _filter_ section in the documentation is lacking in describing what `value` is for newcomers who want to `apply` a custom filter. It's easy for newcomers to assume that `value` is the string value of the query param of the filter, when it is actually the array of string params by default (if not provided a `verify` callable). 

The example also confuses this distinction too, by comparing the value to the symbol `:public` - where `value` would actually be an array of `['public']`, since there is no `verify` callable to modify `value`.

**Changes Proposed:**
- Add clarifying note describing what `value` is to educate newcomers.
- Simplify the example by providing the query param in comments and explicitly using the `apply` callable in the default case with a `value` array without a `verify` callable.
- Add a more complex example that combines both `verify` and `apply` callables to show how to use them in actual practice.
