### PR TITLE
Allow context to be passed through to filter calls

### DIFF
--- a/lib/jsonapi/processor.rb
+++ b/lib/jsonapi/processor.rb
@@ -196,7 +196,7 @@ module JSONAPI
           (paginator && paginator.class.requires_record_count) ||
           (JSONAPI.configuration.top_level_meta_include_page_count))
         related_resource_records = source_resource.public_send("records_for_" + relationship_type)
-        records = resource_klass.filter_records(filters, {},
+        records = resource_klass.filter_records(filters, { context: context },
                                                 related_resource_records)
 
         record_count = resource_klass.count_records(records)


### PR DESCRIPTION
Hey,

Small fix: I wanted the ability to run filters on the basis of context (e.g. "Show me all records belonging to the current user").

This should be fairly isolated and unlikely to cause other problems.

Let me know if you have any questions about it.
