### PR TITLE
Improve polymorphic links

### DIFF
--- a/lib/jsonapi/relationship.rb
+++ b/lib/jsonapi/relationship.rb
@@ -49,8 +49,8 @@ module JSONAPI
 
     def type_for_source(source)
       if polymorphic?
-        resource = source.public_send(name)
-        resource.class._type if resource
+        model = source._model.public_send(@relation_name)
+        source.class.resource_klass_for_model(model)._type if model
       else
         type
       end

--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -454,7 +454,7 @@ module JSONAPI
     def foreign_key_value(source, relationship)
       related_resource_id = if source.preloaded_fragments.has_key?(format_key(relationship.name))
         source.preloaded_fragments[format_key(relationship.name)].values.first.try(:id)
-      elsif !relationship.redefined_pkey? && !relationship.polymorphic? && source.respond_to?(relationship.foreign_key)
+      elsif !relationship.redefined_pkey? && source.respond_to?(relationship.foreign_key)
         # If you have direct access to the underlying id, you don't have to load the relationship
         # which can save quite a lot of time when loading a lot of data.
         # This does not apply to e.g. has_one :through relationships.


### PR DESCRIPTION
This PR will improve loading of polymorphic links.
Now it will point directly to model relation without hitting resource which will improve request time in case of custom logic (in downloading relation) [records_for]

In our case, this improved request time by 300%