### PR TITLE
Public model_name_for_type method

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -324,7 +324,7 @@ module JSONAPI
       relationship = self.class._relationships[relationship_type.to_sym]
 
       _model.public_send("#{relationship.foreign_key}=", key_value)
-      _model.public_send("#{relationship.polymorphic_type}=", self.class.real_model_name(key_type))
+      _model.public_send("#{relationship.polymorphic_type}=", self.class.model_name_for_type(key_type))
 
       @save_needed = true
 
@@ -404,12 +404,6 @@ module JSONAPI
       :completed
     end
 
-    def real_model_name(key_type)
-      type_class_name = key_type.to_s.classify
-      resource = self.class.resource_for(type_class_name)
-      resource ? resource._model_name.to_s : type_class_name
-    end
-
     class << self
       def inherited(subclass)
         subclass.abstract(false)
@@ -465,6 +459,12 @@ module JSONAPI
         else
           model_name.rpartition('/').last
         end
+      end
+
+      def model_name_for_type(key_type)
+        type_class_name = key_type.to_s.classify
+        resource = resource_for(type_class_name)
+        resource ? resource._model_name.to_s : type_class_name
       end
 
       attr_accessor :_attributes, :_relationships, :_type, :_model_hints

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -324,7 +324,7 @@ module JSONAPI
       relationship = self.class._relationships[relationship_type.to_sym]
 
       _model.public_send("#{relationship.foreign_key}=", key_value)
-      _model.public_send("#{relationship.polymorphic_type}=", _model_class_name(key_type))
+      _model.public_send("#{relationship.polymorphic_type}=", self.class.real_model_name(key_type))
 
       @save_needed = true
 
@@ -404,7 +404,7 @@ module JSONAPI
       :completed
     end
 
-    def _model_class_name(key_type)
+    def real_model_name(key_type)
       type_class_name = key_type.to_s.classify
       resource = self.class.resource_for(type_class_name)
       resource ? resource._model_name.to_s : type_class_name


### PR DESCRIPTION
Hi,
I just think this method could be used in many cases associated with polymorphic relations like filtering by polymorphic model type. In that case having this public could make it easier to implement.