### PR TITLE
Fix a bug that occurs when fetching relationships

### DIFF
--- a/lib/jsonapi/active_relation_resource_finder.rb
+++ b/lib/jsonapi/active_relation_resource_finder.rb
@@ -131,7 +131,7 @@ module JSONAPI
         relationship = _relationship(relationship_name)
         related_klass = relationship.resource_klass
 
-        context = context
+        context = options[:context]
 
         records = records(context: context)
         records, table_alias = apply_join(records, relationship, options)


### PR DESCRIPTION
I think there was a little mistake in here, your probably meant
`context = options[:context]` instead of `context = context`
This solve an issue I had while fetching relationships which was returning a nil context.
Thanks a lot for all your efforts!