### PR TITLE
Pass fetched records to paginator instance when building links

### DIFF
--- a/lib/jsonapi/processor.rb
+++ b/lib/jsonapi/processor.rb
@@ -91,7 +91,7 @@ module JSONAPI
       end
 
       if JSONAPI.configuration.top_level_links_include_pagination && paginator
-        page_options[:pagination_params] = paginator.links_page_params(page_options)
+        page_options[:pagination_params] = paginator.links_page_params(page_options.merge(fetched_resources: resource_records))
       end
 
       return JSONAPI::ResourcesOperationResult.new(:ok, resource_records, page_options)
@@ -173,7 +173,7 @@ module JSONAPI
       pagination_params = if paginator && JSONAPI.configuration.top_level_links_include_pagination
                             page_options = {}
                             page_options[:record_count] = record_count if paginator.class.requires_record_count
-                            paginator.links_page_params(page_options)
+                            paginator.links_page_params(page_options.merge(fetched_resources: related_resources))
                           else
                             {}
                           end


### PR DESCRIPTION
I had a problem recently that the `count` queries that were made by the processor (https://github.com/cerebris/jsonapi-resources/blob/master/lib/jsonapi/processor.rb#L88) were taking too long. These queries become very expensive as data grows. Because of this, my service was responding really slowly and the requests were piling up.

To solve that, I created a paginator that never returns the `last` key and calculates if there is a `next` page by checking if the amount of fetched resources is greater than or equal the page size. Like this:

```
if options[:fetched_records].size >= @size
  links_page_params['next'] = {
    'number' => @number + 1,
    'size' => @size
  }
end
```

But for that I need to know how many records were fetched, and with the current implementation I don't have this information. Without this information is impossible to create paginators that don't rely on the `resource_count`.

(Same as #997)