### PR TITLE
Default `id` to being a read only attribute

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -424,7 +424,9 @@ module JSONAPI
         type = subclass.name.demodulize.sub(/Resource$/, '').underscore
         subclass._type = type.pluralize.to_sym
 
-        subclass.attribute :id, format: :id
+        unless subclass._attributes[:id]
+          subclass.attribute :id, format: :id, readonly: true
+        end
 
         check_reserved_resource_name(subclass._type, subclass.name)
       end

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -1111,7 +1111,7 @@ class PostResource < JSONAPI::Resource
   end
 
   def self.creatable_fields(context)
-    super(context) - [:subject, :id]
+    super(context) - [:subject]
   end
 
   def self.sortable_fields(context)
@@ -1132,6 +1132,7 @@ end
 
 class IsoCurrencyResource < JSONAPI::Resource
   attributes :name, :country_name, :minor_unit
+  attribute :id, format: :id, readonly: false
 
   filter :country_name
 


### PR DESCRIPTION
Fixes #960

Potentially a breaking change for apps with guids