### PR TITLE
Enable custom related links on resource

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -167,6 +167,11 @@ module JSONAPI
       {}
     end
 
+    # Override this to return a custom related link for a given relationship
+    def custom_related_link(relationship, _options)
+      nil
+    end
+
     private
 
     def save

--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -339,6 +339,9 @@ module JSONAPI
     end
 
     def related_link(source, relationship)
+      custom_related_link = source.custom_related_link(relationship, custom_generation_options)
+      return custom_related_link if custom_related_link.present?
+
       link_builder.relationships_related_link(source, relationship)
     end
 

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -1435,6 +1435,12 @@ class SimpleCustomLinkResource < JSONAPI::Resource
   def custom_links(options)
     { raw: options[:serializer].link_builder.self_link(self) + "/raw" }
   end
+
+  def custom_related_link(relationship, options)
+    if relationship.name == 'section' && @model.section_id.present?
+      return options[:serializer].link_builder.base_url + "/sections/#{@model.section_id}"
+    end
+  end
 end
 
 class CustomLinkWithRelativePathOptionResource < JSONAPI::Resource

--- a/test/unit/serializer/serializer_test.rb
+++ b/test/unit/serializer/serializer_test.rb
@@ -2195,6 +2195,49 @@
 #     assert_hash_equals(custom_link_spec, serialized_custom_link_resource)
 #   end
 #
+#   def test_custom_related_link
+#     post = Post.find(2)
+#     serialized_custom_link_resource = JSONAPI::ResourceSerializer.new(SimpleCustomLinkResource, base_url: 'http://example.com').serialize_to_hash(SimpleCustomLinkResource.new(post, {}))
+#
+#     custom_related_link_spec = {
+#         data: {
+#           type: 'simpleCustomLinks',
+#           id: '2',
+#           attributes: {
+#             title: "JR Solves your serialization woes!",
+#             body: "Use JR",
+#             subject: "JR Solves your serialization woes!"
+#           },
+#         links: {
+#           self: "http://example.com/simpleCustomLinks/2",
+#           raw: "http://example.com/simpleCustomLinks/2/raw"
+#         },
+#         relationships: {
+#           writer: {
+#             links: {
+#               self: "http://example.com/simpleCustomLinks/2/relationships/writer",
+#               related: "http://example.com/simpleCustomLinks/2/writer"
+#             }
+#           },
+#           section: {
+#             links: {
+#               self: "http://example.com/simpleCustomLinks/2/relationships/section",
+#               related: "http://example.com/sections/#{post.section_id}"
+#             }
+#           },
+#           comments: {
+#             links: {
+#               self: "http://example.com/simpleCustomLinks/2/relationships/comments",
+#               related: "http://example.com/simpleCustomLinks/2/comments"
+#             }
+#           }
+#         }
+#       }
+#     }
+#
+#     assert_hash_equals(custom_related_link_spec, serialized_custom_link_resource)
+#   end
+#
 #   def test_includes_two_relationships_with_same_foreign_key
 #     serialized_resource = JSONAPI::ResourceSerializer
 #       .new(PersonWithEvenAndOddPostsResource, include: ['even_posts','odd_posts'])


### PR DESCRIPTION
I ran into a use case where a related resource lives on another server, and by providing a custom `related` link for the relationship my Ember code can seamlessly fetch the relationship.