### PR TITLE
Allow to access results of the response document

### DIFF
--- a/lib/jsonapi/response_document.rb
+++ b/lib/jsonapi/response_document.rb
@@ -1,9 +1,10 @@
 module JSONAPI
   class ResponseDocument
-    attr_reader :serialized_results
+    attr_reader :serialized_results, :results
 
     def initialize(options = {})
       @serialized_results = []
+      @results = []
       @result_codes = []
       @error_results = []
       @global_errors = []
@@ -30,6 +31,7 @@ module JSONAPI
           add_global_error(error)
         end
       else
+        @results.push result
         @serialized_results.push result.to_hash(operation.options[:serializer])
         @result_codes.push result.code.to_i
         update_links(operation.options[:serializer], result)


### PR DESCRIPTION
Hi @lgebhardt,
I added the results of `process_request` to an instance variable. Thanks to that we can write better controllers tests using assertions with `resource` instances instead of parsing JSON string. 