### PR TITLE
Drop support for rails 4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 sudo: false
 env:
-  - "RAILS_VERSION=4.1.0"
   - "RAILS_VERSION=4.2.6"
   - "RAILS_VERSION=5.0.0"
 rvm:

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ when 'master'
   gem 'rails', { git: 'https://github.com/rails/rails.git' }
   gem 'arel', { git: 'https://github.com/rails/arel.git' }
 when 'default'
-  gem 'rails', '>= 4.2'
+  gem 'rails', '>= 5.0'
 else
   gem 'rails', "~> #{version}"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,8 +7,8 @@ require 'simplecov'
 # export RAILS_VERSION=4.2.6; bundle update rails; bundle exec rake test
 # export RAILS_VERSION=5.0.0; bundle update rails; bundle exec rake test
 
-# We are no longer having Travis test Rails 4.0.x., but you can try it with:
-# export RAILS_VERSION=4.0.0; bundle update rails; bundle exec rake test
+# We are no longer having Travis test Rails 4.1.x., but you can try it with:
+# export RAILS_VERSION=4.1.0; bundle update rails; bundle exec rake test
 
 # To Switch rails versions and run a particular test order:
 # export RAILS_VERSION=4.2.6; bundle update rails; bundle exec rake TESTOPTS="--seed=39333" test


### PR DESCRIPTION
With the release of Rails 5 version 4.1 has reached it's end-of-life and is no longer supported. http://weblog.rubyonrails.org/2016/6/30/Rails-5-0-final/

I'd like to drop support for Rails 4.1 as it adds testing complexity, time, and minor issues crop up that we need to work around.
