### PR TITLE
Bug fix: Allow multiple relationships to be defined in one declaration.

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -913,7 +913,7 @@ module JSONAPI
         if _model_class && _model_class.ancestors.collect { |ancestor| ancestor.name }.include?('ActiveRecord::Base')
           model_association = _model_class.reflect_on_association(relationship_name)
           if model_association
-            options[:class_name] ||= model_association.class_name
+            options = options.reverse_merge(class_name: model_association.class_name)
           end
         end
 

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -936,8 +936,7 @@ class PersonResource < BaseResource
   attributes :name, :email
   attribute :date_joined, format: :date_with_timezone
 
-  has_many :comments
-  has_many :posts
+  has_many :comments, :posts
   has_many :vehicles, polymorphic: true
 
   has_one :preferences


### PR DESCRIPTION
I ran into some weird errors when I used `has_many :foo, :bar` to define two relationships in one declaration. I tracked it down to the fact that it was mutating the options hash in order to add `class_name: Foo` for the first relationship, which polluted the options for the second relationship.