### PR TITLE
Add :readonly option to attributes and relationships

### DIFF
--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -98,6 +98,11 @@ module MyAPI
   end
 end
 
+class PostWithReadonlyAttributesResource < JSONAPI::Resource
+  attribute :title, readonly: true
+  has_one :author, readonly: true
+end
+
 class ResourceTest < ActiveSupport::TestCase
   def setup
     @post = Post.first
@@ -628,5 +633,13 @@ LEFT JOIN people AS author_sorting ON author_sorting.id = posts.author_id", resu
   def test_resources_for_transforms_records_into_resources
     resources = PostResource.resources_for([Post.first], {})
     assert_equal(PostResource, resources.first.class)
+  end
+
+  def test_readonly_attribute
+    refute_includes(PostWithReadonlyAttributesResource.creatable_fields, :title)
+    refute_includes(PostWithReadonlyAttributesResource.updatable_fields, :title)
+
+    refute_includes(PostWithReadonlyAttributesResource.creatable_fields, :author)
+    refute_includes(PostWithReadonlyAttributesResource.updatable_fields, :author)
   end
 end


### PR DESCRIPTION
This PR adds the :readonly flag to both the attribute method and the relationship method on JSONAPI::Resource. Flagging an attribute or relationship as readonly prevents it from being included in either the `creatable_fields` or `updatable_fields`.

It is a second attempt at PR #239. Compared to #239, it adds the readonly flag for both the `attribute` helper and the `relationship` helper. A further difference is that this implementation does not remove the `#{attr}=` method from the Resource, since IMO a readonly flag should only influence whether an attribute or relationship is or isn't in the `creatable_` and `updatable_fields`.

This attempt 'caches' which attributes and relationships are readonly. Another possibility is to change `_updatable_relationships` and create `_updatable_attributes` which could then inspect the readonly option of each field.