### PR TITLE
Add a default_filters configuration option

### DIFF
--- a/lib/jsonapi/configuration.rb
+++ b/lib/jsonapi/configuration.rb
@@ -14,6 +14,7 @@ module JSONAPI
                 :default_paginator,
                 :default_page_size,
                 :maximum_page_size,
+                :default_filters,
                 :default_processor_klass,
                 :use_text_errors,
                 :top_level_links_include_pagination,
@@ -59,6 +60,16 @@ module JSONAPI
 
       self.default_page_size = 10
       self.maximum_page_size = 20
+
+      # Default filters
+      # filters specified here will be applied to all resources
+      self.default_filters = {
+          id: {
+              apply: -> (records, value, options) {
+                records.where("#{options[:resource_klass]._primary_key} IN (?)", value)
+              }
+          }
+      }
 
       # Metadata
       # Output record count in top level meta for find operation
@@ -208,6 +219,8 @@ module JSONAPI
     attr_writer :default_page_size
 
     attr_writer :maximum_page_size
+
+    attr_writer :default_filters
 
     attr_writer :use_text_errors
 

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -924,7 +924,7 @@ module JSONAPI
       end
 
       def _allowed_filters
-        defined?(@_allowed_filters) ? @_allowed_filters : { id: {} }
+        defined?(@_allowed_filters) ? @_allowed_filters : JSONAPI.configuration.default_filters
       end
 
       def _paginator
@@ -1050,7 +1050,7 @@ module JSONAPI
 
       def find_records(filters, options = {})
         context = options[:context]
-
+        options[:resource_klass] = self
         records = filter_records(filters, options)
 
         sort_criteria = options.fetch(:sort_criteria) { [] }

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -1930,6 +1930,12 @@ class PicturesControllerTest < ActionController::TestCase
     assert_equal 3, json_response['data'].size
   end
 
+  def test_pictures_index_default_filter
+    assert_cacheable_get :index, params: {filter: {id: '1'}}
+    assert_response :success
+    assert_equal 1, json_response['data'].size
+  end
+
   def test_pictures_index_with_polymorphic_include_one_level
     assert_cacheable_get :index, params: {include: 'imageable'}
     assert_response :success


### PR DESCRIPTION
Defaults to `id`, which will filter on the primary key for the resource_klass which is also passed as an option

Allows the default filter to be removed