### PR TITLE
Adding ability to use resource from other namespace

### DIFF
--- a/lib/jsonapi/acts_as_resource_controller.rb
+++ b/lib/jsonapi/acts_as_resource_controller.rb
@@ -63,7 +63,9 @@ module JSONAPI
     def process_request
       return unless verify_accept_header
 
-      @request = JSONAPI::RequestParser.new(params, context: context,
+      @request = JSONAPI::RequestParser.new(params,
+                                            resource_klass: resource_klass,
+                                            context: context,
                                             key_formatter: key_formatter,
                                             server_error_callbacks: (self.class.server_error_callbacks || []))
 
@@ -110,7 +112,7 @@ module JSONAPI
     private
 
     def resource_klass
-      @resource_klass ||= resource_klass_name.safe_constantize
+      @resource_klass ||= self.class.resource_klass
     end
 
     def resource_serializer_klass
@@ -132,10 +134,6 @@ module JSONAPI
 
     def base_url
       @base_url ||= request.protocol + request.host_with_port
-    end
-
-    def resource_klass_name
-      @resource_klass_name ||= "#{self.class.name.underscore.sub(/_controller$/, '').singularize}_resource".camelize
     end
 
     def verify_content_type_header
@@ -313,6 +311,14 @@ module JSONAPI
         end.compact
         callbacks += method_callbacks
         self.class_variable_set :@@server_error_callbacks, callbacks
+      end
+
+      def resource_klass_name
+        "#{self.name.underscore.sub(/_controller$/, '').singularize}_resource".camelize
+      end
+
+      def resource_klass
+        self.resource_klass_name.safe_constantize
       end
 
     end

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -3602,3 +3602,76 @@ class Api::BoxesControllerTest < ActionController::TestCase
     assert_equal '2',  json_response['included'][1]['relationships']['things']['data'][0]['id']
   end
 end
+
+
+class ApiRest::PeopleControllerTest < ActionController::TestCase
+  def setup
+    JSONAPI.configuration.json_key_format = :underscored_key
+  end
+
+  def test_people_index_with_include_comments_post
+    assert_cacheable_get :index, params: {include: 'comments,comments.post'}
+    assert_response :success
+  end
+
+  def test_people_create_with_comment
+    set_content_type_header!
+    post :create, params: {
+        data: {
+            type: 'people',
+            attributes: {
+                name: 'John Doe',
+                email: 'jd@example.com',
+                date_joined: DateTime.parse('2016-10-30 10:20:00 UTC +00:00')
+            },
+            relationships: {
+                comments: {data: [{type: 'comments', id: '8'}]}
+            }
+        }
+    }
+    assert_response :success
+  end
+
+  def test_people_show_relationship_comments
+    assert_cacheable_get :show_relationship, params: {person_id: '1', relationship: 'comments'}
+    assert_response :success
+  end
+end
+
+class ApiRest::CommentsControllerTest < ActionController::TestCase
+  def test_comments_get_related_resources_source_people
+    assert_cacheable_get :get_related_resources, params: {person_id: '1', relationship: 'comments', source: 'rest/people'}
+    assert_response :success
+  end
+end
+
+class ApiRest::PeoplePostsControllerTest < ActionController::TestCase
+  def test_posts_index_with_include_tags_and_section
+    assert_cacheable_get :index, params: {include: 'tags,section'}
+    assert_response :success
+  end
+
+  def test_posts_show_relationship_tags
+    assert_cacheable_get :show_relationship, params: {post_id: '1', relationship: 'tags'}
+    assert_response :success
+  end
+
+  def test_posts_show_relationship_section
+    assert_cacheable_get :show_relationship, params: {post_id: '1', relationship: 'section'}
+    assert_response :success
+  end
+end
+
+class ApiRest::PostsTagsControllerTest < ActionController::TestCase
+  def test_tags_get_related_resources_source_posts
+    assert_cacheable_get :get_related_resources, params: {post_id: '1', relationship: 'tags', source: 'rest/posts'}
+    assert_response :success
+  end
+end
+
+class ApiRest::PostSectionControllerTest < ActionController::TestCase
+  def test_section_get_related_resource_source_posts
+    assert_cacheable_get :get_related_resource, params: {post_id: '1', relationship: 'section', source: 'rest/posts'}
+    assert_response :success
+  end
+end

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -879,6 +879,70 @@ module Api
   end
 end
 
+module ApiV2Engine
+  class PeopleController < JSONAPI::ResourceController
+  end
+end
+
+module MyEngine
+
+  module Api
+    module V1
+      class PeopleController < JSONAPI::ResourceController
+      end
+    end
+  end
+
+  module AdminApi
+    module V1
+      class PeopleController < JSONAPI::ResourceController
+      end
+    end
+  end
+
+  module DasherizedNamespace
+    module V1
+      class PeopleController < JSONAPI::ResourceController
+      end
+    end
+  end
+
+end
+
+module ApiRest
+
+  class PeopleController < JSONAPI::ResourceController
+    def self.resource_klass_name
+      'Rest::PersonResource'
+    end
+  end
+
+  class CommentsController < JSONAPI::ResourceController
+    def self.resource_klass_name
+      'CommentResource'
+    end
+  end
+
+  class PeoplePostsController < JSONAPI::ResourceController
+    def self.resource_klass_name
+      'Rest::PostResource'
+    end
+  end
+
+  class PostsTagsController < JSONAPI::ResourceController
+    def self.resource_klass_name
+      'TagResource'
+    end
+  end
+
+  class PostSectionController < JSONAPI::ResourceController
+    def self.resource_klass_name
+      'SectionResource'
+    end
+  end
+
+end
+
 ### RESOURCES
 class BaseResource < JSONAPI::Resource
   abstract
@@ -926,6 +990,15 @@ class SpecialPersonResource < SpecialBaseResource
 
   def self.records(options = {})
     Person.where(special: true)
+  end
+end
+
+module Rest
+  class PersonResource < BaseResource
+    model_name 'Person'
+    attributes :name, :email
+    attribute :date_joined, format: :date_with_timezone
+    has_many :comments, class_name: '::Comment'
   end
 end
 
@@ -1074,6 +1147,15 @@ class PostResource < JSONAPI::Resource
     super(key)
     raise JSONAPI::Exceptions::RecordNotFound.new(key) unless find_by_key(key, context: context)
     return key
+  end
+end
+
+module Rest
+  class PostResource < BaseResource
+    model_name 'Post'
+    attributes :title, :body
+    has_one :section, class_name: '::Section'
+    has_many :tags, class_name: '::Tag'
   end
 end
 

--- a/test/integration/routes/routes_test.rb
+++ b/test/integration/routes/routes_test.rb
@@ -197,6 +197,47 @@ class RoutesTest < ActionDispatch::IntegrationTest
                    {action: 'show', controller: 'iso_currencies', id: 'USD'})
   end
 
