### PR TITLE
Fix has_one polymorphism

### DIFF
--- a/lib/jsonapi/relationship_builder.rb
+++ b/lib/jsonapi/relationship_builder.rb
@@ -120,10 +120,16 @@ module JSONAPI
       define_on_resource relationship_name do |options = {}|
         relationship = self.class._relationships[relationship_name]
 
-        resource_klass = relationship.resource_klass
-        if resource_klass
+        if relationship.polymorphic?
           associated_model = public_send(associated_records_method_name)
-          return associated_model ? resource_klass.new(associated_model, @context) : nil
+          resource_klass = self.class.resource_for_model(associated_model) if associated_model
+          return resource_klass.new(associated_model, @context) if resource_klass && associated_model
+        else
+          resource_klass = relationship.resource_klass
+          if resource_klass
+            associated_model = public_send(associated_records_method_name)
+            return associated_model ? resource_klass.new(associated_model, @context) : nil
+          end
         end
       end
     end

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -291,6 +291,25 @@ ActiveRecord::Schema.define do
     t.timestamps null: false
   end
 
+  create_table :questions, force: true do |t|
+    t.string :text
+  end
+
+  create_table :answers, force: true do |t|
+    t.references :question
+    t.integer :respondent_id
+    t.string  :respondent_type
+    t.string :text
+  end
+
+  create_table :patients, force: true do |t|
+    t.string :name
+  end
+
+  create_table :doctors, force: true do |t|
+    t.string :name
+  end
+
   # special cases
 end
 
@@ -606,6 +625,25 @@ class RelatedThing < ActiveRecord::Base
   belongs_to :to, class_name: Thing, foreign_key: :to_id
 end
 
+class Question < ActiveRecord::Base
+  has_one :answer
+
+  def respondent
+    answer.try(:respondent)
+  end
+end
+
+class Answer < ActiveRecord::Base
+  belongs_to :question
+  belongs_to :respondent, polymorphic: true
+end
+
+class Patient < ActiveRecord::Base
+end
+
+class Doctor < ActiveRecord::Base
+end
+
 module Api
   module V7
     class Client < Customer
@@ -880,6 +918,21 @@ end
 module Api
   class BoxesController < JSONAPI::ResourceController
   end
+end
+
+class QuestionsController < JSONAPI::ResourceController
+end
+
+class AnswersController < JSONAPI::ResourceController
+end
+
+class PatientsController < JSONAPI::ResourceController
+end
+
+class DoctorsController < JSONAPI::ResourceController
+end
+
+class RespondentController < JSONAPI::ResourceController
 end
 
 ### RESOURCES
@@ -1793,6 +1846,30 @@ module Api
   class UserResource < JSONAPI::Resource
     has_many :things
   end
+end
+
+class QuestionResource < JSONAPI::Resource
+  has_one :answer
+  has_one :respondent, polymorphic: true, class_name: "Respondent", foreign_key_on: :related
+
+  attributes :text
+end
+
+class AnswerResource < JSONAPI::Resource
+  has_one :question
+  has_one :respondent, polymorphic: true
+end
+
+class PatientResource < JSONAPI::Resource
+  attributes :name
+end
+
+class DoctorResource < JSONAPI::Resource
+  attributes :name
+end
+
+class RespondentResource < JSONAPI::Resource
+  abstract
 end
 
 ### PORO Data - don't do this in a production app

--- a/test/fixtures/answers.yml
+++ b/test/fixtures/answers.yml
@@ -1,0 +1,12 @@
+answer1:
+  id: 1
+  question_id: 1
+  text: Great thanks
+  respondent_id: 1
+  respondent_type: Patient
+answer2:
+  id: 2
+  question_id: 2
+  text: Better than last week
+  respondent_id: 1
+  respondent_type: Doctor

--- a/test/fixtures/doctors.yml
+++ b/test/fixtures/doctors.yml
@@ -1,0 +1,3 @@
+doctor1:
+  id: 1
+  name: Henry Jones Jr

