### PR TITLE
Fix typos

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -656,7 +656,7 @@ module JSONAPI
               associations = _lookup_association_chain([records.model.to_s, *model_names])
               joins_query = _build_joins([records.model, *associations])
 
-              # _sorting is appended to avoid name clashes with manual joins eg. overriden filters
+              # _sorting is appended to avoid name clashes with manual joins eg. overridden filters
               order_by_query = "#{associations.last.name}_sorting.#{column_name} #{direction}"
               records = records.joins(joins_query).order(order_by_query)
             else

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -2488,7 +2488,7 @@ class BooksControllerTest < ActionController::TestCase
     JSONAPI.configuration.use_relationship_reflection = false
   end
 
-  def test_destroy_relationship_has_and_belongs_to_many_refect
+  def test_destroy_relationship_has_and_belongs_to_many_reflect
     JSONAPI.configuration.use_relationship_reflection = true
 
     assert_equal 2, Book.find(2).authors.count


### PR DESCRIPTION
```
go get -u github.com/client9/misspell/cmd/misspell
misspell  -w -error -source=text .
```