### PR TITLE
unify checking for @fields if nil or empty with active support blank,…

### DIFF
--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -137,7 +137,7 @@ module JSONAPI
     end
 
     def requested_fields(klass)
-      return if @fields.nil? || @fields.empty?
+      return if @fields.blank?
       if @fields[klass._type]
         @fields[klass._type]
       elsif klass.superclass != JSONAPI::Resource


### PR DESCRIPTION
… in resource_serializer#requested_fields

This is a very minimal change. Please don't take it as an offense I don't want to change anything in other developers code (especially someone more experienced than me). I was just reading through the code and thought that checking  `@fields.nil? || @fields.empty?` is unnecessary when you already have `ActiveSupport` with his `blank?`.