### PR TITLE
Fix removal of polymorphic has-one relationship with PATCH

### DIFF
--- a/lib/jsonapi/request_parser.rb
+++ b/lib/jsonapi/request_parser.rb
@@ -653,8 +653,8 @@ module JSONAPI
 
       if relationship.is_a?(JSONAPI::Relationship::ToOne)
         if relationship.polymorphic?
-          options[:key_value] = verified_params[:to_one].values[0][:id]
-          options[:key_type] = verified_params[:to_one].values[0][:type]
+          options[:key_value] = verified_params[:to_one].values[0] && verified_params[:to_one].values[0][:id]
+          options[:key_type] = verified_params[:to_one].values[0] && verified_params[:to_one].values[0][:type]
 
           operation_type = :replace_polymorphic_to_one_relationship
         else

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -321,7 +321,11 @@ module JSONAPI
       relationship = self.class._relationships[relationship_type.to_sym]
 
       _model.public_send("#{relationship.foreign_key}=", key_value)
-      _model.public_send("#{relationship.polymorphic_type}=", self.class.model_name_for_type(key_type))
+      if key_value.nil? && key_type.nil?
+        _model.public_send("#{relationship.polymorphic_type}=", nil)
+      else
+        _model.public_send("#{relationship.polymorphic_type}=", self.class.model_name_for_type(key_type))
+      end
 
       @save_needed = true
 

--- a/test/unit/serializer/polymorphic_serializer_test.rb
+++ b/test/unit/serializer/polymorphic_serializer_test.rb
@@ -479,4 +479,26 @@ class PolymorphismTest < ActionDispatch::IntegrationTest
     picture.imageable = original_imageable
     picture.save
   end
+
+  def test_polymorphic_delete_relationship_with_patch
+    picture = Picture.find(1)
+    original_imageable = picture.imageable
+    assert original_imageable
+
+    patch "/pictures/#{picture.id}/relationships/imageable", params:
+           {
+             data: nil
+           }.to_json,
+           headers: {
+             'Content-Type' => JSONAPI::MEDIA_TYPE,
+             'Accept' => JSONAPI::MEDIA_TYPE
+           }
+    assert_response :no_content
+    picture = Picture.find(1)
+    assert_nil picture.imageable
+
+    # restore data
+    picture.imageable = original_imageable
+    picture.save
+  end
 end


### PR DESCRIPTION
Fixes #1081, closes #1082

This PR incorporates the failing test case that is present in https://github.com/cerebris/jsonapi-resources/pull/1082 and has a fix for #1081.

