### PR TITLE
Release 0.8 backport fixes

### DIFF
--- a/lib/jsonapi/link_builder.rb
+++ b/lib/jsonapi/link_builder.rb
@@ -95,7 +95,12 @@ module JSONAPI
       scopes         = module_scopes_from_class(klass)[1..-1]
       base_path_name = scopes.map { |scope| scope.underscore }.join("_")
       end_path_name  = klass._type.to_s
-      "#{ base_path_name }_#{ end_path_name }_path"
+
+      if base_path_name.blank?
+        "#{ end_path_name }_path"
+      else
+        "#{ base_path_name }_#{ end_path_name }_path"
+      end
     end
 
     def format_route(route)

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -539,10 +539,9 @@ module JSONAPI
       end
 
       def model_hint(model: _model_name, resource: _type)
-        model_name = ((model.is_a?(Class)) && (model < ActiveRecord::Base)) ? model.name : model
         resource_type = ((resource.is_a?(Class)) && (resource < JSONAPI::Resource)) ? resource._type : resource.to_s
 
-        _model_hints[model_name.to_s.gsub('::', '/').underscore] = resource_type.to_s
+        _model_hints[model.to_s.gsub('::', '/').underscore] = resource_type.to_s
       end
 
       def filters(*attrs)

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -423,6 +423,7 @@ module JSONAPI
       end
 
       def resource_for(type)
+        type = type.underscore
         type_with_module = type.include?('/') ? type : module_path + type
 
         resource_name = _resource_name_from_type(type_with_module)

--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -171,9 +171,9 @@ module JSONAPI
     end
 
     def links_hash(source)
-      {
-        self: link_builder.self_link(source)
-      }.merge(custom_links_hash(source)).compact
+      links = custom_links_hash(source)
+      links[:self] = link_builder.self_link(source) unless links.key?(:self)
+      links.compact
     end
 
     def custom_links_hash(source)

--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -247,16 +247,12 @@ module JSONAPI
     end
 
     def to_one_linkage(source, relationship)
-      linkage = {}
-      linkage_id = foreign_key_value(source, relationship)
-
-      if linkage_id
-        linkage[:type] = format_key(relationship.type_for_source(source))
-        linkage[:id] = linkage_id
-      else
-        linkage = nil
-      end
-      linkage
+      return unless linkage_id = foreign_key_value(source, relationship)
+      return unless linkage_type = format_key(relationship.type_for_source(source))
+      {
+        type: linkage_type,
+        id: linkage_id,
+      }
     end
 
     def to_many_linkage(source, relationship)
@@ -264,7 +260,9 @@ module JSONAPI
       linkage_types_and_values = foreign_key_types_and_values(source, relationship)
 
       linkage_types_and_values.each do |type, value|
-        linkage.append({type: format_key(type), id: value})
+        if type && value
+          linkage.append({type: format_key(type), id: @id_formatter.format(value)})
+        end
       end
       linkage
     end

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -1652,6 +1652,11 @@ module MyEngine
   end
 end
 
+module ApiV2Engine
+  class PersonResource < JSONAPI::Resource
+  end
+end
+
 module Legacy
   class FlatPost < ActiveRecord::Base
     self.table_name = "posts"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -67,6 +67,12 @@ module MyEngine
   end
 end
 
+module ApiV2Engine
+  class Engine < ::Rails::Engine
+    isolate_namespace ApiV2Engine
+  end
+end
+
 # Patch RAILS 4.0 to not use millisecond precision
 if Rails::VERSION::MAJOR >= 4 && Rails::VERSION::MINOR < 1
   module ActiveSupport
@@ -389,6 +395,7 @@ TestApp.routes.draw do
   end
 
   mount MyEngine::Engine => "/boomshaka", as: :my_engine
+  mount ApiV2Engine::Engine => "/api_v2", as: :api_v2_engine
 end
 
 MyEngine::Engine.routes.draw do
@@ -409,6 +416,10 @@ MyEngine::Engine.routes.draw do
       jsonapi_resources :people
     end
   end
+end
+
+ApiV2Engine::Engine.routes.draw do
+  jsonapi_resources :people
 end
 
 # Ensure backward compatibility with Minitest 4

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -125,19 +125,22 @@ class ResourceTest < ActiveSupport::TestCase
     end
   end
 
-  def test_resource_for_with_namespaced_paths
+  def test_resource_for_resource_does_not_exist_at_root
+    assert_raises NameError do
+      ArticleResource.resource_for('related')
+    end
+  end
+
+  def test_resource_for_with_underscored_namespaced_paths
     assert_equal(JSONAPI::Resource.resource_for('my_module/related'), MyModule::RelatedResource)
     assert_equal(PostResource.resource_for('my_module/related'), MyModule::RelatedResource)
     assert_equal(MyModule::MyNamespacedResource.resource_for('my_module/related'), MyModule::RelatedResource)
   end
 
-  def test_resource_for_resource_does_not_exist_at_root
-    assert_raises NameError do
-      ArticleResource.resource_for('related')
-    end
-    assert_raises NameError do
-      JSONAPI::Resource.resource_for('related')
-    end
+  def test_resource_for_with_camelized_namespaced_paths
+    assert_equal(JSONAPI::Resource.resource_for('MyModule::Related'), MyModule::RelatedResource)
+    assert_equal(PostResource.resource_for('MyModule::Related'), MyModule::RelatedResource)
+    assert_equal(MyModule::MyNamespacedResource.resource_for('MyModule::Related'), MyModule::RelatedResource)
   end
 
   def test_resource_for_namespaced_resource

