### PR TITLE
Filter nil values from include param

### DIFF
--- a/lib/jsonapi/request_parser.rb
+++ b/lib/jsonapi/request_parser.rb
@@ -352,7 +352,7 @@ module JSONAPI
 
       return if included_resources.nil?
 
-      result = included_resources.map do |included_resource|
+      result = included_resources.compact.map do |included_resource|
         check_include(resource_klass, included_resource.partition('.'))
         unformat_key(included_resource).to_s
       end

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -3629,6 +3629,11 @@ class Api::BoxesControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  def test_complex_includes_filters_nil_includes
+    assert_cacheable_get :index, params: {include: ',,'}
+    assert_response :success
+  end
+
   def test_complex_includes_two_level
     assert_cacheable_get :index, params: {include: 'things,things.user'}
 


### PR DESCRIPTION
Sending `?include=,,` results CSV parsing `[nil, nil, nil]`, which in turn trows an internal server error.

This PR fixes the problem by silently ignoring empty include directives.