### PR TITLE
fixes #909 add possibility to set generic validation error

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -837,6 +837,10 @@ module JSONAPI
         @_attributes.fetch(attr.to_sym, {}).fetch(:delegate, attr)
       end
 
+      def _has_attribute?(attr)
+        @_attributes.keys.include?(attr.to_sym)
+      end
+
       def _updatable_attributes
         _attributes.map { |key, options| key unless options[:readonly] }.compact
       end


### PR DESCRIPTION
Fixes #909 
very simple example usage:
```ruby
class Person < ActiveRecord::Base
  validate do
    errors.add(:base, 'invalid attributes') if name.blank?
  end
end

class PersonResource < JSONAPI::Resource
  model 'Person'
  attributes :name

  def model_error_messages
    errors = super
    errors[nil] = errors[:base] if errors.has_key?(:base)
    errors
  end
end
```
request
```ruby
post '/people', {data: {type: 'people', attributes: {name: ''}}}, json_api_headers
```
will be responded with
```http
HTTP/1.1 422 Unprocessable Entity
Content-Type: application/vnd.api+json

{
  "errors": [
    {
      "title": "invalid attributes",
      "detail": "invalid attributes",
      "code": "100",
      "source": {
        "pointer": "/data"
      },
      "status": "422"
    }
  ]
}
```

I didn't add tests for it because I don't know where I should put it.
I decide to use `nil` key - not `:base` because `base` is a valid attribute name for a `jsonapi`, and to not break existing functionality. 