### PR TITLE
Travis: use Ruby 2.4.1 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,12 @@ rvm:
   - 2.1.10
   - 2.2.6
   - 2.3.3
-  - 2.4.0
+  - 2.4.1
 matrix:
   exclude:
     - rvm: 2.1.10
       env: "RAILS_VERSION=5.0.0"
-    - rvm: 2.4.0
+    - rvm: 2.4.1
       env: "RAILS_VERSION=4.2.7"
   allow_failures:
     - env: "RAILS_VERSION=master"


### PR DESCRIPTION
This PR updates the Travis build matrix to use Ruby 2.4.1.