### PR TITLE
Add ::always_load to resources for eager loading.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ backed by ActiveRecord models or by custom objects.
     * [Filters] (#filters)
     * [Pagination] (#pagination)
     * [Included relationships (side-loading resources)] (#included-relationships-side-loading-resources)
+    * [Loaded relationships (eager-loading resources)] (#loaded-relationships-eager-loading-resources)
     * [Resource meta] (#resource-meta)
     * [Custom Links] (#custom-links)
     * [Callbacks] (#callbacks)
@@ -1034,6 +1035,40 @@ Will get you the following payload by default:
     }
   }]
 }
+```
+
+#### Loaded relationships (eager-loading resources)
+
+To avoid N+1 queries when a resource attribute relies on attributes of related model records to calculate it `always_load` can be used. [Included relationships](#included-relationships-side-loading-resources) have their `always_load` relationships loaded.
+
+```ruby
+class CompanyResource
+  attribute :plan_start_at
+
+  always_load :subscription
+
+  def plan_start_at
+    @model.subscription.created_at
+  end
+end
+```
+
+Nested records to eager load can be declared.
+
+```ruby
+class CompanyResource
+  attribute :plan_start_at
+
+  always_load subscription: [:settings]
+
+  def plan_start_at
+    @model.subscription.created_at
+  end
+
+  def needs_tokens
+    @model.subscription.settings.needs_tokens
+  end
+end
 ```
 
 #### Resource Meta

--- a/lib/jsonapi/processor.rb
+++ b/lib/jsonapi/processor.rb
@@ -148,7 +148,7 @@ module JSONAPI
       fields = params[:fields]
 
       # TODO Should fetch related_resource from cache if caching enabled
-      source_resource = source_klass.find_by_key(source_id, context: context, fields: fields)
+      source_resource = source_klass.find_by_key(source_id, context: context, fields: fields, relationship_type: relationship_type)
 
       related_resource = source_resource.public_send(relationship_type)
 
@@ -165,7 +165,7 @@ module JSONAPI
       fields = params[:fields]
       include_directives = params[:include_directives]
 
-      source_resource ||= source_klass.find_by_key(source_id, context: context, fields: fields)
+      source_resource ||= source_klass.find_by_key(source_id, context: context, fields: fields, relationship_type: relationship_type)
 
       rel_opts = {
         filters:  filters,

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -630,6 +630,8 @@ module JSONAPI
         else
           nil
         end
+      rescue NameError => ex
+        nil
       end
 
       def resolve_always_includes(resource_klass, model_includes, options = {}, seen = [])

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -670,7 +670,16 @@ module JSONAPI
         model_includes = model_includes(options)
         first_level_includes = model_includes.map{ |inc| inc.try(:keys) || inc }.flatten
         includes = model_includes + ( always_includes - first_level_includes )
-        resolve_always_includes(self, includes, options)
+        includes = resolve_always_includes(self, includes, options)
+        filter_for_relationship_type(includes, options)
+      end
+
+      def filter_for_relationship_type(includes, options)
+        if options[:relationship_type].present?
+          includes.select{|v| (v.try(:keys).try(:first) || v) == options[:relationship_type] }
+        else
+          includes
+        end
       end
 
       def apply_includes(records, options = {})

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -98,7 +98,7 @@ module MyAPI
   end
 end
 
-class AlwaysIncludeTest < ActiveSupport::TestCase
+class AlwaysIncludeTests < ActiveSupport::TestCase
   module Ai
     class PersonResource < ::PersonResource
       always_include :hair_cut, :comments
@@ -121,6 +121,7 @@ class AlwaysIncludeTest < ActiveSupport::TestCase
     end
 
     class SectionResource < ::SectionResource
+
     end
   end
 
@@ -168,7 +169,7 @@ class AlwaysIncludeTest < ActiveSupport::TestCase
   end
 end
 
-class AlwayIncludeCircularTest < ActiveSupport::TestCase
+class AlwayIncludeCircularTests < ActiveSupport::TestCase
   module Circular
     class PersonResource < ::PersonResource
       always_include :comments
@@ -191,6 +192,19 @@ class AlwayIncludeCircularTest < ActiveSupport::TestCase
     expected = [{comments: [{tags: [{posts: [:comments]}]}]}]
     result = JSONAPI::Resource.resolve_always_includes(Circular::PersonResource, [:comments])
     assert_equal(expected, result)
+  end
+end
+
+class AlwaysIncludeNoResourceTest < ActiveSupport::TestCase
+  module NoResource
+    class MoonResource < ::MoonResource
+      always_include :craters
+    end
+  end
+
+  def test_always_include_no_resource_no_error_raised
+    result = JSONAPI::Resource.resolve_always_includes(NoResource::MoonResource, [:craters])
+    assert_equal([:craters], result)
   end
 end
 

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -167,6 +167,14 @@ class AlwaysIncludeTests < ActiveSupport::TestCase
     result = Ai::PersonResource.get_includes(include_directives: include_directive)
     assert_equal(expected, result)
   end
+
+  def test_get_includes_for_relationship
+    include_directive = JSONAPI::IncludeDirectives.new(Ai::PersonResource, ['comments.tags', 'posts.section'])
+    expected = [{comments: [{tags: [:posts]}]}]
+
+    result = Ai::PersonResource.get_includes(include_directives: include_directive, relationship_type: :comments)
+    assert_equal(expected, result)
+  end
 end
 
 class AlwayIncludeCircularTests < ActiveSupport::TestCase

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -98,32 +98,31 @@ module MyAPI
   end
 end
 
-module Ai
-  class PersonResource < ::PersonResource
-    always_include :hair_cut, :comments
-  end
-
-  class CommentResource < ::CommentResource
-  end
-
-  class TagResource < ::TagResource
-    always_include :posts
-  end
-
-  class PostResource < ::PostResource
-  end
-
-  class VehicleResource < ::VehicleResource
-  end
-
-  class HairCutResource < ::HairCutResource
-  end
-
-  class SectionResource < ::SectionResource
-  end
-end
-
 class AlwaysIncludeTest < ActiveSupport::TestCase
+  module Ai
+    class PersonResource < ::PersonResource
+      always_include :hair_cut, :comments
+    end
+
+    class CommentResource < ::CommentResource
+    end
+
+    class TagResource < ::TagResource
+      always_include :posts
+    end
+
+    class PostResource < ::PostResource
+    end
+
+    class VehicleResource < ::VehicleResource
+    end
+
+    class HairCutResource < ::HairCutResource
+    end
+
+    class SectionResource < ::SectionResource
+    end
+  end
 
   def test_always_includes
     assert_equal([:hair_cut, :comments], Ai::PersonResource.always_includes)
@@ -165,6 +164,32 @@ class AlwaysIncludeTest < ActiveSupport::TestCase
     expected = [{comments: [{tags: [:posts]}]}, {posts: [:section]}, :hair_cut]
 
     result = Ai::PersonResource.get_includes(include_directives: include_directive)
+    assert_equal(expected, result)
+  end
+end
+
+class AlwayIncludeCircularTest < ActiveSupport::TestCase
+  module Circular
+    class PersonResource < ::PersonResource
+      always_include :comments
+    end
+
+    class CommentResource < ::CommentResource
+      always_include :tags
+    end
+
+    class TagResource < ::TagResource
+      always_include :posts
+    end
+
+    class PostResource < ::PostResource
+      always_include :comments
+    end
+  end
+
+  def test_always_includes_circular
+    expected = [{comments: [{tags: [{posts: [:comments]}]}]}]
+    result = JSONAPI::Resource.resolve_always_includes(Circular::PersonResource, [:comments])
     assert_equal(expected, result)
   end
 end

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -101,14 +101,14 @@ end
 class AlwaysIncludeTests < ActiveSupport::TestCase
   module Ai
     class PersonResource < ::PersonResource
-      always_include :hair_cut, :comments
+      always_load :hair_cut, :comments
     end
 
     class CommentResource < ::CommentResource
     end
 
     class TagResource < ::TagResource
-      always_include :posts
+      always_load :posts
     end
 
     class PostResource < ::PostResource
@@ -125,67 +125,67 @@ class AlwaysIncludeTests < ActiveSupport::TestCase
     end
   end
 
-  def test_always_includes
-    assert_equal([:hair_cut, :comments], Ai::PersonResource.always_includes)
+  def test_always_loads
+    assert_equal([:hair_cut, :comments], Ai::PersonResource.always_loads)
   end
 
-  def test_resolve_always_includes
-    result = JSONAPI::Resource.resolve_always_includes(Ai::PersonResource, [:vehicles, :comments])
+  def test_resolve_always_loads
+    result = JSONAPI::Resource.resolve_always_loads(Ai::PersonResource, [:vehicles, :comments])
     assert_equal([:vehicles, :comments], result)
   end
 
-  def test_resolve_always_includes_nested
+  def test_resolve_always_loads_nested
     expected = {comments: [{tags: [:posts]}]}
 
-    result = JSONAPI::Resource.resolve_always_includes(Ai::PersonResource, comments: [:tags])
+    result = JSONAPI::Resource.resolve_always_loads(Ai::PersonResource, comments: [:tags])
     assert_equal(expected, result)
 
-    result = JSONAPI::Resource.resolve_always_includes(Ai::PersonResource, comments: [{tags: [:posts]}])
+    result = JSONAPI::Resource.resolve_always_loads(Ai::PersonResource, comments: [{tags: [:posts]}])
     assert_equal(expected, result)
   end
 
-  def test_get_includes
+  def test_get_loads
     include_directive = JSONAPI::IncludeDirectives.new(Ai::PersonResource, ['comments'])
     expected = [:hair_cut, :comments]
 
-    result = Ai::PersonResource.get_includes(include_directives: include_directive)
+    result = Ai::PersonResource.get_loads(include_directives: include_directive)
     assert_equal(expected, result)
   end
 
-  def test_get_includes_again
-     include_directive = JSONAPI::IncludeDirectives.new(Ai::PersonResource, ['comments.tags', 'posts.section'])
-    expected = [:hair_cut, {comments: [{tags: [:posts]}], posts: [:section]}]
-
-    result = Ai::PersonResource.get_includes(include_directives: include_directive)
-    assert_equal(expected, result)
-  end
-
-  def test_get_includes_nested
-    include_directive = JSONAPI::IncludeDirectives.new(Ai::PersonResource, ['comments.tags'])
-    expected = [:hair_cut, {comments: [{tags: [:posts]}]}]
-
-    result = Ai::PersonResource.get_includes(include_directives: include_directive)
-    assert_equal(expected, result)
-  end
-
-  def test_get_includes_nested_more_complex
+  def test_get_loads_again
     include_directive = JSONAPI::IncludeDirectives.new(Ai::PersonResource, ['comments.tags', 'posts.section'])
     expected = [:hair_cut, {comments: [{tags: [:posts]}], posts: [:section]}]
 
-    result = Ai::PersonResource.get_includes(include_directives: include_directive)
+    result = Ai::PersonResource.get_loads(include_directives: include_directive)
     assert_equal(expected, result)
   end
 
-  def test_normalize_includes
-    result = JSONAPI::Resource.normalize_includes([{comments: [{tags: [:posts]}]}, {posts: [:section]}, :hair_cut])
+  def test_get_loads_nested
+    include_directive = JSONAPI::IncludeDirectives.new(Ai::PersonResource, ['comments.tags'])
+    expected = [:hair_cut, {comments: [{tags: [:posts]}]}]
+
+    result = Ai::PersonResource.get_loads(include_directives: include_directive)
+    assert_equal(expected, result)
+  end
+
+  def test_get_loads_nested_more_complex
+    include_directive = JSONAPI::IncludeDirectives.new(Ai::PersonResource, ['comments.tags', 'posts.section'])
+    expected = [:hair_cut, {comments: [{tags: [:posts]}], posts: [:section]}]
+
+    result = Ai::PersonResource.get_loads(include_directives: include_directive)
+    assert_equal(expected, result)
+  end
+
+  def test_normalize_loads
+    result = JSONAPI::Resource.normalize_loads([{comments: [{tags: [:posts]}]}, {posts: [:section]}, :hair_cut])
     assert_equal([:hair_cut, {comments: [{tags: [:posts]}], posts: [:section]}], result)
   end
 
-  def test_merge_includes
-    includes_a = [:hair_cut, {comments: [{tags: [:posts]}]}, :posts]
-    includes_b = [{comments: :tags, posts: [:section]}, :hair_cut]
+  def test_merge_loads
+    loads_a = [:hair_cut, {comments: [{tags: [:posts]}]}, :posts]
+    loads_b = [{comments: :tags, posts: [:section]}, :hair_cut]
     expected = [:hair_cut, {comments: [{tags: [:posts]}], posts: [:section]}]
-    result = JSONAPI::Resource.merge_includes(includes_a, includes_b)
+    result = JSONAPI::Resource.merge_loads(loads_a, loads_b)
     assert_equal(expected, result)
   end
 end
@@ -193,14 +193,14 @@ end
 class AlwaysIncludeRelationshipTest < ActiveSupport::TestCase
   module AiRel
     class PersonResource < ::PersonResource
-      always_include :hair_cut, :comments
+      always_load :hair_cut, :comments
     end
 
     class CommentResource < ::CommentResource
     end
 
     class TagResource < ::TagResource
-      always_include posts: [:section]
+      always_load posts: [:section]
     end
 
     class PostResource < ::PostResource
@@ -210,27 +210,27 @@ class AlwaysIncludeRelationshipTest < ActiveSupport::TestCase
     end
   end
 
-  def test_get_includes_for_relationship
+  def test_get_loads_for_relationship
     include_directive = JSONAPI::IncludeDirectives.new(AiRel::PersonResource, ['comments.tags', 'posts.section'])
     expected = [{comments: [{tags: [{posts: [:section]}]}]}]
 
-    result = AiRel::PersonResource.get_includes(include_directives: include_directive, relationship_type: :comments)
+    result = AiRel::PersonResource.get_loads(include_directives: include_directive, relationship_type: :comments)
     assert_equal(expected, result)
   end
 
-  def test_get_includes_for_relationship_2
+  def test_get_loads_for_relationship_2
     include_directive = JSONAPI::IncludeDirectives.new(AiRel::PersonResource, ['posts.section'])
     expected = [:comments]
 
-    result = AiRel::PersonResource.get_includes(include_directives: include_directive, relationship_type: :comments)
+    result = AiRel::PersonResource.get_loads(include_directives: include_directive, relationship_type: :comments)
     assert_equal(expected, result)
   end
 
-  def test_get_include_for_relationship_no_model_includes
+  def test_get_loads_for_relationship_no_model_includes
     include_directive = JSONAPI::IncludeDirectives.new(AiRel::CommentResource, ['post'])
     expected = [{tags: [{posts: [:section]}]}]
 
-    result = AiRel::CommentResource.get_includes(include_directives: include_directive, relationship_type: :tags)
+    result = AiRel::CommentResource.get_loads(include_directives: include_directive, relationship_type: :tags)
     assert_equal(expected, result)
   end
 end
@@ -238,12 +238,12 @@ end
 class AlwaysIncludeNoResourceTest < ActiveSupport::TestCase
   module NoResource
     class MoonResource < ::MoonResource
-      always_include :craters
+      always_load :craters
     end
   end
 
   def test_always_include_no_resource_no_error_raised
-    result = JSONAPI::Resource.resolve_always_includes(NoResource::MoonResource, [:craters])
+    result = JSONAPI::Resource.resolve_always_loads(NoResource::MoonResource, [:craters])
     assert_equal([:craters], result)
   end
 end


### PR DESCRIPTION
Enables resources to be defined with `always_includes` for eager loading. e.g.

```
class TagResource < JSONAPI::Resource  
  always_include posts: [:section]
  has_many :posts
end

class PostResource < JSONAPI::Resource
  has_one :section
  has_many :tags, acts_as_set: true, inverse_relationship: :posts, eager_load_on_include: false
end

class SectionResource < JSONAPI::Resource
  has_many :posts
end
```

Normalize and merge the model includes and always includes, iterate over the model includes and merge their always includes. The model and always includes can both be nested.

See #485
