### PR TITLE
Drop self link if nil

### DIFF
--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -255,8 +255,10 @@ module JSONAPI
     end
 
     def custom_links_hash(source)
-      custom_links = source.custom_links(custom_generation_options)
-      (custom_links.is_a?(Hash) && custom_links) || {}
+      links = custom_links_hash(source)
+      links['self'] = link_builder.self_link(source) unless links.key?('self')
+      links.delete('self') if links.key?('self') && links[:self].nil?
+      links.compact
     end
 
     def top_level_source_key(source)


### PR DESCRIPTION
There is a demand for dropping `self` link. Right now it's impossible. This PR will drop link if it's nil via
```
  def custom_links(_options)
    { self: nil }
  end
```