### PR TITLE
Fix issue where resources received context nested in hash

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -1040,7 +1040,7 @@ module JSONAPI
           cache_ids = pluck_arel_attributes(records, t[_primary_key], t[_cache_field])
           resources = CachedResourceFragment.fetch_fragments(self, serializer, options[:context], cache_ids)
         else
-          resources = resources_for(records, options).map{|r| [r.id, r] }.to_h
+          resources = resources_for(records, options[:context]).map{|r| [r.id, r] }.to_h
         end
 
         preload_included_fragments(resources, records, serializer, options)

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -2451,6 +2451,12 @@ class BooksControllerTest < ActionController::TestCase
   ensure
     JSONAPI.configuration.use_relationship_reflection = false
   end
+
+  def test_index_with_caching_enabled_uses_context
+    assert_cacheable_get :index
+    assert_response :success
+    assert json_response['data'][0]['attributes']['title'] = 'Title'
+  end
 end
 
 class Api::V5::AuthorsControllerTest < ActionController::TestCase

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -717,6 +717,9 @@ class BoatsController < JSONAPI::ResourceController
 end
 
 class BooksController < JSONAPI::ResourceController
+  def context
+    { title: 'Title' }
+  end
 end
 
 ### CONTROLLERS
@@ -1246,7 +1249,13 @@ class AuthorResource < JSONAPI::Resource
 end
 
 class BookResource < JSONAPI::Resource
+  attribute :title
+
   has_many :authors, class_name: 'Author', inverse_relationship: :books
+
+  def title
+    context[:title]
+  end
 end
 
 class AuthorDetailResource < JSONAPI::Resource


### PR DESCRIPTION
* If caching has been enabled, however disabled for a resource, the context values are nested in a a 'context' key. For example:

```
{ context: { foo: :bar } } 
vs. 
{ foo: :bar }
```

I wasn't sure how to test, so I ended up adding context to a resource. I'm open to suggestions on how you wanted this case covered.