### PR TITLE
Fix caching for namespaced polymorphic associations

### DIFF
--- a/lib/jsonapi/cached_resource_fragment.rb
+++ b/lib/jsonapi/cached_resource_fragment.rb
@@ -65,7 +65,8 @@ module JSONAPI
     end
 
     def to_real_resource
-      rs = Resource.resource_klass_for(self.type).find_by_keys([self.id], {context: self.context})
+      rs_klass = @resource_klass || Resource.resource_klass_for(self.type)
+      rs = rs_klass.find_by_keys([self.id], {context: self.context})
       return rs.try(:first)
     end
 

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -3520,6 +3520,21 @@ class Api::V1::CratersControllerTest < ActionController::TestCase
   end
 end
 
+class Api::V1::PicturesControllerTest < ActionController::TestCase
+  def test_pictures_index
+    assert_cacheable_get :index
+    assert_response :success
+    assert_equal 3, json_response['data'].size
+  end
+
+  def test_pictures_index_with_polymorphic_include_one_level
+    assert_cacheable_get :index, params: {include: 'imageable'}
+    assert_response :success
+    assert_equal 3, json_response['data'].size
+    assert_equal 2, json_response['included'].size
+  end
+end
+
 class CarsControllerTest < ActionController::TestCase
   def setup
     JSONAPI.configuration.json_key_format = :camelized_key

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -833,6 +833,9 @@ module Api
 
     class LikesController < JSONAPI::ResourceController
     end
+
+    class PicturesController < JSONAPI::ResourceController
+    end
   end
 
   module V2
@@ -1492,6 +1495,10 @@ module Api
     class VehicleResource < VehicleResource; end
     class CarResource < CarResource; end
     class BoatResource < BoatResource; end
+    class ImageableResource < ImageableResource; end
+    class PictureResource < PictureResource; end
+    class ProductResource < ProductResource; end
+    class DocumentResource < DocumentResource; end
   end
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -281,6 +281,7 @@ TestApp.routes.draw do
       jsonapi_resources :craters
       jsonapi_resources :preferences
       jsonapi_resources :likes
+      jsonapi_resources :pictures
     end
 
     JSONAPI.configuration.route_format = :underscored_route


### PR DESCRIPTION
Hi guys,

I noticed there was an issue with caching when looking up namespaced resource classes for polymorphic associations. This issue prevents include queries on resources having a polymorphic association.

Something like this:
```ruby
class Api::V1::PictureResource < JSONAPI::Resource
  caching
  has_one :imageable, polymorphic: true
end

class Api::V1::ProductResource < JSONAPI::Resource
  has_one :picture
end
```

..will fail when doing:
```
# Fails because JR attempts to lookup PictureResource when compiling cached fragments
GET /api/v1/pictures?include=imageable
```

The test attached to this PR does not create a 500 if the patch is not applied (because both PictureResource and Api::V1::PictureResource are defined) but clearly show that the links are incorrect when caching is enabled.