--- a/test/fixtures/patients.yml
+++ b/test/fixtures/patients.yml
@@ -1,0 +1,3 @@
+patient1:
+  id: 1
+  name: Bob Smith

--- a/test/fixtures/questions.yml
+++ b/test/fixtures/questions.yml
@@ -1,0 +1,6 @@
+question1:
+  id: 1
+  text: How are you feeling today?
+question2:
+  id: 2
+  text: How does the patient look today?

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -255,6 +255,11 @@ TestApp.routes.draw do
   jsonapi_resources :books
   jsonapi_resources :authors
 
+  jsonapi_resources :questions
+  jsonapi_resources :answers
+  jsonapi_resources :doctors
+  jsonapi_resources :patients
+
   namespace :api do
     jsonapi_resources :boxes
 

--- a/test/unit/serializer/polymorphic_serializer_test.rb
+++ b/test/unit/serializer/polymorphic_serializer_test.rb
@@ -7,6 +7,8 @@ class PolymorphismTest < ActionDispatch::IntegrationTest
     @pictures = Picture.all
     @person = Person.find(1)
 
+    @questions = Question.all
+
     JSONAPI.configuration.json_key_format = :camelized_key
     JSONAPI.configuration.route_format = :camelized_route
   end
@@ -128,7 +130,7 @@ class PolymorphismTest < ActionDispatch::IntegrationTest
     )
   end
 
-  def test_polymorphic_to_one_serialization
+  def test_polymorphic_belongs_to_serialization
     serialized_data = JSONAPI::ResourceSerializer.new(
       PictureResource,
       include: %w(imageable)
@@ -242,6 +244,99 @@ class PolymorphismTest < ActionDispatch::IntegrationTest
                 }
               }
             }
+          }
+        ]
+      },
+      serialized_data
+    )
+  end
+
+  def test_polymorphic_has_one_serialization
+    serialized_data = JSONAPI::ResourceSerializer.new(
+      QuestionResource,
+      include: %w(respondent)
+    ).serialize_to_hash(@questions.map { |p| QuestionResource.new p, nil })
+
+    assert_hash_equals(
+      {
+        data: [
+          {
+            id: '1',
+            type: 'questions',
+            links: {
+              self: '/questions/1'
+            },
+            attributes: {
+              text: 'How are you feeling today?'
+            },
+            relationships: {
+              answer: {
+                links: {
+                  self: '/questions/1/relationships/answer',
+                  related: '/questions/1/answer'
+                }
+              },
+              respondent: {
+                links: {
+                  self: '/questions/1/relationships/respondent',
+                  related: '/questions/1/respondent'
+                },
+                data: {
+                  type: 'patients',
+                  id: '1'
+                }
+              }
+            }
+          },
+          {
+            id: '2',
+            type: 'questions',
+            links: {
+              self: '/questions/2'
+            },
+            attributes: {
+              text: 'How does the patient look today?'
+            },
+            relationships: {
+              answer: {
+                links: {
+                  self: '/questions/2/relationships/answer',
+                  related: '/questions/2/answer'
+                }
+              },
+              respondent: {
+                links: {
+                  self: '/questions/2/relationships/respondent',
+                  related: '/questions/2/respondent'
+                },
+                data: {
+                  type: 'doctors',
+                  id: '1'
+                }
+              }
+            }
+          }
+        ],
+        :included => [
+          {
+            id: '1',
+            type: 'patients',
+            links: {
+              self: '/patients/1'
+            },
+            attributes: {
+              name: 'Bob Smith'
+            },
+          },
+          {
+            id: '1',
+            type: 'doctors',
+            links: {
+              self: '/doctors/1'
+            },
+            attributes: {
+              name: 'Henry Jones Jr'
+            },
           }
         ]
       },


### PR DESCRIPTION
Problem: `has_one` relationships that are polymorphic do not work as expected: instead of getting the actual polymorphic resource, you get instead the base class.

Fix: extend the handling used in the polymorphic `belongs_to` relationship to cover the `has_one` case as well. I used the exact same code as the block above.

Tested on Rails 4.2.x.

Let me know if you have any questions or concerns.