### PR TITLE
Allow for explicit resource_class on relationship definition

### DIFF
--- a/lib/jsonapi/relationship.rb
+++ b/lib/jsonapi/relationship.rb
@@ -23,7 +23,13 @@ module JSONAPI
     end
 
     def resource_klass
-      @resource_klass ||= @parent_resource.resource_for(@class_name)
+      @resource_klass ||=
+        begin
+          if options[:resource_class]
+            klass = options[:resource_class].safe_constantize
+          end
+          klass || @parent_resource.resource_for(@class_name)
+        end
     end
 
     def table_name

--- a/lib/jsonapi/routing_ext.rb
+++ b/lib/jsonapi/routing_ext.rb
@@ -215,7 +215,7 @@ module ActionDispatch
           if relationship.polymorphic?
             options[:controller] ||= relationship.class_name.underscore.pluralize
           else
-            related_resource = JSONAPI::Resource.resource_for(resource_type_with_module_prefix(relationship.class_name.underscore.pluralize))
+            related_resource = relationship.resource_klass
             options[:controller] ||= related_resource._type.to_s
           end
 
@@ -232,7 +232,7 @@ module ActionDispatch
           relationship = source._relationships[relationship_name]
 
           formatted_relationship_name = format_route(relationship.name)
-          related_resource = JSONAPI::Resource.resource_for(resource_type_with_module_prefix(relationship.class_name.underscore))
+          related_resource = relationship.resource_klass
           options[:controller] ||= related_resource._type.to_s
 
           match "#{formatted_relationship_name}", controller: options[:controller],

--- a/test/unit/resource/relationship_test.rb
+++ b/test/unit/resource/relationship_test.rb
@@ -1,5 +1,10 @@
 require File.expand_path('../../../test_helper', __FILE__)
 
+module Test
+  class ImageableResource
+  end
+end
+
 class HasOneRelationshipTest < ActiveSupport::TestCase
 
   def test_polymorphic_type
@@ -7,6 +12,14 @@ class HasOneRelationshipTest < ActiveSupport::TestCase
       polymorphic: true
     )
     assert_equal(relationship.polymorphic_type, "imageable_type")
+  end
+
+  def test_explicit_relationship_class
+    relationship = JSONAPI::Relationship::ToOne.new(
+      "imageable",
+      resource_class: 'Test::ImageableResource'
+    )
+    assert_equal(Test::ImageableResource, relationship.resource_klass)
   end
 
 end


### PR DESCRIPTION
Allow for an explicitly defined `resource_class` on a relationship.

The use case is with namespace models and flat resources:

``` ruby
class Namespace::Form < ActiveRecord::Base
end

class TestFormResource < ::JSONAPI::Resource
  has_one :parent
end

class ParentResource < ::JSONAPI::Resource
  has_many :test_forms, resource_class: 'TestFormResource'
end
```

I was not able to find a way to have a flattened Resource for a namespaced model. If I namespaced the resource and that had a relationship back to the parent it tried to put the parent in the namespace of the form.