+  def test_routing_api_rest_people_show_relationship_comments
+    assert_routing({path: '/api_rest/people/1/relationships/comments', method: :get},
+                   {action: 'show_relationship', controller: 'api_rest/people', person_id: '1', relationship: 'comments'})
+  end
+
+  def test_routing_people_get_related_resources_comments
+    assert_routing({path: '/api_rest/people/1/comments', method: :get},
+                   {action: 'get_related_resources', controller: 'api_rest/comments', person_id: '1',
+                    relationship: 'comments', source: 'rest/people'})
+
+  end
+
+  def test_routing_api_rest_posts_index
+    assert_routing({path: '/api_rest/posts', method: :get},
+                   {action: 'index', controller: 'api_rest/people_posts'})
+  end
+
+  def test_routing_api_rest_posts_show_relationship_tags
+    assert_routing({path: '/api_rest/posts/1/relationships/tags', method: :get},
+                   {action: 'show_relationship', controller: 'api_rest/people_posts', post_id: '1', relationship: 'tags'})
+  end
+
+  def test_routing_api_rest_posts_show_relationship_section
+    assert_routing({path: '/api_rest/posts/1/relationships/section', method: :get},
+                   {action: 'show_relationship', controller: 'api_rest/people_posts', post_id: '1', relationship: 'section'})
+  end
+
+  def test_routing_posts_get_related_resources_tags
+    assert_routing({path: '/api_rest/posts/1/tags', method: :get},
+                   {action: 'get_related_resources', controller: 'api_rest/posts_tags', post_id: '1',
+                    relationship: 'tags', source: 'rest/posts'})
+
+  end
+
+  def test_routing_posts_get_related_resource_section
+    assert_routing({path: '/api_rest/posts/1/section', method: :get},
+                   {action: 'get_related_resource', controller: 'api_rest/post_section', post_id: '1',
+                    relationship: 'section', source: 'rest/posts'})
+
+  end
+
   # ToDo: Refute routing
   # def test_routing_v3_posts_delete
   #   assert_routing({ path: '/api/v3/posts/1', method: :delete },

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -225,7 +225,6 @@ end
 JSONAPI.configuration.route_format = :underscored_route
 TestApp.routes.draw do
   jsonapi_resources :people
