### PR TITLE
Fix apply_sort

### DIFF
--- a/lib/jsonapi/active_record_accessor.rb
+++ b/lib/jsonapi/active_record_accessor.rb
@@ -210,6 +210,11 @@ module JSONAPI
     end
 
     def apply_sort(records, order_options, context = {})
+      if defined?(_resource_klass.apply_sort)
+        custom_sort = _resource_klass.apply_sort(records, order_options, context)
+        records = custom_sort unless custom_sort.nil?
+      end
+
       if order_options.any?
         order_options.each_pair do |field, direction|
           if field.to_s.include?(".")
@@ -227,9 +232,7 @@ module JSONAPI
         end
       end
 
-      return records unless defined?(_resource_klass.apply_sort)
-      custom_sort = _resource_klass.apply_sort(records, order_options, context)
-      custom_sort.nil? ? records : custom_sort
+      records
     end
 
     def _lookup_association_chain(model_names)

--- a/lib/jsonapi/active_record_accessor.rb
+++ b/lib/jsonapi/active_record_accessor.rb
@@ -212,9 +212,13 @@ module JSONAPI
     def apply_sort(records, order_options, context = {})
       if defined?(_resource_klass.apply_sort)
         custom_sort = _resource_klass.apply_sort(records, order_options, context)
-        records = custom_sort unless custom_sort.nil?
+        custom_sort.nil? ? default_sort(records, order_options) : custom_sort
+      else
+        default_sort(records, order_options)
       end
+    end
 
+    def default_sort(records, order_options)
       if order_options.any?
         order_options.each_pair do |field, direction|
           if field.to_s.include?(".")

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -378,12 +378,36 @@ class ResourceTest < ActiveSupport::TestCase
     end
   end
 
+  def test_custom_sorting
+    post_resource = PostResource.new(Post.find(1), nil)
+    comment_ids = post_resource.comments.map{|c| c._model.id }
+    assert_equal [1,2], comment_ids
+
+    # define apply_sort method on post resource that will never sort
+    PostResource.instance_eval do
+      def apply_sort(records, criteria, context = {})
+        if criteria.key?('name')
+          # this sort will never occure
+          records.order('name asc')
+        end
+      end
+    end
+
+    sorted_comment_ids = post_resource.comments(sort_criteria: [{ field: 'id', direction: :desc}]).map{|c| c._model.id }
+    assert_equal [2,1], sorted_comment_ids
+  ensure
+    # reset method to original implementation
+    PostResource.instance_eval do
+      undef :apply_sort
+    end
+  end
+
   def test_to_many_relationship_sorts
     post_resource = PostResource.new(Post.find(1), nil)
     comment_ids = post_resource.comments.map{|c| c._model.id }
     assert_equal [1,2], comment_ids
 
-    # define apply_filters method on post resource to sort descending
+    # define apply_sort method on post resource to sort descending
     PostResource.instance_eval do
       def apply_sort(records, criteria, context = {})
         # :nocov:
@@ -399,28 +423,7 @@ class ResourceTest < ActiveSupport::TestCase
   ensure
     # reset method to original implementation
     PostResource.instance_eval do
-      def apply_sort(records, order_options, _context = {})
-        # :nocov:
-        if order_options.any?
-          order_options.each_pair do |field, direction|
-            if field.to_s.include?(".")
-              *model_names, column_name = field.split(".")
-
-              associations = _lookup_association_chain([records.model.to_s, *model_names])
-              joins_query = _record_accessor._build_joins([records.model, *associations])
-
-              # _sorting is appended to avoid name clashes with manual joins eg. overriden filters
-              order_by_query = "#{associations.last.name}_sorting.#{column_name} #{direction}"
-              records = records.joins(joins_query).order(order_by_query)
-            else
-              records = records.order(field => direction)
-            end
-          end
-        end
-
-        records
-        # :nocov:
-      end
+      undef :apply_sort
     end
   end
 


### PR DESCRIPTION
Hi @lgebhardt,
We encountered an issue associated with `apply_sort` method.

Doc is saying (http://jsonapi-resources.com/v0.9/guide/resources.html#Sortable-Attributes) that we can override apply_sort like:
```ruby
def self.apply_sort(records, order_options, context = {})
  if order_options.has?(:trending)
    records = records.order_by_trending_scope
    order_options - [:trending]
  end

  super(records, order_options, context)
end
```

But indeed, we can not use `super(records, order_options, context)` because the super method does not exist. And because of that, any other sorts have not been applied.

I found a problem and modified the `apply_sort` method and now it's performing default sorting -> passing the results to custom apply_sort (if exist) -> returning custom apply_sort results or if they are `nil` resulting original results.

So now you can just:
```ruby
def self.apply_sort(records, order_options, context = {})
  if order_options.has?(:trending)
    order_options - [:trending]
    records.order_by_trending_scope
  end
end
```

And in fact, this will work as a `super` but also without a need to call it.