### PR TITLE
Fix default_sort for show_related_resources

### DIFF
--- a/lib/jsonapi/relationship_builder.rb
+++ b/lib/jsonapi/relationship_builder.rb
@@ -132,10 +132,8 @@ module JSONAPI
         records = resource_klass.apply_includes(records, options)
 
         sort_criteria = options.fetch(:sort_criteria, {})
-        unless sort_criteria.nil? || sort_criteria.empty?
-          order_options = relationship.resource_klass.construct_order_options(sort_criteria)
-          records = resource_klass.apply_sort(records, order_options, @context)
-        end
+        order_options = relationship.resource_klass.construct_order_options(sort_criteria)
+        records = resource_klass.apply_sort(records, order_options, @context)
 
         paginator = options[:paginator]
         if paginator


### PR DESCRIPTION
The default_sort support from #756 does not work when querying for related resources. I searched through the source and found RelationshipBuilder::build_to_many has the following logic:

```
sort_criteria = options.fetch(:sort_criteria, {})
unless sort_criteria.nil? || sort_criteria.empty?
  order_options = relationship.resource_klass.construct_order_options(sort_criteria)
  records = resource_klass.apply_sort(records, order_options, @context)
end
```

The unless block shouldn't be there. It should be the resource's responsibility to apply sorts, or, if they're null, apply the default sort:

```
sort_criteria = options.fetch(:sort_criteria, {})
order_options = relationship.resource_klass.construct_order_options(sort_criteria)
records = resource_klass.apply_sort(records, order_options, @context)
```

This method looks totally different on the 0.9 branch, so I don't know if the issue exists there.