### PR TITLE
Updates Travis to use latest stable ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,19 @@
 language: ruby
 sudo: false
 env:
-  - "RAILS_VERSION=4.2.6"
+  - "RAILS_VERSION=4.2.7"
   - "RAILS_VERSION=5.0.0"
   - "RAILS_VERSION=master"
 rvm:
-  - 2.1
-  - 2.2.4
-  - 2.3.0
+  - 2.1.10
+  - 2.2.6
+  - 2.3.3
+  - 2.4.0
 matrix:
   exclude:
-    - rvm: 2.0
+    - rvm: 2.1.10
       env: "RAILS_VERSION=5.0.0"
-    - rvm: 2.1
-      env: "RAILS_VERSION=5.0.0"
+    - rvm: 2.4.0
+      env: "RAILS_VERSION=4.2.7"
   allow_failures:
     - env: "RAILS_VERSION=master"


### PR DESCRIPTION
Adds ruby 2.4 testing

There's a bug with ruby 2.4 and rails 4.2. Looks to be related to https://github.com/rails/rails/pull/25161

For now I've excluded testing rails 4.2.7 with ruby 2.4