### PR TITLE
Fix polymorphic type setter

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -324,7 +324,7 @@ module JSONAPI
       relationship = self.class._relationships[relationship_type.to_sym]
 
       _model.public_send("#{relationship.foreign_key}=", key_value)
-      _model.public_send("#{relationship.polymorphic_type}=", key_type.to_s.classify)
+      _model.public_send("#{relationship.polymorphic_type}=", _model_class_name(key_type))
 
       @save_needed = true
 
@@ -402,6 +402,12 @@ module JSONAPI
       end if field_data[:to_many]
 
       :completed
+    end
+
+    def _model_class_name(key_type)
+      type_class_name = key_type.to_s.classify
+      resource = self.class.resource_for(type_class_name)
+      resource ? resource._model_name.to_s : type_class_name
     end
 
     class << self

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -572,6 +572,9 @@ class Document < ActiveRecord::Base
   has_many :pictures, as: :imageable
 end
 
+class Document::Topic < Document
+end
+
 class Product < ActiveRecord::Base
   has_one :picture, as: :imageable
 end
@@ -1206,6 +1209,11 @@ end
 
 class DocumentResource < JSONAPI::Resource
   attribute :name
+  has_many :pictures
+end
+
+class TopicResource < JSONAPI::Resource
+  model_name 'Document::Topic'
   has_many :pictures
 end
 

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -205,6 +205,14 @@ class ResourceTest < ActiveSupport::TestCase
     assert_equal(relationships.size, 2)
   end
 
+  def test_replace_polymorphic_to_one_link
+    picture_resource = PictureResource.find_by_key(Picture.first)
+    picture_resource.replace_polymorphic_to_one_link('imageable', '9', 'Topic')
+
+    assert Picture.first.imageable_id == 9
+    assert Picture.first.imageable_type == Document::Topic.to_s
+  end
+
   def test_duplicate_relationship_name
     assert_output nil, "[DUPLICATE RELATIONSHIP] `mother` has already been defined in CatResource.\n" do
       CatResource.instance_eval do


### PR DESCRIPTION
Hey @lgebhardt!
We encounter a problem associated with the polymorphic relation. Here is an example in code:
## Setup

Models:

``` ruby
class Conversation < ActiveRecord::Base
  has_many :topics
end

class Account::Template < ActiveRecord::Base
  has_many :topics
end

class Topic < ActiveRecord::Base
  belongs_to :document, polymorphic: true
end
```

Resources:

``` ruby
class Template < JSONAPI::Resource
  model_name 'Account::Template'
  has_many :topics
end

class Topic < JSONAPI::Resource
  has_one :document, polymorphic: true
end
```
## Usage

Request: [ POST ] `/topics`

``` json
{
    "data": {
        "attributes": {
            "name": "Topic name",
        },
        "relationships": {
            "document": {
                "data": {
                    "type": "templates",
                    "id": "1"
                }
            },
        },
        "type": "topics"
    }
}
```
## Problem

Newly created topic has the wrong name of `document_type` filed.
After typing `topic.document_type` it was `Templates` but in fact, the polymorphic type should be taken from a model name and it should look like `Account::Template` because it's the real name of the resource's model's class name.
## Solution

I overwrite a method which assigns polymorphic type, and I created a method which looking for a real model class name of given relation's `key_type`.

I hope it will help :)
