### PR TITLE
Add custom sorts feature

### DIFF
--- a/lib/jsonapi/active_record_accessor.rb
+++ b/lib/jsonapi/active_record_accessor.rb
@@ -220,7 +220,7 @@ module JSONAPI
             if custom_sort.is_a?(Symbol) || custom_sort.is_a?(String)
               records = _resource_klass.send(custom_sort, records, direction, context)
             else
-              records = custom_sort.call(records, direction, context)
+              records = _resource_klass.instance_exec(records, direction, context, &custom_sort)
             end
           else
             if field.to_s.include?(".")
@@ -272,7 +272,7 @@ module JSONAPI
         if strategy.is_a?(Symbol) || strategy.is_a?(String)
           _resource_klass.send(strategy, records, value, options)
         else
-          strategy.call(records, value, options)
+          _resource_klass.instance_exec(records, value, options, &strategy)
         end
       else
         if _resource_klass._relationships.include?(filter)

--- a/lib/jsonapi/active_record_accessor.rb
+++ b/lib/jsonapi/active_record_accessor.rb
@@ -230,10 +230,10 @@ module JSONAPI
               joins_query = _build_joins([records.model, *associations])
 
               # _sorting is appended to avoid name clashes with manual joins eg. overridden filters
-              order_by_query = "LOWER(#{associations.last.name}_sorting.#{column_name}) #{direction}"
+              order_by_query = "#{associations.last.name}_sorting.#{column_name} #{direction}"
               records = records.joins(joins_query).order(order_by_query)
             else
-              records = records.order("LOWER(#{records.table_name}.#{field}) #{direction}")
+              records = records.order(field => direction)
             end
           end
         end

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -417,6 +417,7 @@ module JSONAPI
         subclass.rebuild_relationships(_relationships || {})
 
         subclass._allowed_filters = (_allowed_filters || Set.new).dup
+        subclass._custom_sorts = (_custom_sorts || Set.new).dup
 
         type = subclass.name.demodulize.sub(/Resource$/, '').underscore
         subclass._type = type.pluralize.to_sym
@@ -480,7 +481,7 @@ module JSONAPI
       end
 
       attr_accessor :_attributes, :_relationships, :_type, :_model_hints
-      attr_writer :_allowed_filters, :_paginator
+      attr_writer :_allowed_filters, :_paginator, :_custom_sorts
 
       def create(context)
         new(create_model, context)
@@ -586,6 +587,10 @@ module JSONAPI
         @_allowed_filters[attr.to_sym] = args.extract_options!
       end
 
+      def sort(attr, *args)
+        @_custom_sorts[attr.to_sym] = args.extract_options!
+      end
+
       def primary_key(key)
         @_primary_key = key.to_sym
       end
@@ -606,7 +611,7 @@ module JSONAPI
 
       # Override in your resource to filter the sortable keys
       def sortable_fields(_context = nil)
-        _attributes.keys
+        _attributes.keys + _custom_sorts.keys
       end
 
       def sortable_field?(key, context = nil)
@@ -808,6 +813,10 @@ module JSONAPI
 
       def _allowed_filters
         defined?(@_allowed_filters) ? @_allowed_filters : { id: {} }
+      end
+
+      def _custom_sorts
+        @_custom_sorts ||= {}
       end
 
       def _paginator


### PR DESCRIPTION
Hi,
I've just added a feature which adds a possibility to define custom sorts as filters do.
```rb
  sort :my_sort, apply: (lambda do |records, order_direction, context|
    records.my_custom_order_by(order_direction)
  end)
```

Thanks to that users can just forgot about overriding `apply_sort` method to just add a custom sort property like:
```rb
    def apply_sort(records, order_options, _context = {})
      if order_options.key?('my_sort')
        records = records.order_by_my_sort
      end
    end

    def sortable_fields(context)
      super(context) + [:my_sort]
    end
```

So now, this is unneeded.
