### PR TITLE
Adds fix for nil child relationship paginator in `Processor#show_related_resources`

### DIFF
--- a/lib/jsonapi/processor.rb
+++ b/lib/jsonapi/processor.rb
@@ -184,7 +184,7 @@ module JSONAPI
       end
 
       if (JSONAPI.configuration.top_level_meta_include_page_count && record_count)
-        page_count = paginator.calculate_page_count(record_count)
+        page_count = paginator ? paginator.calculate_page_count(record_count) : nil
       end
 
       pagination_params = if paginator && JSONAPI.configuration.top_level_links_include_pagination
@@ -198,7 +198,7 @@ module JSONAPI
       opts = result_options
       opts.merge!(pagination_params: pagination_params) if JSONAPI.configuration.top_level_links_include_pagination
       opts.merge!(record_count: record_count) if JSONAPI.configuration.top_level_meta_include_record_count
-      opts.merge!(page_count: page_count) if JSONAPI.configuration.top_level_meta_include_page_count
+      opts.merge!(page_count: page_count) if JSONAPI.configuration.top_level_meta_include_page_count && page_count
 
       return JSONAPI::RelatedResourcesOperationResult.new(:ok,
                                                           source_resource,


### PR DESCRIPTION
## Background

When specifying `JSONAPI.configuration.top_level_meta_include_page_count = true` in configuration and having a model be paginated via `paginator :paged` in its resource the child relationships for `has_many` on that model try to be get paginated as well. This leads to the following stacktrace: 

```bash
website_1   | [5ef45369-c065-4531-8ebe-729f4221d280] Internal Server Error: undefined method `calculate_page_count' for nil:NilClass /usr/local/bundle/gems/jsonapi-resources-0.9.0/lib/jsonapi/processor.rb:206:in `show_related_resources'
website_1   | /usr/local/bundle/gems/jsonapi-resources-0.9.0/lib/jsonapi/processor.rb:58:in `block (2 levels) in process'
website_1   | /usr/local/bundle/gems/activesupport-5.1.0/lib/active_support/callbacks.rb:97:in `run_callbacks'
website_1   | /usr/local/bundle/gems/jsonapi-resources-0.9.0/lib/jsonapi/processor.rb:57:in `block in process'
website_1   | /usr/local/bundle/gems/activesupport-5.1.0/lib/active_support/callbacks.rb:97:in `run_callbacks'
website_1   | /usr/local/bundle/gems/jsonapi-resources-0.9.0/lib/jsonapi/processor.rb:56:in `process'
website_1   | /usr/local/bundle/gems/jsonapi-resources-0.9.0/lib/jsonapi/operation.rb:16:in `process'
website_1   | /usr/local/bundle/gems/jsonapi-resources-0.9.0/lib/jsonapi/operation_dispatcher.rb:58:in `block in process_operation'
website_1   | /usr/local/bundle/gems/jsonapi-resources-0.9.0/lib/jsonapi/operation_dispatcher.rb:63:in `with_default_handling'
website_1   | /usr/local/bundle/gems/jsonapi-resources-0.9.0/lib/jsonapi/operation_dispatcher.rb:57:in `process_operation'
website_1   | /usr/local/bundle/gems/jsonapi-resources-0.9.0/lib/jsonapi/operation_dispatcher.rb:29:in `block (2 levels) in process'
website_1   | /usr/local/bundle/gems/jsonapi-resources-0.9.0/lib/jsonapi/operation_dispatcher.rb:28:in `each'
website_1   | /usr/local/bundle/gems/jsonapi-resources-0.9.0/lib/jsonapi/operation_dispatcher.rb:28:in `block in process'
website_1   | /usr/local/bundle/gems/jsonapi-resources-0.9.0/lib/jsonapi/operation_dispatcher.rb:46:in `transaction'
website_1   | /usr/local/bundle/gems/jsonapi-resources-0.9.0/lib/jsonapi/operation_dispatcher.rb:24:in `process'
website_1   | /usr/local/bundle/gems/jsonapi-resources-0.9.0/lib/jsonapi/acts_as_resource_controller.rb:86:in `block in process_operations'
website_1   | /usr/local/bundle/gems/activesupport-5.1.0/lib/active_support/callbacks.rb:97:in `run_callbacks'
website_1   | /usr/local/bundle/gems/jsonapi-resources-0.9.0/lib/jsonapi/acts_as_resource_controller.rb:85:in `process_operations'
website_1   | /usr/local/bundle/gems/jsonapi-resources-0.9.0/lib/jsonapi/acts_as_resource_controller.rb:77:in `process_request'
website_1   | /usr/local/bundle/gems/jsonapi-resources-0.9.0/lib/jsonapi/acts_as_resource_controller.rb:60:in `get_related_resources'
```

This is due to the child not having a paginator, which should be fine as we shouldn't need to have the child paginated just because the parent is. This PR follows what 48eaa022 did for `Processor#find`. If the model doesn't have a paginator, we skip adding the `page_count` in `show_related_resources`. 

I would like to add tests to this so I can feel confident that it's not breaking anything else, but I couldn't find a `processor_test.rb` file. @lgebhardt looks like you're the primary maintainer... got any suggestions for adding tests here?

Fixes #968