### PR TITLE
apply_filter and apply_sort respects :delegate option of attribute

### DIFF
--- a/lib/jsonapi/active_record_accessor.rb
+++ b/lib/jsonapi/active_record_accessor.rb
@@ -225,6 +225,7 @@ module JSONAPI
               order_by_query = "#{associations.last.name}_sorting.#{column_name} #{direction}"
               records = records.joins(joins_query).order(order_by_query)
             else
+              field = _resource_klass._attribute_delegated_name(field)
               records = records.order(field => direction)
             end
           end
@@ -274,6 +275,7 @@ module JSONAPI
             records.where("#{_resource_klass._relationships[filter].table_name}.#{_resource_klass._relationships[filter].primary_key}" => value)
           end
         else
+          filter = _resource_klass._attribute_delegated_name(filter)
           records.where(filter => value)
         end
       end

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -755,6 +755,10 @@ module JSONAPI
         default_attribute_options.merge(@_attributes[attr])
       end
 
+      def _attribute_delegated_name(attr)
+        @_attributes.fetch(attr.to_sym, {}).fetch(:delegate, attr)
+      end
+
       def _updatable_attributes
         _attributes.map { |key, options| key unless options[:readonly] }.compact
       end

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -3757,3 +3757,26 @@ class Api::BoxesControllerTest < ActionController::TestCase
     assert_equal '2',  json_response['included'][1]['relationships']['things']['data'][0]['id']
   end
 end
+
+class BlogPostsControllerTest < ActionController::TestCase
+  def test_filter_by_delegated_attribute
+    assert_cacheable_get :index, params: {filter: {name: 'some title'}}
+    assert_response :success
+  end
+
+  def test_sorting_by_delegated_attribute
+    assert_cacheable_get :index, params: {sort: 'name'}
+    assert_response :success
+  end
+
+  def test_fields_with_delegated_attribute
+    original_config = JSONAPI.configuration.dup
+    JSONAPI.configuration.json_key_format = :underscored_key
+
+    assert_cacheable_get :index, params: {fields: {blog_posts: 'name'}}
+    assert_response :success
+    assert_equal ['name'], json_response['data'].first['attributes'].keys
+  ensure
+    JSONAPI.configuration = original_config
+  end
+end

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -1801,6 +1801,24 @@ end
 class FlatPostsController < JSONAPI::ResourceController
 end
 
+class BlogPost < ActiveRecord::Base
+  self.table_name = 'posts'
+end
+
+class BlogPostsController < JSONAPI::ResourceController
+
+end
+
+class BlogPostResource < JSONAPI::Resource
+  model_name 'BlogPost', add_model_hint: false
+  model_hint model: 'BlogPost', resource: BlogPostResource
+
+  attribute :name, :delegate => :title
+  attribute :body
+
+  filter :name
+end
+
 # CustomProcessors
 class Api::V4::BookProcessor < JSONAPI::Processor
   after_find do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -252,6 +252,7 @@ TestApp.routes.draw do
   jsonapi_resources :cars
   jsonapi_resources :boats
   jsonapi_resources :flat_posts
+  jsonapi_resources :blog_posts
 
   jsonapi_resources :books
   jsonapi_resources :authors


### PR DESCRIPTION
Allows to sort and filter by delegated attribute without additional patching.
For example request like
```ruby
get '/posts', params: {
    filter: {name: 'some_title'}, 
    sort: '-name', 
    fields: {posts: 'name'}
}
```
 for such resource
```ruby
class PostResource < JSONAPI::Resource
  model_name 'Post'

  attribute :name, delegate: :title
  attribute :body

  filter :name
end
```
will responds successfully with correct data.