-  jsonapi_resources :special_people
   jsonapi_resources :comments
   jsonapi_resources :firms
   jsonapi_resources :tags
@@ -237,11 +236,6 @@ TestApp.routes.draw do
   jsonapi_resources :iso_currencies
   jsonapi_resources :expense_entries
   jsonapi_resources :breeds
-  jsonapi_resources :planets
-  jsonapi_resources :planet_types
-  jsonapi_resources :moons
-  jsonapi_resources :craters
-  jsonapi_resources :preferences
   jsonapi_resources :facts
   jsonapi_resources :categories
   jsonapi_resources :pictures
@@ -260,10 +254,8 @@ TestApp.routes.draw do
 
     namespace :v1 do
       jsonapi_resources :people
-      jsonapi_resources :comments
       jsonapi_resources :tags
       jsonapi_resources :posts
-      jsonapi_resources :sections
       jsonapi_resources :iso_currencies
       jsonapi_resources :expense_entries
       jsonapi_resources :breeds
@@ -271,7 +263,6 @@ TestApp.routes.draw do
       jsonapi_resources :planet_types
       jsonapi_resources :moons
       jsonapi_resources :craters
-      jsonapi_resources :preferences
       jsonapi_resources :likes
     end
 
@@ -288,10 +279,6 @@ TestApp.routes.draw do
     end
 
     namespace :v3 do
-      jsonapi_resource :preferences do
-        # Intentionally empty block to skip relationship urls
-      end
-
       jsonapi_resources :posts, except: [:destroy] do
         jsonapi_link :author, except: [:destroy]
         jsonapi_links :tags, only: [:show, :create]
@@ -323,8 +310,6 @@ TestApp.routes.draw do
       jsonapi_resources :expense_entries
       jsonapi_resources :iso_currencies
 
-      jsonapi_resources :employees
-
     end
     JSONAPI.configuration.route_format = :underscored_route
 
@@ -352,21 +337,22 @@ TestApp.routes.draw do
     end
   end
 
-  namespace :admin_api do
-    namespace :v1 do
-      jsonapi_resources :people
-    end
-  end
-
-  namespace :dasherized_namespace, path: 'dasherized-namespace' do
-    namespace :v1 do
-      jsonapi_resources :people
-    end
-  end
-
   namespace :pets do
     namespace :v1 do
       jsonapi_resources :cats
+    end
+  end
+
+  namespace :api_rest do
+    jsonapi_resources :people do
+      jsonapi_related_resources :comments
+      jsonapi_links :comments
+    end
+    jsonapi_resources :posts, controller: 'people_posts' do
+      jsonapi_related_resources :tags, controller: 'posts_tags'
+      jsonapi_related_resource :section, controller: 'post_section'
+      jsonapi_links :tags
+      jsonapi_link :section
     end
   end
 

--- a/test/unit/jsonapi_request/jsonapi_request_test.rb
+++ b/test/unit/jsonapi_request/jsonapi_request_test.rb
@@ -28,6 +28,7 @@ class JSONAPIRequestTest < ActiveSupport::TestCase
       params,
       {
         context: nil,
+        resource_klass: ExpenseEntryResource,
         key_formatter: JSONAPI::Formatter.formatter_for(:underscored_key)
       }
     )
@@ -48,6 +49,7 @@ class JSONAPIRequestTest < ActiveSupport::TestCase
       params,
       {
         context: nil,
+        resource_klass: ExpenseEntryResource,
         key_formatter: JSONAPI::Formatter.formatter_for(:dasherized_key)
       }
     )
@@ -68,6 +70,7 @@ class JSONAPIRequestTest < ActiveSupport::TestCase
       params,
       {
         context: nil,
+        resource_klass: ExpenseEntryResource,
         key_formatter: JSONAPI::Formatter.formatter_for(:dasherized_key)
       }
     )
@@ -89,6 +92,7 @@ class JSONAPIRequestTest < ActiveSupport::TestCase
       params,
       {
         context: nil,
+        resource_klass: ExpenseEntryResource,
         key_formatter: JSONAPI::Formatter.formatter_for(:underscored_key)
       }
     )
