### PR TITLE
Store exceptions in request env

### DIFF
--- a/lib/jsonapi/acts_as_resource_controller.rb
+++ b/lib/jsonapi/acts_as_resource_controller.rb
@@ -284,6 +284,9 @@ module JSONAPI
               }
             end
 
+            # Store exception for other middlewares
+            request.env['action_dispatch.exception'] ||= e
+
             internal_server_error = JSONAPI::Exceptions::InternalServerError.new(e)
             Rails.logger.error { "Internal Server Error: #{e.message} #{e.backtrace.join("\n")}" }
             errors = internal_server_error.errors

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -104,6 +104,21 @@ class PostsControllerTest < ActionController::TestCase
     JSONAPI.configuration.whitelist_all_exceptions = original_config
   end
 
+  def test_exception_added_to_request_env
+    original_config = JSONAPI.configuration.whitelist_all_exceptions
+    $PostProcessorRaisesErrors = true
+    refute @request.env['action_dispatch.exception']
+    assert_cacheable_get :index
+    assert @request.env['action_dispatch.exception']
+
+    JSONAPI.configuration.whitelist_all_exceptions = true
+    assert_cacheable_get :index
+    assert @request.env['action_dispatch.exception']
+  ensure
+    $PostProcessorRaisesErrors = false
+    JSONAPI.configuration.whitelist_all_exceptions = original_config
+  end
+
   def test_exception_includes_backtrace_when_enabled
     original_config = JSONAPI.configuration.include_backtraces_in_errors
     $PostProcessorRaisesErrors = true


### PR DESCRIPTION
I know that there is an exception whitelist, and that all exceptions can be whitelisted in the latest version with the `whitelist_all_exceptions` configuration. IMO, this is tangential issue, because as a developer, I might want the gem to handle an exception for me as far as responding to users with error messages, but I _also_ want this exception to be logged separately.

For example, I rely on a Rollbar middleware to report exceptions for alerting/monitoring of my services. Because the gem was swallowing exceptions (in this case a database timeout, which should absolutely sound the alarms), I wasn't aware of a critical app error. Again, I still want the gem to handle responding to users with error messages, but I want those server errors to be processed by the rest of my middleware chain.