### PR TITLE
path option is now used when generating url paths

### DIFF
--- a/lib/jsonapi/routing_ext.rb
+++ b/lib/jsonapi/routing_ext.rb
@@ -23,7 +23,7 @@ module ActionDispatch
           options = resources.extract_options!.dup
           options[:controller] ||= @resource_type
           options.merge!(res.routing_resource_options)
-          options[:path] = format_route(@resource_type)
+          options[:path] = format_route(options[:path] || @resource_type)
 
           if options[:except]
             options[:except] << :new unless options[:except].include?(:new) || options[:except].include?('new')
@@ -86,7 +86,7 @@ module ActionDispatch
 
           options[:param] = :id
 
-          options[:path] = format_route(@resource_type)
+          options[:path] = format_route(options[:path] || @resource_type)
 
           if res.resource_key_type == :uuid
             options[:constraints] ||= {}


### PR DESCRIPTION
previously when generating routes in rails app and using path option like this:

```
jsonapi_resources users, path: 'members'
```

the generated routes from rake routes:

```
          POST /users   /users#create
users GET   /users   /users#index
etc
```
now when we specify this option
```
          POST /members /users/#create
users GET   /members /users#index
etc
```

helpers stay the same, only url path changes

if path option is not specified or is `nil` then routes generated make use of the `@resource_type` as before

I was under impression that we want to generate and handle routes in similar fashon as in 

http://guides.rubyonrails.org/routing.html#translated-paths

that's why im making this change