### PR TITLE
Use plural of resource type for controller

### DIFF
--- a/lib/jsonapi/request_parser.rb
+++ b/lib/jsonapi/request_parser.rb
@@ -152,7 +152,7 @@ module JSONAPI
           resource_klass,
           context: @context,
           relationship_type: relationship_type,
-          parent_key: resource_klass.verify_key(parent_key)
+          parent_key: resource_klass.verify_key(parent_key, @context)
       )
     end
 

--- a/lib/jsonapi/routing_ext.rb
+++ b/lib/jsonapi/routing_ext.rb
@@ -21,7 +21,7 @@ module ActionDispatch
           res = JSONAPI::Resource.resource_klass_for(resource_type_with_module_prefix(@resource_type))
 
           options = resources.extract_options!.dup
-          options[:controller] ||= @resource_type
+          options[:controller] ||= @resource_type.pluralize
           options.merge!(res.routing_resource_options)
           options[:path] = format_route(@resource_type)
 


### PR DESCRIPTION
Currently, doing `jsonapi_resource :current_user` will use the `CurrentUserController`, however, any relationships on the `current_user` resource will instead look for the `CurrentUsersController`. By default, rails uses the plural name controller for any singular resource. Keeping this the same for JA:R seems like a good idea.

This is currently not picked up by the tests currently, since `Preferences` is already a plural.