### PR TITLE
Loosen Accept header check to allow starts with :api_json

### DIFF
--- a/lib/jsonapi/acts_as_resource_controller.rb
+++ b/lib/jsonapi/acts_as_resource_controller.rb
@@ -162,9 +162,9 @@ module JSONAPI
       media_types = media_types_for('Accept')
 
       media_types.blank? ||
-          media_types.any? do |media_type|
-            (media_type == JSONAPI::MEDIA_TYPE || media_type == ALL_MEDIA_TYPES)
-          end
+        media_types.any? do |media_type|
+          (media_type == JSONAPI::MEDIA_TYPE || media_type.start_with?(ALL_MEDIA_TYPES))
+        end
     end
 
     def media_types_for(header)

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -56,6 +56,13 @@ class PostsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  def test_accept_header_all_modified
+    @request.headers['Accept'] = "*/*;q=0.8"
+
+    assert_cacheable_get :index
+    assert_response :success
+  end
+
   def test_accept_header_not_jsonapi
     @request.headers['Accept'] = 'text/plain'
 


### PR DESCRIPTION
- Allow the check for the Accept header to begin with `*/*` (All media types)
  - For example, `"*/*;q=0.8"`

Fixes #799
