### PR TITLE
Included the ability to define a custom type to a resource

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -834,6 +834,10 @@ module JSONAPI
         @abstract = val
       end
 
+      def type(type)
+        self._type = type
+      end
+
       def _abstract
         @abstract
       end

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -58,6 +58,10 @@ class FelineResource < JSONAPI::Resource
   has_one :father, class_name: 'Cat'
 end
 
+class PersonWithCustomResourceTypeResource < PersonResource
+  type 'this-is-a-custom-type'
+end
+
 class PersonWithCustomRecordsForResource < PersonResource
   def records_for(relationship_name)
     :records_for
@@ -710,5 +714,11 @@ LEFT JOIN people AS author_sorting ON author_sorting.id = posts.author_id", resu
     assert(PostResource.sortable_field?(:title))
     assert(PostResource.sortable_field?(:body))
     refute(PostResource.sortable_field?(:color))
+  end
+
+  def test_custom_resource_type
+    author = Person.find(1)
+    author_resource = PersonWithCustomResourceTypeResource.new(author, nil)
+    assert_equal(author_resource.class._type, "this-is-a-custom-type")
   end
 end


### PR DESCRIPTION
This enables the developer to define a customize the resource type. In order to do so, the developer should invoke the method `type` passing the required type as a parameter. See the example below:

```
class PersonWithCustomResourceTypeResource < PersonResource
  type 'this-is-a-custom-type'
end
```



