### PR TITLE
Allow sorting on related attributes of has_one relationships.

### DIFF
--- a/jsonapi-resources.gemspec
+++ b/jsonapi-resources.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.5'
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'minitest'
+  spec.add_development_dependency 'minitest', '~> 5.10', '!= 5.10.2'
   spec.add_development_dependency 'minitest-spec-rails'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'pry'

--- a/lib/jsonapi/active_record_accessor.rb
+++ b/lib/jsonapi/active_record_accessor.rb
@@ -257,7 +257,12 @@ module JSONAPI
       joins = []
 
       associations.inject do |prev, current|
-        joins << "LEFT JOIN #{current.table_name} AS #{current.name}_sorting ON #{current.name}_sorting.id = #{prev.table_name}.#{current.foreign_key}"
+        if current.has_one?
+          joins << "LEFT JOIN #{current.table_name} AS #{current.name}_sorting ON #{current.name}_sorting.#{current.foreign_key} = #{prev.table_name}.id"
+        else
+          joins << "LEFT JOIN #{current.table_name} AS #{current.name}_sorting ON #{current.name}_sorting.id = #{prev.table_name}.#{current.foreign_key}"
+        end
+
         current
       end
       joins.join("\n")

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -457,12 +457,15 @@ class ResourceTest < ActiveSupport::TestCase
   end
 
   def test_build_joins
-    model_names = %w(person posts parent_post author)
+    model_names = %w(person posts parent_post author author_detail)
     associations = PostResource._lookup_association_chain(model_names)
     result = PostResource._record_accessor._build_joins(associations)
 
-    assert_equal "LEFT JOIN posts AS parent_post_sorting ON parent_post_sorting.id = posts.parent_post_id
-LEFT JOIN people AS author_sorting ON author_sorting.id = posts.author_id", result
+    sql = "LEFT JOIN posts AS parent_post_sorting ON parent_post_sorting.parent_post_id = posts.id
+LEFT JOIN people AS author_sorting ON author_sorting.id = posts.author_id
+LEFT JOIN author_details AS author_detail_sorting ON author_detail_sorting.person_id = people.id"
+
+    assert_equal sql, result
   end
 
   def test_to_many_relationship_pagination


### PR DESCRIPTION
Current master has a bug when sorting on related attributes, if the relationship is a `has_one`/`foreign_key_on: :related`. The following code will produce this error

```
Mysql2::Error: Unknown column 'containers.container_id' in 'on clause': SELECT  `containers`.* FROM `containers` LEFT JOIN sensors AS sensor_sorting ON sensor_sorting.id = containers.container_id
```

``` ruby
class Container < ApplicationRecord
  has_one :inventory_sensor, required: false
end

class Sensor < ApplicationRecord
  belongs_to :container, required: false
end

class ContainerResource < BaseResource
  has_one :sensor, foreign_key_on: :related

  def self.sortable_fields(context)
    super(context) + [:"sensor.reading"]
  end
end
```
`_build_joins()` was looking at the wrong table for the related foreign_key. The join needs to be built differently depending on where the foreign key will live. The current tests don't catch this because they seem to all use a self-referential `has_one` relationship, so the foreign_key is there.

So I just added a conditional that alters the query based on whether or not it is a `has_one` relationship, and updated the test. I have integration testing around this in my project, but I was having difficulty dealing with the `jsonapi-resources` test suite, so I just fixed the one test I broke, but it would be great to have some integration testing around this.

Feel free to make any necessary adjustments or provide me with any feedback.

Thanks for the awesome gem.