### PR TITLE
WIP - Allow custom scopes.

### DIFF
--- a/lib/jsonapi/link_builder.rb
+++ b/lib/jsonapi/link_builder.rb
@@ -85,9 +85,9 @@ module JSONAPI
 
     def engine_resource_path_name_from_source(source)
       scopes         = scopes_from_source(source)
-      base_path_name = scopes.map(&:underscore).join("_")
+      base_path_name = scopes.map { |scope| scope.to_s.underscore }.join('_')
       end_path_name  = source.class._type.to_s.singularize
-      [base_path_name, end_path_name, "path"].reject(&:blank?).join("_")
+      [base_path_name, end_path_name, 'path'].reject(&:blank?).join('_')
     end
 
     # Allow overriding scopes, e.g. for nested resources.
@@ -102,7 +102,7 @@ module JSONAPI
 
     def engine_resources_path_name_from_class(klass)
       scopes         = module_scopes_from_class(klass)[1..-1]
-      base_path_name = scopes.map(&:underscore).join("_")
+      base_path_name = scopes.map { |scope| scope.to_s.underscore }.join('_')
       end_path_name  = klass._type.to_s
 
       if base_path_name.blank?

--- a/lib/jsonapi/link_builder.rb
+++ b/lib/jsonapi/link_builder.rb
@@ -84,16 +84,15 @@ module JSONAPI
     end
 
     def engine_resource_path_name_from_source(source)
-      scopes         = scopes_from_source(source)
+      scopes         = scopes_from_resource_class(source.class)
       base_path_name = scopes.map { |scope| scope.to_s.underscore }.join('_')
       end_path_name  = source.class._type.to_s.singularize
       [base_path_name, end_path_name, 'path'].reject(&:blank?).join('_')
     end
 
-    # Allow overriding scopes, e.g. for nested resources.
-    # TODO: use this method for all path generation
-    def scopes_from_source(source)
-      source.custom_route_scopes || module_scopes_from_class(source.class)[1..-1]
+    def scopes_from_resource_class(resource_klass)
+      # Extension point -- allow overriding scopes in Resource definition, e.g. for nested resources.
+      resource_klass.custom_route_scopes || module_scopes_from_class(resource_klass)[1..-1]
     end
 
     def engine_resource_url(source)
@@ -101,7 +100,7 @@ module JSONAPI
     end
 
     def engine_resources_path_name_from_class(klass)
-      scopes         = module_scopes_from_class(klass)[1..-1]
+      scopes         = scopes_from_resource_class(klass)
       base_path_name = scopes.map { |scope| scope.to_s.underscore }.join('_')
       end_path_name  = klass._type.to_s
 

--- a/lib/jsonapi/link_builder.rb
+++ b/lib/jsonapi/link_builder.rb
@@ -77,14 +77,23 @@ module JSONAPI
 
     def engine_resource_path(source)
       resource_path_name = engine_resource_path_name_from_source(source)
-      engine_name.routes.url_helpers.public_send(resource_path_name, source.id)
+
+      path_parameters = source.context.try(:[], :path_parameters) || []
+      path_parameters << source.id
+      engine_name.routes.url_helpers.public_send(resource_path_name, *path_parameters)
     end
 
     def engine_resource_path_name_from_source(source)
-      scopes         = module_scopes_from_class(source.class)[1..-1]
-      base_path_name = scopes.map { |scope| scope.underscore }.join("_")
+      scopes         = scopes_from_source(source)
+      base_path_name = scopes.map(&:underscore).join("_")
       end_path_name  = source.class._type.to_s.singularize
       [base_path_name, end_path_name, "path"].reject(&:blank?).join("_")
+    end
+
+    # Allow overriding scopes, e.g. for nested resources.
+    # TODO: use this method for all path generation
+    def scopes_from_source(source)
+      source.custom_route_scopes || module_scopes_from_class(source.class)[1..-1]
     end
 
     def engine_resource_url(source)
@@ -93,7 +102,7 @@ module JSONAPI
 
     def engine_resources_path_name_from_class(klass)
       scopes         = module_scopes_from_class(klass)[1..-1]
-      base_path_name = scopes.map { |scope| scope.underscore }.join("_")
+      base_path_name = scopes.map(&:underscore).join("_")
       end_path_name  = klass._type.to_s
 
       if base_path_name.blank?

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -171,7 +171,7 @@ module JSONAPI
 
     # Override this to add a custom route scope.  
     # e.g. to support nested resource routes.
-    def custom_route_scopes
+    def self.custom_route_scopes
       nil
     end
 
@@ -465,8 +465,12 @@ module JSONAPI
       end
 
       def resource_type_for(model)
-        model_name = model.class.to_s.underscore
-        if _model_hints[model_name]
+        resource_type_for_class(model.class)
+      end
+
+      def resource_type_for_class(klass)
+        model_name = klass.to_s.underscore
+        if _model_hints.try(:[], model_name)
           _model_hints[model_name]
         else
           model_name.rpartition('/').last

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -465,12 +465,8 @@ module JSONAPI
       end
 
       def resource_type_for(model)
-        resource_type_for_class(model.class)
-      end
-
-      def resource_type_for_class(klass)
-        model_name = klass.to_s.underscore
-        if _model_hints.try(:[], model_name)
+        model_name = model.class.to_s.underscore
+        if _model_hints[model_name]
           _model_hints[model_name]
         else
           model_name.rpartition('/').last

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -169,6 +169,12 @@ module JSONAPI
       {}
     end
 
+    # Override this to add a custom route scope.  
+    # e.g. to support nested resource routes.
+    def custom_route_scopes
+      nil
+    end
+
     def preloaded_fragments
       # A hash of hashes
       @preloaded_fragments ||= Hash.new


### PR DESCRIPTION
Supports custom scopes, for example to make nested resources work.

1) Adds an extension point class method named `custom_route_scopes` to JSONAPI::Resource, which allows overriding the scopes used to locate the path helper.
2) If context[:path_parameter] is specified in the controller (via override of `context` method), this will pass the parameters into the path helper to specify the parent id path segments.

Given routes like this:
```
jsonapi_resouces :parents do
  jsonapi_relationships
  jsonapi_resources :children
end
```

Override `context` in the ChildrenController:
```
    def context
      { 
        parent_id: params[:parent_id],
        path_parameters: [ params[:parent_id] ],
      }
    end
```

And a custom ChildProcessor, that e.g. searches using the parent_id.
```
def load_parent
    parent_id = params[:context].try(:[], :parent_id)
    # TODO: <load the parent resource>
end
```

and override the `show`, `create_resource` etc. methods to call load_parent and work from there.
