### PR TITLE
Fix for Rails `pluck` Bug to Prevent Truncating UUIDs

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -1244,9 +1244,10 @@ module JSONAPI
       def pluck_arel_attributes(relation, *attrs)
         conn = relation.connection
         quoted_attrs = attrs.map do |attr|
-          quoted_table = conn.quote_table_name(attr.relation.table_alias || attr.relation.name)
+          table_name = attr.relation.table_alias || attr.relation.name
+          quoted_table = conn.quote_table_name(table_name)
           quoted_column = conn.quote_column_name(attr.name)
-          "#{quoted_table}.#{quoted_column}"
+          "#{quoted_table}.#{quoted_column} as #{table_name}_#{attr.name}"
         end
         relation.pluck(*quoted_attrs)
       end


### PR DESCRIPTION
This fixes an upstream bug in rails (rails/rails#28044) that causes UUIDs to be truncated by the `pluck` method's type casting. By aliasing each column as `#{table_name}_#{column}` we bypass the default type casting and preserve UUIDs in their full form.

Since there are 3 active versions of jsonapi-resources (0.8.x, 0.9.x, 0.10.x) I wasn't sure which to base this fix against, since IMO it should be fixed in all versions. I went with 0.9.x for selfish reasons, but I'm happy to help port it to the other versions.