### PR TITLE
Fix nested namespaces parsing and resource resolving

### DIFF
--- a/lib/jsonapi/request_parser.rb
+++ b/lib/jsonapi/request_parser.rb
@@ -529,7 +529,7 @@ module JSONAPI
 
       unless links_object[:id].nil?
         resource = resource_klass || Resource
-        relationship_resource = resource.resource_klass_for(unformat_key(links_object[:type]).to_s)
+        relationship_resource = resource.resource_klass_for(unformat_key(relationship.options[:class_name] || links_object[:type]).to_s)
         relationship_id = relationship_resource.verify_key(links_object[:id], @context)
         if relationship.polymorphic?
           { id: relationship_id, type: unformat_key(links_object[:type].to_s) }

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -446,7 +446,7 @@ module JSONAPI
 
       def resource_klass_for(type)
         type = type.underscore
-        type_with_module = type.include?('/') ? type : module_path + type
+        type_with_module = type.start_with?(module_path) ? type : module_path + type
 
         resource_name = _resource_name_from_type(type_with_module)
         resource = resource_name.safe_constantize if resource_name

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -85,10 +85,17 @@ module MyModule
   class MyNamespacedResource < JSONAPI::Resource
     model_name "Person"
     has_many :related
+    has_one :default_profile, class_name: "Nested::Profile"
   end
 
   class RelatedResource < JSONAPI::Resource
     model_name "Comment"
+  end
+
+  module Nested
+    class ProfileResource < JSONAPI::Resource
+      model_name "Nested::Profile"
+    end
   end
 end
 
@@ -153,6 +160,12 @@ class ResourceTest < ActiveSupport::TestCase
 
   def test_resource_for_namespaced_resource
     assert_equal(MyModule::MyNamespacedResource.resource_klass_for('related'), MyModule::RelatedResource)
+  end
+
+  def test_resource_for_nested_namespaced_resource
+    assert_equal(JSONAPI::Resource.resource_klass_for('my_module/nested/profile'), MyModule::Nested::ProfileResource)
+    assert_equal(MyModule::MyNamespacedResource.resource_klass_for('my_module/nested/profile'), MyModule::Nested::ProfileResource)
+    assert_equal(MyModule::MyNamespacedResource.resource_klass_for('nested/profile'), MyModule::Nested::ProfileResource)
   end
 
   def test_relationship_parent_point_to_correct_resource


### PR DESCRIPTION
With this setup: 
```ruby
class Managing::Profile < ActiveRecord::Base
  belongs_to :company
end

class Company < ActiveRecord::Base
  belongs_to :default_managing_profile, class_name: '::Managing::Profile'
end

class Api::V1::BaseResource < JSONAPI::Resource
  abstract

  attributes :created_at, :updated_at

  def self.updatable_fields(context)
    super - [:created_at, :updated_at]
  end

  def self.creatable_fields(context)
    super - [:created_at, :updated_at]
  end
end

class Api::V1::Managing::ProfileResource < Api::V1::BaseResource
  model_name 'Managing::Profile'
  attributes :name
end

class Api::V1::CompanyResource < Api::V1::BaseResource
  model_name 'Company'
  attributes :name
  has_one :default_managing_profile, class_name: 'Managing::Profile'
end
```
, there were several things that didn't work:
- on startup, without `class_name: 'Managing::Profile'` in `CompanyResource`, it would report that it could not find related model
- requesting included profile via `http://localhost:3000/api/v1/companies/3?include=default_managing_profile`, it would also break, unable to find the related resource
- on posting a new company, with relation to existing managing profile, it would again break, for the same reason

example of post payload: 
```json
{
  "data": {
    "attributes": {
      "name": "Dummy"
    },
    "relationships": {
      "default_managing_profile": {
        "data": {
          "type": "profiles",
          "id": "3"
        }
      }
    },
    "type": "companies"
  }
}
```
I also tried setting the data type for `default_managing_profile` to one of:
- `managing/profiles`
- `/managing/profiles`
- `Managing::Profile`
- `managing_profiles`

and probably some other too, but without luck.

The fix in `resource.rb` solved first two issues. The fix in `request_parser.rb` fixed the last one. I tried adding related tests, but could not find a simple way to test the last issue.

Hopefully this makes sense 😄 

P.S. I've noticed that `RequestParser#parse_to_many_relationship` has a bit different logic than `parse_to_one_relationship` so maybe I'm missing something here. Maybe there is a way to accomplish the desired outcome without this fix?

P.P.S. Possibly related to #893 and #927.