### PR TITLE
Set version constant to 0.10.0.pre

### DIFF
--- a/lib/jsonapi/resources/version.rb
+++ b/lib/jsonapi/resources/version.rb
@@ -1,5 +1,5 @@
 module JSONAPI
   module Resources
-    VERSION = '0.9.0.pre'
+    VERSION = '0.10.0.pre'
   end
 end


### PR DESCRIPTION
This is to make it easier to test gems against the master branch of JR when their dep specs say ">= 0.9.0" or similar.