--- a/test/unit/serializer/link_builder_test.rb
+++ b/test/unit/serializer/link_builder_test.rb
@@ -19,6 +19,10 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
       primary_resource_klass: MyEngine::Api::V1::PersonResource
     ).engine?, "MyEngine should be considered an Engine"
 
+    assert JSONAPI::LinkBuilder.new(
+      primary_resource_klass: ApiV2Engine::PersonResource
+    ).engine?, "ApiV2 shouldn't be considered an Engine"
+
     refute JSONAPI::LinkBuilder.new(
       primary_resource_klass: Api::V1::PersonResource
     ).engine?, "Api shouldn't be considered an Engine"
@@ -28,6 +32,11 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
     assert_equal MyEngine::Engine,
       JSONAPI::LinkBuilder.new(
         primary_resource_klass: MyEngine::Api::V1::PersonResource
+    ).engine_name
+
+    assert_equal ApiV2Engine::Engine,
+      JSONAPI::LinkBuilder.new(
+        primary_resource_klass: ApiV2Engine::PersonResource
     ).engine_name
 
     assert_equal nil,
@@ -53,6 +62,22 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
   end
 
   def test_self_link_with_engine_app
+    primary_resource_klass = ApiV2Engine::PersonResource
+
+    config = {
+      base_url: @base_url,
+      route_formatter: @route_formatter,
+      primary_resource_klass: primary_resource_klass,
+    }
+
+    builder = JSONAPI::LinkBuilder.new(config)
+    source  = primary_resource_klass.new(@steve, nil)
+    expected_link = "#{ @base_url }/api_v2/people/#{ source.id }"
+
+    assert_equal expected_link, builder.self_link(source)
+  end
+
+  def test_self_link_with_engine_namespaced_app
     primary_resource_klass = MyEngine::Api::V1::PersonResource
 
     config = {
@@ -101,6 +126,19 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
     config = {
       base_url: @base_url,
       route_formatter: @route_formatter,
+      primary_resource_klass: ApiV2Engine::PersonResource
+    }
+
+    builder = JSONAPI::LinkBuilder.new(config)
+    expected_link = "#{ @base_url }/api_v2/people"
+
+    assert_equal expected_link, builder.primary_resources_url
+  end
+
+  def test_primary_resources_url_for_namespaced_engine
+    config = {
+      base_url: @base_url,
+      route_formatter: @route_formatter,
       primary_resource_klass: MyEngine::Api::V1::PersonResource
     }
 
@@ -127,6 +165,22 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
   end
 
   def test_relationships_self_link_for_engine
+    config = {
+      base_url: @base_url,
+      route_formatter: @route_formatter,
+      primary_resource_klass: ApiV2Engine::PersonResource
+    }
+
+    builder       = JSONAPI::LinkBuilder.new(config)
+    source        = ApiV2Engine::PersonResource.new(@steve, nil)
+    relationship  = JSONAPI::Relationship::ToMany.new("posts", {})
+    expected_link = "#{ @base_url }/api_v2/people/#{ @steve.id }/relationships/posts"
+
+    assert_equal expected_link,
+      builder.relationships_self_link(source, relationship)
+  end
+
+  def test_relationships_self_link_for_namespaced_engine
     config = {
       base_url: @base_url,
       route_formatter: @route_formatter,
@@ -159,6 +213,22 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
   end
 
   def test_relationships_related_link_for_engine
+    config = {
+      base_url: @base_url,
+      route_formatter: @route_formatter,
+      primary_resource_klass: ApiV2Engine::PersonResource
+    }
+
+    builder       = JSONAPI::LinkBuilder.new(config)
+    source        = ApiV2Engine::PersonResource.new(@steve, nil)
+    relationship  = JSONAPI::Relationship::ToMany.new("posts", {})
+    expected_link = "#{ @base_url }/api_v2/people/#{ @steve.id }/posts"
+
+    assert_equal expected_link,
+      builder.relationships_related_link(source, relationship)
+  end
+
+  def test_relationships_related_link_for_namespaced_engine
     config = {
       base_url: @base_url,
       route_formatter: @route_formatter,
@@ -234,6 +304,20 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
   end
 
   def test_query_link_for_engine
+    config = {
+      base_url: @base_url,
+      route_formatter: @route_formatter,
+      primary_resource_klass: ApiV2Engine::PersonResource
+    }
+
+    query         = { page: { offset: 0, limit: 12 } }
+    builder       = JSONAPI::LinkBuilder.new(config)
+    expected_link = "#{ @base_url }/api_v2/people?page%5Blimit%5D=12&page%5Boffset%5D=0"
+
+    assert_equal expected_link, builder.query_link(query)
+  end
+
+  def test_query_link_for_namespaced_engine
     config = {
       base_url: @base_url,
       route_formatter: @route_formatter,


### PR DESCRIPTION
Backport fixes from master into 0.8 in prep for a 0.8.1 release.

Notably missing is c0e2f8d which will require a more in depth refactor due to significant changes between master and 0.8. I'm not sure if we should hold up 0.8.1 for c0e2f8d, which could go in a 0.8.2 release.

Fixes #862
