### PR TITLE
Use foreign_key option when getting foreign key value.

### DIFF
--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -454,11 +454,11 @@ module JSONAPI
     def foreign_key_value(source, relationship)
       related_resource_id = if source.preloaded_fragments.has_key?(format_key(relationship.name))
         source.preloaded_fragments[format_key(relationship.name)].values.first.try(:id)
-      elsif source.respond_to?("#{relationship.name}_id")
+      elsif source.respond_to?(relationship.foreign_key)
         # If you have direct access to the underlying id, you don't have to load the relationship
         # which can save quite a lot of time when loading a lot of data.
         # This does not apply to e.g. has_one :through relationships.
-        source.public_send("#{relationship.name}_id")
+        source.public_send(relationship.foreign_key)
       else
         source.public_send(relationship.name).try(:id)
       end

--- a/test/unit/serializer/serializer_test.rb
+++ b/test/unit/serializer/serializer_test.rb
@@ -985,6 +985,18 @@ class SerializerTest < ActionDispatch::IntegrationTest
     JSONAPI.configuration.always_include_to_one_linkage_data = false
   end
 
+  def test_serializer_always_include_to_one_linkage_data_does_not_load_association
+    JSONAPI.configuration.always_include_to_one_linkage_data = true
+
+    post = Post.find(1)
+    resource = Api::V1::PostResource.new(post, nil)
+    JSONAPI::ResourceSerializer.new(Api::V1::PostResource).serialize_to_hash(resource)
+
+    refute_predicate post.association(:writer), :loaded?
+  ensure
+    JSONAPI.configuration.always_include_to_one_linkage_data = false
+  end
+
   def test_serializer_array_of_resources
 
     posts = []


### PR DESCRIPTION
I noticed that I was getting N+1 queries when using `always_include_to_one_linkage_data`. I tracked it down to the `foreign_key_value` method, which does try to use the foreign key without loading the associated object, but it was hardcoded to use `foo_id` rather than using the relationship's `:foreign_key` option if provided. Pretty straightforward fix.

I also added a unit test for this logic, because I couldn't find any obvious way to modify an existing test to cover this. Let me know if you have a better idea (or if you think it doesn't need to be tested).
