### PR TITLE
update version to 0.8.0

### DIFF
--- a/lib/jsonapi/resources/version.rb
+++ b/lib/jsonapi/resources/version.rb
@@ -1,5 +1,5 @@
 module JSONAPI
   module Resources
-    VERSION = '0.7.0'
+    VERSION = '0.8.0'
   end
 end


### PR DESCRIPTION
The version used in the master branch should be `0.8.0` to properly resolve dependencies, e.g. `jsonapi-utils`.
