### PR TITLE
Rework apply_filter(s) to allow callables to be called for relationship filters

### DIFF
--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -1488,7 +1488,11 @@ module Api
 
       has_many :aliased_comments, class_name: 'BookComments', relation_name: :approved_book_comments
 
-      filters :book_comments
+      filter :book_comments,
+              apply: ->(records, value, options) {
+                return records.where('book_comments.id' => value)
+              }
+
       filter :banned, apply: :apply_filter_banned
 
       class << self


### PR DESCRIPTION
Noticed that callables on filters on relationships were not being called. This should fix that.

Moves the filtering logic to `apply_filter` from `apply_filters`.
Modifies the includes in the options hash instead of applying the includes twice.

One possible change we could make is to modify the includes if an `apply` callable is provide. This would push handling the included relationship onto the callable author, which might create problems for authors since it's not obvious it must be done.