### PR TITLE
Allow includes to follow namespacing

### DIFF
--- a/lib/jsonapi/request_parser.rb
+++ b/lib/jsonapi/request_parser.rb
@@ -201,7 +201,7 @@ module JSONAPI
       relationship = resource_klass._relationship(relationship_name)
       if relationship && format_key(relationship_name) == include_parts.first
         unless include_parts.last.empty?
-          check_include(Resource.resource_for(@resource_klass.module_path + relationship.class_name.to_s.underscore), include_parts.last.partition('.'))
+          check_include(Resource.resource_for(resource_klass.module_path + relationship.class_name.to_s.underscore), include_parts.last.partition('.'))
         end
       else
         @errors.concat(JSONAPI::Exceptions::InvalidInclude.new(format_key(resource_klass._type),


### PR DESCRIPTION
Minor bug fix: there was a bug where if you do an `include` across a namespace boundary, e.g. in the case of:

    class BaseResource
      relationship :intermediate, to: :one, class_name: "Namespaced::Intermediate",
    end

    class Namespaced::IntermediateResource
       relationship :child, to: :one
    end
   
    class Namspaced::ChildResource
      relationship :intermediate, to: :one
    end

An includes request of `?includes=intermediate.child` would bomb out because it was using `BaseResource` rather than `Namespaced::IntermediateResource` for looking up `ChildResource`. This fixes that specific issue.

Not sure what your intentions with regards to namespaced resources are in general - I've had to put a few hacks in place to make things work in general, but this particular bug fix seems like it should go in right away.

