### PR TITLE
Allow more control over allowing includes

### DIFF
--- a/lib/jsonapi/configuration.rb
+++ b/lib/jsonapi/configuration.rb
@@ -10,7 +10,8 @@ module JSONAPI
                 :route_format,
                 :raise_if_parameters_not_allowed,
                 :warn_on_route_setup_issues,
-                :allow_include,
+                :default_allow_include_to_one,
+                :default_allow_include_to_many,
                 :allow_sort,
                 :allow_filter,
                 :default_paginator,
@@ -50,7 +51,8 @@ module JSONAPI
       self.resource_key_type = :integer
 
       # optional request features
-      self.allow_include = true
+      self.default_allow_include_to_one = true
+      self.default_allow_include_to_many = true
       self.allow_sort = true
       self.allow_filter = true
 
@@ -227,7 +229,13 @@ module JSONAPI
       @resource_finder = resource_finder
     end
 
-    attr_writer :allow_include, :allow_sort, :allow_filter
+    def allow_include=(allow_include)
+      ActiveSupport::Deprecation.warn('`allow_include` has been replaced by `default_allow_include_to_one` and `default_allow_include_to_many` options.')
+      @default_allow_include_to_one = allow_include
+      @default_allow_include_to_many = allow_include
+    end
+
+    attr_writer :allow_sort, :allow_filter, :default_allow_include_to_one, :default_allow_include_to_many
 
     attr_writer :default_paginator
 

--- a/lib/jsonapi/exceptions.rb
+++ b/lib/jsonapi/exceptions.rb
@@ -342,7 +342,7 @@ module JSONAPI
                              title: I18n.translate('jsonapi-resources.exceptions.invalid_include.title',
                                                    default: 'Invalid field'),
                              detail: I18n.translate('jsonapi-resources.exceptions.invalid_include.detail',
-                                                    default: "#{relationship} is not a valid relationship of #{resource}",
+                                                    default: "#{relationship} is not a valid includable relationship of #{resource}",
                                                     relationship: relationship, resource: resource))]
       end
     end

--- a/lib/jsonapi/relationship.rb
+++ b/lib/jsonapi/relationship.rb
@@ -5,6 +5,8 @@ module JSONAPI
                 :parent_resource, :eager_load_on_include, :custom_methods,
                 :inverse_relationship, :allow_include
 
+    attr_writer :allow_include
+
     def initialize(name, options = {})
       @name = name.to_s
       @options = options
@@ -134,7 +136,7 @@ module JSONAPI
 
       def allow_include?(context = nil)
         strategy = if @allow_include.nil?
-                     JSONAPI.configuration.default_allow_include_to_one
+                     JSONAPI.configuration.default_allow_include_to_many
                    else
                      @allow_include
                    end

--- a/lib/jsonapi/relationship.rb
+++ b/lib/jsonapi/relationship.rb
@@ -3,7 +3,7 @@ module JSONAPI
     attr_reader :acts_as_set, :foreign_key, :options, :name,
                 :class_name, :polymorphic, :always_include_linkage_data,
                 :parent_resource, :eager_load_on_include, :custom_methods,
-                :inverse_relationship
+                :inverse_relationship, :allow_include
 
     def initialize(name, options = {})
       @name = name.to_s
@@ -17,6 +17,7 @@ module JSONAPI
       @polymorphic_relations = options[:polymorphic_relations]
       @always_include_linkage_data = options.fetch(:always_include_linkage_data, false) == true
       @eager_load_on_include = options.fetch(:eager_load_on_include, true) == true
+      @allow_include = options[:allow_include]
     end
 
     alias_method :polymorphic?, :polymorphic
@@ -100,6 +101,14 @@ module JSONAPI
       def polymorphic_type
         "#{name}_type" if polymorphic?
       end
+
+      def allow_include?
+        if @allow_include.nil?
+          JSONAPI.configuration.default_allow_include_to_one
+        else
+          @allow_include
+        end
+      end
     end
 
     class ToMany < Relationship
@@ -112,6 +121,14 @@ module JSONAPI
         @reflect = options.fetch(:reflect, true) == true
         if parent_resource
           @inverse_relationship = options.fetch(:inverse_relationship, parent_resource._type.to_s.singularize.to_sym)
+        end
+      end
+
+      def allow_include?
+        if @allow_include.nil?
+          JSONAPI.configuration.default_allow_include_to_one
+        else
+          @allow_include
         end
       end
     end

--- a/lib/jsonapi/relationship.rb
+++ b/lib/jsonapi/relationship.rb
@@ -102,11 +102,19 @@ module JSONAPI
         "#{name}_type" if polymorphic?
       end
 
