### PR TITLE
Fix detecting resource class

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -433,6 +433,7 @@ module JSONAPI
       end
 
       def resource_for(type)
+        type = type.underscore
         type_with_module = type.include?('/') ? type : module_path + type
 
         resource_name = _resource_name_from_type(type_with_module)

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -125,19 +125,22 @@ class ResourceTest < ActiveSupport::TestCase
     end
   end
 
-  def test_resource_for_with_namespaced_paths
+  def test_resource_for_resource_does_not_exist_at_root
+    assert_raises NameError do
+      ArticleResource.resource_for('related')
+    end
+  end
+
+  def test_resource_for_with_underscored_namespaced_paths
     assert_equal(JSONAPI::Resource.resource_for('my_module/related'), MyModule::RelatedResource)
     assert_equal(PostResource.resource_for('my_module/related'), MyModule::RelatedResource)
     assert_equal(MyModule::MyNamespacedResource.resource_for('my_module/related'), MyModule::RelatedResource)
   end
 
-  def test_resource_for_resource_does_not_exist_at_root
-    assert_raises NameError do
-      ArticleResource.resource_for('related')
-    end
-    assert_raises NameError do
-      JSONAPI::Resource.resource_for('related')
-    end
+  def test_resource_for_with_camelized_namespaced_paths
+    assert_equal(JSONAPI::Resource.resource_for('MyModule::Related'), MyModule::RelatedResource)
+    assert_equal(PostResource.resource_for('MyModule::Related'), MyModule::RelatedResource)
+    assert_equal(MyModule::MyNamespacedResource.resource_for('MyModule::Related'), MyModule::RelatedResource)
   end
 
   def test_resource_for_namespaced_resource


### PR DESCRIPTION
`JSONAPI::Resource.resource_for` can receive a camelized string (not the underscored), so checking for `/` presence doesn't work for such cases and string need to be underscored first.