@@ -111,6 +115,7 @@ class JSONAPIRequestTest < ActiveSupport::TestCase
       params,
       {
         context: nil,
+        resource_klass: ExpenseEntryResource,
         key_formatter: JSONAPI::Formatter.formatter_for(:dasherized_key)
       }
     )
@@ -133,6 +138,7 @@ class JSONAPIRequestTest < ActiveSupport::TestCase
       params,
       {
         context: nil,
+        resource_klass: ExpenseEntryResource,
         key_formatter: JSONAPI::Formatter.formatter_for(:dasherized_key)
       }
     )
@@ -156,6 +162,7 @@ class JSONAPIRequestTest < ActiveSupport::TestCase
       params,
       {
         context: nil,
+        resource_klass: ExpenseEntryResource,
         key_formatter: JSONAPI::Formatter.formatter_for(:dasherized_key)
       }
     )


### PR DESCRIPTION
### Routing:

resource for jsonapi_resource(s), jsonapi_related_resource(s), jsonapi_link(s), jsonapi_relationships will be founded through controller
**Breaking changes - application will not start if route's controller is missing**
### Controller:

provides resource_klass to `RequestParser` (previously it was provided only for `resource_serializer`,  `RequestParser` detected `resource_klass` by `params[:controller]`)

usage example:

``` ruby
# config/routes.rb
TestApp.routes.draw do
  namespace :api do
    namespace :v1 do
      jsonapi_resources :people
      jsonapi_resources :countries do
        jsonapi_related_resources :cities, controller: 'country_cities'
        jsonapi_links :cities
      end
      jsonapi_resources :cities
    end
  end

 namespace :api do
    namespace :v2 do
      jsonapi_resources :people
      jsonapi_resources :countries do
        jsonapi_relationships
      end
      jsonapi_resources :cities, controller: 'not_nested_cities'
    end
  end
end

# app/controllers/json_api_controller.rb
class JsonApiController < ApplicationController
  skip_before_filter :verify_authenticity_token
  include JSONAPI::ActsAsResourceController
end

# app/controllers/api/v1/people_controller.rb
class Api::V1::PeopleController < JsonApiController
end

# app/controllers/api/v1/countries_controller.rb
class Api::V1::CountriesController < JsonApiController
  def self.resource_klass_name
    'CountryResource'
  end
end

# app/controllers/api/v1/country_cities_controller.rb
class Api::V1::CountryCitiesController < Api::V1::CitiesController
  def context
    super.merge skip_country_id: true
  end
end

# app/controllers/api/v1/cities_controller.rb
class Api::V1::CitiesController < JsonApiController
  def self.resource_klass_name
    'CityResource'
  end
end

# app/controllers/api/v2/people_controller.rb
class Api::V2::PeopleController < JsonApiController
end

# app/controllers/api/v1/countries_controller.rb
class Api::V2::CountriesController < JsonApiController
  def self.resource_klass_name
    'CountryResource'
  end
end

# app/controllers/api/v2/cities_controller.rb
class Api::V2::CitiesController < JsonApiController
  def self.resource_klass_name
    'CityResource'
  end
  def context
    super.merge skip_country_id: true
  end
end

# app/controllers/api/v2/not_nested_cities_controller.rb
class Api::V2::NotNestedCitiesController < Api::V2::CitiesController
   def context
    super.merge skip_country_id: false
  end
end


# app/resources/base_resource.rb
class BaseResource < JSONAPI::Resource
  abstract
end

# app/resources/country_resource.rb
class CountryResource < BaseResource
  immutable
  attributes :name, :iso_code, :prefix
  filters :name, :iso_code, :prefix
  has_many :cities, class_name: 'City'
end

# app/resources/city_resource.rb
class CityResource < BaseResource
  immutable
  attributes :name, :country_id
  filters :name
  def self.fetchable_fields(context = {})
    res = super
    res - [:country_id] if context[:skip_country_id]
   res
  end
end

# app/resources/api/v1/person_resource.rb
class Api::V1::PersonResource < ::BaseResource
  model_name 'Person'
  attributes :first_name, :last_name
  filters :first_name, :last_name
end

# app/resources/api/v2/person_resource.rb
class Api::V2::PersonResource < Api::V1::PersonResource
  attributes :middle_name
  filter :middle_name
end
```