-      def allow_include?
-        if @allow_include.nil?
-          JSONAPI.configuration.default_allow_include_to_one
+      def allow_include?(context = nil)
+        strategy = if @allow_include.nil?
+                     JSONAPI.configuration.default_allow_include_to_one
+                   else
+                     @allow_include
+                   end
+
+        if !!strategy == strategy #check for boolean
+          return strategy
+        elsif strategy.is_a?(Symbol) || strategy.is_a?(String)
+          parent_resource.send(strategy, context)
         else
-          @allow_include
+          strategy.call(context)
         end
       end
     end
@@ -124,12 +132,21 @@ module JSONAPI
         end
       end
 
-      def allow_include?
-        if @allow_include.nil?
-          JSONAPI.configuration.default_allow_include_to_one
+      def allow_include?(context = nil)
+        strategy = if @allow_include.nil?
+                     JSONAPI.configuration.default_allow_include_to_one
+                   else
+                     @allow_include
+                   end
+
+        if !!strategy == strategy #check for boolean
+          return strategy
+        elsif strategy.is_a?(Symbol) || strategy.is_a?(String)
+          parent_resource.send(strategy, context)
         else
-          @allow_include
+          strategy.call(context)
         end
+
       end
     end
   end

--- a/lib/jsonapi/request_parser.rb
+++ b/lib/jsonapi/request_parser.rb
@@ -330,6 +330,10 @@ module JSONAPI
 
       relationship = resource_klass._relationship(relationship_name)
       if relationship && format_key(relationship_name) == include_parts.first
+        unless relationship.allow_include?
+          fail JSONAPI::Exceptions::InvalidInclude.new(format_key(resource_klass._type), include_parts.first)
+        end
+
         unless include_parts.last.empty?
           check_include(Resource.resource_klass_for(resource_klass.module_path + relationship.class_name.to_s.underscore),
                         include_parts.last.partition('.'))
@@ -341,10 +345,6 @@ module JSONAPI
 
     def parse_include_directives(resource_klass, raw_include)
       return unless raw_include
-
-      unless JSONAPI.configuration.allow_include
-        fail JSONAPI::Exceptions::ParameterNotAllowed.new(:include)
-      end
 
       included_resources = []
       begin

--- a/lib/jsonapi/request_parser.rb
+++ b/lib/jsonapi/request_parser.rb
@@ -341,6 +341,7 @@ module JSONAPI
       else
         fail JSONAPI::Exceptions::InvalidInclude.new(format_key(resource_klass._type), include_parts.first)
       end
+      true
     end
 
     def parse_include_directives(resource_klass, raw_include)

--- a/lib/jsonapi/request_parser.rb
+++ b/lib/jsonapi/request_parser.rb
@@ -330,7 +330,7 @@ module JSONAPI
 
       relationship = resource_klass._relationship(relationship_name)
       if relationship && format_key(relationship_name) == include_parts.first
-        unless relationship.allow_include?
+        unless relationship.allow_include?(context)
           fail JSONAPI::Exceptions::InvalidInclude.new(format_key(resource_klass._type), include_parts.first)
         end
 

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -48,7 +48,7 @@ en:
         detail: "%{field} is not a valid field for %{type}."
       invalid_include:
         title: 'Invalid include'
-        detail: "%{relationship} is not a valid relationship of %{resource}"
+        detail: "%{relationship} is not a valid includable relationship of %{resource}"
       invalid_sort_criteria:
         title: 'Invalid sort criteria'
         detail: "%{sort_criteria} is not a valid sort criteria for %{resource}"

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -551,11 +551,12 @@ class PostsControllerTest < ActionController::TestCase
   end
 
   def test_show_single_with_include_disallowed
+    original_config = JSONAPI.configuration.dup
     JSONAPI.configuration.allow_include = false
     assert_cacheable_get :show, params: {id: '1', include: 'comments'}
     assert_response :bad_request
   ensure
-    JSONAPI.configuration.allow_include = true
+    JSONAPI.configuration = original_config
   end
 
   def test_show_single_with_fields
@@ -2122,25 +2123,25 @@ class ExpenseEntriesControllerTest < ActionController::TestCase
   def test_expense_entries_show_bad_include_missing_relationship
     assert_cacheable_get :show, params: {id: 1, include: 'isoCurrencies,employees'}
     assert_response :bad_request
-    assert_match /isoCurrencies is not a valid relationship of expenseEntries/, json_response['errors'][0]['detail']
+    assert_match /isoCurrencies is not a valid includable relationship of expenseEntries/, json_response['errors'][0]['detail']
   end
 
   def test_expense_entries_show_bad_include_missing_sub_relationship
     assert_cacheable_get :show, params: {id: 1, include: 'isoCurrency,employee.post'}
     assert_response :bad_request
-    assert_match /post is not a valid relationship of employees/, json_response['errors'][0]['detail']
+    assert_match /post is not a valid includable relationship of employees/, json_response['errors'][0]['detail']
   end
 
   def test_invalid_include
     assert_cacheable_get :index, params: {include: 'invalid../../../../'}
     assert_response :bad_request
