### PR TITLE
Tightens the error handling on include parsing.

### DIFF
--- a/lib/jsonapi/include_directives.rb
+++ b/lib/jsonapi/include_directives.rb
@@ -52,7 +52,7 @@ module JSONAPI
           current_relationship = current_resource_klass._relationships[fragment]
           current_resource_klass = current_relationship.try(:resource_klass)
         else
-          warn "[RELATIONSHIP NOT FOUND] Relationship could not be found for #{current_path}."
+          raise JSONAPI::Exceptions::InvalidInclude.new(current_resource_klass, current_path)
         end
 
         include_in_join = @force_eager_load || !current_relationship || current_relationship.eager_load_on_include

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -2043,13 +2043,24 @@ class ExpenseEntriesControllerTest < ActionController::TestCase
     assert_cacheable_get :show, params: {id: 1, include: 'isoCurrencies,employees'}
     assert_response :bad_request
     assert_match /isoCurrencies is not a valid relationship of expenseEntries/, json_response['errors'][0]['detail']
-    assert_match /employees is not a valid relationship of expenseEntries/, json_response['errors'][1]['detail']
   end
 
   def test_expense_entries_show_bad_include_missing_sub_relationship
     assert_cacheable_get :show, params: {id: 1, include: 'isoCurrency,employee.post'}
     assert_response :bad_request
     assert_match /post is not a valid relationship of people/, json_response['errors'][0]['detail']
+  end
+
+  def test_invalid_include
+    assert_cacheable_get :index, params: {include: 'invalid../../../../'}
+    assert_response :bad_request
+    assert_match /invalid is not a valid relationship of expenseEntries/, json_response['errors'][0]['detail']
+  end
+
+  def test_invalid_include_long_garbage_string
+    assert_cacheable_get :index, params: {include: 'invalid.foo.bar.dfsdfs,dfsdfs.sdfwe.ewrerw.erwrewrew'}
+    assert_response :bad_request
+    assert_match /invalid is not a valid relationship of expenseEntries/, json_response['errors'][0]['detail']
   end
 
   def test_expense_entries_show_fields

--- a/test/unit/serializer/include_directives_test.rb
+++ b/test/unit/serializer/include_directives_test.rb
@@ -143,4 +143,22 @@ class IncludeDirectivesTest < ActiveSupport::TestCase
     directives = JSONAPI::IncludeDirectives.new(PersonResource, ['posts.comments.tags'])
     assert_array_equals([{:posts=>[{:comments=>[:tags]}]}], directives.model_includes)
   end
+
+  def test_invalid_includes_1
+    assert_raises JSONAPI::Exceptions::InvalidInclude do
+      JSONAPI::IncludeDirectives.new(PersonResource, ['../../../../']).include_directives
+    end
+  end
+
+  def test_invalid_includes_2
+    assert_raises JSONAPI::Exceptions::InvalidInclude do
+      JSONAPI::IncludeDirectives.new(PersonResource, ['posts./sdaa./........']).include_directives
+    end
+  end
+
+  def test_invalid_includes_3
+    assert_raises JSONAPI::Exceptions::InvalidInclude do
+      JSONAPI::IncludeDirectives.new(PersonResource, ['invalid../../../../']).include_directives
+    end
+  end
 end


### PR DESCRIPTION
Now fails on the first error encountered.