### PR TITLE
Use original key format when displaying error for filter not allowed

### DIFF
--- a/lib/jsonapi/request_parser.rb
+++ b/lib/jsonapi/request_parser.rb
@@ -384,7 +384,7 @@ module JSONAPI
         if resource_klass._allowed_filter?(filter)
           parsed_filters[filter] = value
         else
-          fail JSONAPI::Exceptions::FilterNotAllowed.new(filter)
+          fail JSONAPI::Exceptions::FilterNotAllowed.new(key)
         end
       end
 


### PR DESCRIPTION
`/clients?filter[first-name]='bob'` 

which results in:

```ruby
{
   "errors":[
      {
         "code":"102",
         "detail":"first_name is not allowed.",
         "status":"400",
         "title":"Filter not allowed"
      }
   ]
}
```

Which could be potentially confusing.