-    assert_match /invalid is not a valid relationship of expenseEntries/, json_response['errors'][0]['detail']
+    assert_match /invalid is not a valid includable relationship of expenseEntries/, json_response['errors'][0]['detail']
   end
 
   def test_invalid_include_long_garbage_string
     assert_cacheable_get :index, params: {include: 'invalid.foo.bar.dfsdfs,dfsdfs.sdfwe.ewrerw.erwrewrew'}
     assert_response :bad_request
-    assert_match /invalid is not a valid relationship of expenseEntries/, json_response['errors'][0]['detail']
+    assert_match /invalid is not a valid includable relationship of expenseEntries/, json_response['errors'][0]['detail']
   end
 
   def test_expense_entries_show_fields

--- a/test/unit/jsonapi_request/jsonapi_request_test.rb
+++ b/test/unit/jsonapi_request/jsonapi_request_test.rb
@@ -87,7 +87,7 @@ class JSONAPIRequestTest < ActiveSupport::TestCase
 
     request.parse_include_directives(ExpenseEntryResource, params[:include])
     refute request.errors.empty?
-    assert_equal 'iso_currency is not a valid relationship of expense-entries', request.errors[0].detail
+    assert_equal 'iso_currency is not a valid includable relationship of expense-entries', request.errors[0].detail
   end
 
   def test_parse_fields_underscored

--- a/test/unit/resource/relationship_test.rb
+++ b/test/unit/resource/relationship_test.rb
@@ -9,4 +9,67 @@ class HasOneRelationshipTest < ActiveSupport::TestCase
     assert_equal(relationship.polymorphic_type, "imageable_type")
   end
 
+  def test_allow_include_not_set_defaults_to_config_to_one
+    original_config = JSONAPI.configuration.dup
+
+    JSONAPI.configuration.default_allow_include_to_one = true
+    relationship = JSONAPI::Relationship::ToOne.new("foo")
+    assert(relationship.allow_include?)
+
+    JSONAPI.configuration.default_allow_include_to_one = false
+    relationship = JSONAPI::Relationship::ToOne.new("foo")
+    refute(relationship.allow_include?)
+
+  ensure
+    JSONAPI.configuration = original_config
+  end
+
+  def test_allow_include_not_set_defaults_to_config_to_many
+    original_config = JSONAPI.configuration.dup
+
+    JSONAPI.configuration.default_allow_include_to_many = true
+    relationship = JSONAPI::Relationship::ToMany.new("foobar")
+    assert(relationship.allow_include?)
+
+    JSONAPI.configuration.default_allow_include_to_one = false
+    relationship = JSONAPI::Relationship::ToOne.new("foobar")
+    refute(relationship.allow_include?)
+
+  ensure
+    JSONAPI.configuration = original_config
+  end
+
+  def test_allow_include_set_overrides_to_config_to_one
+    original_config = JSONAPI.configuration.dup
+
+    JSONAPI.configuration.default_allow_include_to_one = true
+    relationship1 = JSONAPI::Relationship::ToOne.new("foo1", allow_include: false)
+    relationship2 = JSONAPI::Relationship::ToOne.new("foo2", allow_include: true)
+    refute(relationship1.allow_include?)
+    assert(relationship2.allow_include?)
+
+    JSONAPI.configuration.default_allow_include_to_one = false
+    refute(relationship1.allow_include?)
+    assert(relationship2.allow_include?)
+
+  ensure
+    JSONAPI.configuration = original_config
+  end
+
+  def test_allow_include_set_overrides_to_config_to_many
+    original_config = JSONAPI.configuration.dup
+
+    JSONAPI.configuration.default_allow_include_to_one = true
+    relationship1 = JSONAPI::Relationship::ToMany.new("foobar1", allow_include: false)
+    relationship2 = JSONAPI::Relationship::ToMany.new("foobar2", allow_include: true)
+    refute(relationship1.allow_include?)
+    assert(relationship2.allow_include?)
+
+    JSONAPI.configuration.default_allow_include_to_one = false
+    refute(relationship1.allow_include?)
+    assert(relationship2.allow_include?)
+
+  ensure
+    JSONAPI.configuration = original_config
+  end
 end


### PR DESCRIPTION
Deprecates and replaces the `allow_include` config option

Replaces `allow_includes` with `default_allow_include_to_one` and `default_allow_include_to_many` configuration options.
Adds support for `allow_include` option on Relationships to override the config settings.

Purpose:
- Includes without pagination allows potentially resource intensive requests.
- Pagination of includes is a non-trivial problem to solve efficiently with SQL databases
- By allowing includes defaults to be set for to_one and to_many relationship types separately includes for the riskier to_many relationships can be disabled by default, while still allowing them on specific relationships if desired.