### PR TITLE
Fixed the indentation of meta example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1053,7 +1053,7 @@ class BookResource < JSONAPI::Resource
       computed_copyright: options[:serialization_options][:copyright],
       last_updated_at: _model.updated_at
     }
-   end
+  end
 end
 
 ```


### PR DESCRIPTION
There was an extra space in the Meta example in the README. This PR removes the extra space.