### PR TITLE
Add test case for removal of has-one polymorphic relationship with PATCH

### DIFF
--- a/test/unit/serializer/polymorphic_serializer_test.rb
+++ b/test/unit/serializer/polymorphic_serializer_test.rb
@@ -479,4 +479,26 @@ class PolymorphismTest < ActionDispatch::IntegrationTest
     picture.imageable = original_imageable
     picture.save
   end
+
+  def test_polymorphic_delete_relationship_with_patch
+    picture = Picture.find(1)
+    original_imageable = picture.imageable
+    assert original_imageable
+
+    patch "/pictures/#{picture.id}/relationships/imageable", params:
+           {
+             data: nil
+           }.to_json,
+           headers: {
+             'Content-Type' => JSONAPI::MEDIA_TYPE,
+             'Accept' => JSONAPI::MEDIA_TYPE
+           }
+    assert_response :no_content
+    picture = Picture.find(1)
+    assert_nil picture.imageable
+
+    # restore data
+    picture.imageable = original_imageable
+    picture.save
+  end
 end


### PR DESCRIPTION
This PR adds a failing test case for the issue in #1081

EDIT: For a fix suggestion, see PR #1083 that renders this PR obsolete.