### PR TITLE
Update minimum required Ruby version.

### DIFF
--- a/jsonapi-resources.gemspec
+++ b/jsonapi-resources.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.0'
+  spec.required_ruby_version = '>= 2.1'
 
   spec.add_development_dependency 'bundler', '~> 1.5'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
According to issue #774, Ruby 2.0 appears to be no longer supported by this project. This is change is just to update the gemspec, so nobody accidentally installs it into a legacy project.
