### PR TITLE
WIP: Resource level pagination options

### DIFF
--- a/lib/jsonapi/request_parser.rb
+++ b/lib/jsonapi/request_parser.rb
@@ -259,7 +259,13 @@ module JSONAPI
 
     def parse_pagination(resource_klass, page)
       paginator_name = resource_klass._paginator
-      JSONAPI::Paginator.paginator_for(paginator_name).new(page) unless paginator_name == :none
+      return if paginator_name == :none
+
+      options   = resource_klass._paginator_options
+      paginator = JSONAPI::Paginator.paginator_for(paginator_name)
+      arity     = paginator.instance_method(:initialize).arity
+
+      arity == 2 ? paginator.new(page, options) : paginator.new(page)
     end
 
     def parse_fields(resource_klass, fields)

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -806,8 +806,13 @@ module JSONAPI
         @_paginator ||= JSONAPI.configuration.default_paginator
       end
 
-      def paginator(paginator)
+      def _paginator_options
+        @_paginator_options ||= {}
+      end
+
+      def paginator(paginator, options = {})
         @_paginator = paginator
+        @_paginator_options = options
       end
 
       def _record_accessor


### PR DESCRIPTION
I've recently had the need to implement resource level pagination options. I've put in a `WIP` MR for this - not fully tested, and I suspect that the changes to `request_parser` will break *something* somewhere. 


```
class MyResource < JSONAPI::Resource
  paginator :paged, default_page_size: 50, default_page_number: 3
end
```

Is this an idea that is worth pursuing? 