### PR TITLE
Apply memoization on request object

### DIFF
--- a/lib/jsonapi/acts_as_resource_controller.rb
+++ b/lib/jsonapi/acts_as_resource_controller.rb
@@ -63,9 +63,12 @@ module JSONAPI
     def process_request
       return unless verify_accept_header
 
-      @request = JSONAPI::RequestParser.new(params, context: context,
-                                            key_formatter: key_formatter,
-                                            server_error_callbacks: (self.class.server_error_callbacks || []))
+      @request ||= JSONAPI::RequestParser.new(
+        params,
+        context: context,
+        key_formatter: key_formatter,
+        server_error_callbacks: (self.class.server_error_callbacks || [])
+      )
 
       unless @request.errors.empty?
         render_errors(@request.errors)


### PR DESCRIPTION
Hey there!

It's just a proposal for applying memoization on the `@request` instance variable :-)

## Context

There's this [jsonapi-utils](https://github.com/tiagopog/jsonapi-utils) gem (aka JU), built on top of JR, which also [instantiates](https://github.com/tiagopog/jsonapi-utils/blob/master/lib/jsonapi/utils/request.rb#L10) a `JSONAPI::RequestParser` object in the `@request` instance variable.

JU lets developers define their controller actions as they wish and take advantage of its helpers (e.g. `jsonapi_render`, `jsonapi_render_erros` etc). Then the gem uses a `JSONAPI::RequestParser` object in a [before-action callback](https://github.com/tiagopog/jsonapi-utils/blob/master/lib/jsonapi/utils.rb#L19) in order to apply a proper request parsing/check in same way JR does.

## Problem

When using JU without defining controller actions, thus using JR's default actions, there's a duplicated request parsing:

1. The first parse happens in the JU's side due to the before-action callback, [changing the internals of `params`](https://github.com/cerebris/jsonapi-resources/blob/master/lib/jsonapi/request_parser.rb#L610);
1. Since it has a fallback on the JR's default actions, the [request will be reparsed](https://github.com/cerebris/jsonapi-resources/blob/release-0-8/lib/jsonapi/acts_as_resource_controller.rb#L62) and an error will be returned due to the absence of `:id` on `params` for `PATCH/PUT` requests:

```json
{
  "errors": [
    {
      "title": "A key is required",
      "detail": "The resource object does not contain a key.",
      "code": "109",
      "status": "400"
    }
  ]
}
```
Reference issues: [#28](https://github.com/tiagopog/jsonapi-utils/issues/28) and [#44](https://github.com/tiagopog/jsonapi-utils/issues/44)

## Solution 

I'm working on a workaround in the gem but this issue can be easily fixed by applying a memoization on the `@request` instance variable, as suggested in this PR.

Well, there might be other cases out there where `@request` is redefined, so it would be great to take advantage of a memoized value.