### PR TITLE
Rename local variable include

### DIFF
--- a/lib/jsonapi/request_parser.rb
+++ b/lib/jsonapi/request_parser.rb
@@ -211,7 +211,7 @@ module JSONAPI
     end
 
     def parse_include_directives(raw_include)
-      return if raw_include.nil?
+      return unless raw_include
 
       unless JSONAPI.configuration.allow_include
         fail JSONAPI::Exceptions::ParametersNotAllowed.new([:include])

--- a/lib/jsonapi/request_parser.rb
+++ b/lib/jsonapi/request_parser.rb
@@ -210,14 +210,14 @@ module JSONAPI
       end
     end
 
-    def parse_include_directives(include_directives)
-      return if include_directives.nil?
+    def parse_include_directives(raw_include)
+      return if raw_include.nil?
 
       unless JSONAPI.configuration.allow_include
         fail JSONAPI::Exceptions::ParametersNotAllowed.new([:include])
       end
 
-      included_resources = CSV.parse_line(include_directives)
+      included_resources = CSV.parse_line(raw_include)
       return if included_resources.nil?
 
       result = included_resources.map do |included_resource|

--- a/lib/jsonapi/request_parser.rb
+++ b/lib/jsonapi/request_parser.rb
@@ -210,23 +210,22 @@ module JSONAPI
       end
     end
 
-    def parse_include_directives(include)
-      return if include.nil?
+    def parse_include_directives(include_directives)
+      return if include_directives.nil?
 
       unless JSONAPI.configuration.allow_include
         fail JSONAPI::Exceptions::ParametersNotAllowed.new([:include])
       end
 
-      included_resources = CSV.parse_line(include)
+      included_resources = CSV.parse_line(include_directives)
       return if included_resources.nil?
 
-      include = []
-      included_resources.each do |included_resource|
+      result = included_resources.map do |included_resource|
         check_include(@resource_klass, included_resource.partition('.'))
-        include.push(unformat_key(included_resource).to_s)
+        unformat_key(included_resource).to_s
       end
 
-      @include_directives = JSONAPI::IncludeDirectives.new(@resource_klass, include)
+      @include_directives = JSONAPI::IncludeDirectives.new(@resource_klass, result)
     end
 
     def parse_filters(filters)


### PR DESCRIPTION
This PR renames a local variable in one of the methods concerning `include`s, the JSONAPI concept.

This avoids collision with the Ruby keyword, which can be confusing for the reader.

(Also: use `#map` to create a list.)

(_I came to read #937 and was a little confused, at first_.)