### PR TITLE
Handle empty include= parameter.

### DIFF
--- a/lib/jsonapi/request_parser.rb
+++ b/lib/jsonapi/request_parser.rb
@@ -345,7 +345,7 @@ module JSONAPI
 
       included_resources = []
       begin
-        included_resources += raw_include.is_a?(Array) ? raw_include : CSV.parse_line(raw_include)
+        included_resources += raw_include.is_a?(Array) ? raw_include : CSV.parse_line(raw_include) || []
       rescue CSV::MalformedCSVError
         fail JSONAPI::Exceptions::InvalidInclude.new(format_key(resource_klass._type), raw_include)
       end

--- a/test/unit/jsonapi_request/jsonapi_request_test.rb
+++ b/test/unit/jsonapi_request/jsonapi_request_test.rb
@@ -42,6 +42,11 @@ class JSONAPIRequestTest < ActiveSupport::TestCase
     assert request.errors.empty?
   end
 
+  def test_parse_blank_includes
+    include_directives = JSONAPI::RequestParser.new.parse_include_directives(nil, '')
+    assert_empty include_directives.model_includes
+  end
+
   def test_parse_dasherized_with_dasherized_include
     params = ActionController::Parameters.new(
       {


### PR DESCRIPTION
Out of curiosity, I tried sending my JR server a request with `?include=` with nothing after the `=`, and got a 500 error. It turns out that, annoyingly, `CSV.parse_line('')` returns `nil` rather than an empty array.

I thought about also changing the `nil?` check on line 353 to be `empty?`, because I don't see how `included_resources` can ever be `nil` at that point, but I figured it might be important to return an empty `IncludeDirectives` object in this case. (In which case that line should probably be deleted.)