### PR TITLE
Remove rails 4.1 build env from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 sudo: false
 env:
-  - "RAILS_VERSION=4.1.0"
   - "RAILS_VERSION=4.2.6"
   - "RAILS_VERSION=5.0.0"
 rvm:


### PR DESCRIPTION
Test suite passing for 5.0 and 4.2 but is failing on rails 4.1. 4.1 is
[no longer officially supported](http://rubyonrails.org/security/) and
[isn't supported by railslts](https://railslts.com/). No unpatched
[secuirty vunrebilities
reported](https://groups.google.com/forum/#!forum/rubyonrails-security)
yet but it's just a matter of time.
