### PR TITLE
Give resource more control over sortable fields

### DIFF
--- a/lib/jsonapi/request_parser.rb
+++ b/lib/jsonapi/request_parser.rb
@@ -426,9 +426,8 @@ module JSONAPI
 
     def check_sort_criteria(resource_klass, sort_criteria)
       sort_field = sort_criteria[:field]
-      sortable_fields = resource_klass.sortable_fields(context)
 
-      unless sortable_fields.include? sort_field.to_sym
+      unless resource_klass.sortable_field?(sort_field.to_sym, context)
         @errors.concat(JSONAPI::Exceptions::InvalidSortCriteria
                            .new(format_key(resource_klass._type), sort_field).errors)
       end

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -607,6 +607,10 @@ module JSONAPI
         _attributes.keys
       end
 
+      def sortable_field?(key, context = nil)
+        sortable_fields(context).include? key.to_sym
+      end
+
       def fields
         _relationships.keys | _attributes.keys
       end

--- a/test/unit/jsonapi_request/jsonapi_request_test.rb
+++ b/test/unit/jsonapi_request/jsonapi_request_test.rb
@@ -14,6 +14,12 @@ class CatResource < JSONAPI::Resource
   end
 end
 
+class TreeResource < JSONAPI::Resource
+  def self.sortable_field?(key, context)
+    key =~ /^sort\d+/
+  end
+end
+
 class JSONAPIRequestTest < ActiveSupport::TestCase
   def test_parse_includes_underscored
     params = ActionController::Parameters.new(
@@ -209,6 +215,15 @@ class JSONAPIRequestTest < ActiveSupport::TestCase
     sort_criteria = @request.parse_sort_criteria(CatResource, "-name")
     assert_equal(@request.errors, [])
     assert_equal(sort_criteria, [{:field=>"name", :direction=>:desc}])
+  end
+
+  def test_parse_sort_with_resource_validated_sorts
+    setup_request
+    sort_criteria = @request.parse_sort_criteria(TreeResource, "sort66,name")
+    assert_equal(@request.errors.count, 1)
+    assert_equal(@request.errors.first.title, "Invalid sort criteria")
+    assert_equal(@request.errors.first.detail, "name is not a valid sort criteria for trees")
+    assert_equal(sort_criteria, [{:field=>"sort66", :direction=>:asc}, {:field=>"name", :direction=>:asc}])
   end
 
   def test_parse_sort_with_relationships

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -689,4 +689,10 @@ LEFT JOIN people AS author_sorting ON author_sorting.id = posts.author_id", resu
     refute_includes(PostWithReadonlyAttributesResource.creatable_fields, :author)
     refute_includes(PostWithReadonlyAttributesResource.updatable_fields, :author)
   end
+
+  def test_sortable_field?
+    assert(PostResource.sortable_field?(:title))
+    assert(PostResource.sortable_field?(:body))
+    refute(PostResource.sortable_field?(:color))
+  end
 end


### PR DESCRIPTION
I'm in a situation where I want clients to have repeatable, random sort
order on a collection. My solution is to pass a ?sort=rand-N, with N
being the seed used for sorting. This way, if the client was to page
through the list or link to the list, the sort order would be preserved.

For example, `/providers?sort=rand-42` would apply a random sort order
with 42 as the key.

To accommodate this, I need JSONAPI::RequestParser to allow sort keys
that are not in a predetermined list. I think a good solution to this
would be to have the RequestParser defer to the Resource when checking
if a sort key is valid.

The existing behaviour is maintained by moving the check on
sortable_fields to sortable_field?, which can be overloaded by
application specific resource classes.

I will write some tests and docs if this approach is acceptable to the
maintainers.