### PR TITLE
WIP #1105 fix bug with inclusion and linkage of has_one polymorphic

### DIFF
--- a/lib/jsonapi/relationship.rb
+++ b/lib/jsonapi/relationship.rb
@@ -41,6 +41,9 @@ module JSONAPI
             klass.reflect_on_all_associations(:has_many).select{|r| r.options[:as] }.each do |reflection|
               (hash[reflection.options[:as]] ||= []) << klass.name.downcase
             end
+            klass.reflect_on_all_associations(:has_one).select{|r| r.options[:as] }.each do |reflection|
+              (hash[reflection.options[:as]] ||= []) << klass.name.downcase
+            end
           end
         end
       end

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -1039,8 +1039,10 @@ module JSONAPI
       def define_foreign_key_setter(relationship)
         if relationship.polymorphic?
           define_on_resource "#{relationship.foreign_key}=" do |v|
-            _model.method("#{relationship.foreign_key}=").call(v[:id])
-            _model.public_send("#{relationship.polymorphic_type}=", v[:type])
+            model_id = v.nil? ? nil : v[:id]
+            model_type = v.nil? ? nil : self.class.resource_klass_for(v[:type].to_s)._model_class.to_s
+            _model.method("#{relationship.foreign_key}=").call(model_id)
+            _model.public_send("#{relationship.polymorphic_type}=", model_type)
           end
         else
           define_on_resource "#{relationship.foreign_key}=" do |value|

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -356,6 +356,25 @@ ActiveRecord::Schema.define do
     t.integer :version
     t.timestamps null: false
   end
+
+  create_table :options, force: true do |t|
+    t.integer :optionable_id
+    t.string :optionable_type
+    t.integer :maintainer_id
+    t.boolean :enabled, default: false, null: false
+    t.timestamps null: false
+  end
+
+  create_table :androids, force: true do |t|
+    t.string :version_name
+    t.timestamps null: false
+  end
+
+  create_table :maintainers, force: true do |t|
+    t.string :name
+    t.timestamps null: false
+  end
+
 end
 
 ### MODELS
@@ -734,6 +753,19 @@ end
 class Robot < ActiveRecord::Base
 end
 
+class Option < ActiveRecord::Base
+  belongs_to :optionable, polymorphic: true, required: false
+  belongs_to :maintainer, required: false
+end
+
+class Android < ActiveRecord::Base
+  has_one :option, as: :optionable
+end
+
+class Maintainer < ActiveRecord::Base
+  has_one :maintained_option
+end
+
 ### CONTROLLERS
 class AuthorsController < JSONAPI::ResourceControllerMetal
 end
@@ -1031,6 +1063,9 @@ class IndicatorsController < JSONAPI::ResourceController
 end
 
 class RobotsController < JSONAPI::ResourceController
+end
+
+class OptionsController < JSONAPI::ResourceController
 end
 
 ### RESOURCES
@@ -2205,6 +2240,20 @@ class RobotResource < ::JSONAPI::Resource
   sort :lower_name, apply: ->(records, direction, _context) do
     records.order("LOWER(robots.name) #{direction}")
   end
+end
+
+class OptionResource < JSONAPI::Resource
+  attribute :enabled
+  has_one :optionable, polymorphic: true, class_name: 'Android'
+  has_one :maintainer, class_name: 'Maintainer'
+end
+
+class AndroidResource < JSONAPI::Resource
+  attribute :version_name
+end
+
+class MaintainerResource < JSONAPI::Resource
+  attribute :name
 end
 
 ### PORO Data - don't do this in a production app

--- a/test/integration/requests/request_test.rb
+++ b/test/integration/requests/request_test.rb
@@ -1162,4 +1162,97 @@ class RequestTest < ActionDispatch::IntegrationTest
     assert_equal 'access_cards', included.first['type']
     assert_equal access_card.token, included.first['id']
   end
+
+  def test_update_option_link_with_optionable_include_optionable
+    android = Android.create! version_name: '1.0'
+    option = Option.create!
+    json_request = {
+        data: {
+            id: option.id.to_s,
+            type: 'options',
+            relationships: {
+                optionable: {
+                    data: {
+                        id: android.id.to_s,
+                        type: 'androids'
+                    }
+                }
+            }
+        }
+    }
+    json_api_headers = {
+        'CONTENT_TYPE' => JSONAPI::MEDIA_TYPE,
+        'Accept' => JSONAPI::MEDIA_TYPE
+    }
+    patch "/options/#{option.id}?include=optionable", params: json_request.to_json, headers: json_api_headers
+    assert_jsonapi_response 200
+    relationship_data = {'id' => android.id.to_s, 'type' => 'androids'}
+    assert_equal relationship_data, json_response['data']['relationships']['optionable']['data']
+    assert_equal relationship_data, json_response['included'].first.slice('id', 'type')
+    assert_equal android, option.reload.optionable
+  end
+
+  def test_update_option_unlink_from_optionable_include_optionable
+    android = Android.create! version_name: '1.0'
+    option = Option.create! optionable: android
+    json_request = {
+        data: {
+            id: option.id.to_s,
+            type: 'options',
+            relationships: {
+                optionable: {
+                    data: nil
+                }
+            }
+        }
+    }
+    json_api_headers = {
+        'CONTENT_TYPE' => JSONAPI::MEDIA_TYPE,
+        'Accept' => JSONAPI::MEDIA_TYPE
+    }
+    patch "/options/#{option.id}?include=optionable", params: json_request.to_json, headers: json_api_headers
+    assert_jsonapi_response 200
+    assert_equal true, json_response['data']['relationships']['optionable'].has_key?('data')
+    assert_nil json_response['data']['relationships']['optionable']['data']
+    assert_equal false, json_response.has_key?('included')
+    assert_nil option.reload.optionable
+  end
+
+  def test_fetch_option_linked_with_optionable_include_optionable
+    android = Android.create! version_name: '1.0'
+    option = Option.create! optionable: android
+    assert_cacheable_jsonapi_get "/options/#{option.id}?include=optionable"
+    assert_jsonapi_response 200
+    relationship_data = {'id' => android.id.to_s, 'type' => 'androids'}
+    assert_equal relationship_data, json_response['data']['relationships']['optionable']['data']
+    assert_equal relationship_data, json_response['included'].first.slice('id', 'type')
+  end
+
+  def test_fetch_option_not_linked_with_optionable_include_optionable
+    option = Option.create!
+    assert_cacheable_jsonapi_get "/options/#{option.id}?include=optionable"
+    assert_jsonapi_response 200
+    assert_equal true, json_response['data']['relationships']['optionable'].has_key?('data')
+    assert_nil json_response['data']['relationships']['optionable']['data']
+    assert_equal false, json_response.has_key?('included')
+  end
+
+  def test_fetch_option_not_linked_with_maintainer_include_maintainer
+    option = Option.create!
+    assert_cacheable_jsonapi_get "/options/#{option.id}?include=maintainer"
+    assert_jsonapi_response 200
+    assert_equal true, json_response['data']['relationships']['maintainer'].has_key?('data')
+    assert_nil json_response['data']['relationships']['maintainer']['data']
+    assert_equal false, json_response.has_key?('included')
+  end
+
+  def test_fetch_option_linked_with_maintainer_include_maintainer
+    maintainer = Maintainer.create! name: 'John Doe'
+    option = Option.create! maintainer: maintainer
+    assert_cacheable_jsonapi_get "/options/#{option.id}?include=maintainer"
+    assert_jsonapi_response 200
+    relationship_data = {'id' => maintainer.id.to_s, 'type' => 'maintainers'}
+    assert_equal relationship_data, json_response['data']['relationships']['maintainer']['data']
+    assert_equal relationship_data, json_response['included'].first.slice('id', 'type')
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -401,6 +401,7 @@ TestApp.routes.draw do
   jsonapi_resources :widgets, only: [:index]
   jsonapi_resources :indicators, only: [:index]
   jsonapi_resources :robots, only: [:index]
+  jsonapi_resources :options, only: [:show, :update]
 
   mount MyEngine::Engine => "/boomshaka", as: :my_engine
   mount ApiV2Engine::Engine => "/api_v2", as: :api_v2_engine


### PR DESCRIPTION
WIP Fix #1105 
assignment and inclusion of has_one polymorphic relationships works incorrectly

tested on bug report
```ruby
begin
  require 'bundler/inline'
  require 'bundler'
rescue LoadError => e
  STDERR.puts 'Bundler version 1.10 or later is required. Please update your Bundler'
  raise e
end

gemfile(true, ui: ENV['SILENT'] ? Bundler::UI::Silent.new : Bundler::UI::Shell.new) do
  source 'https://rubygems.org'

  gem 'rails', require: false
  gem 'sqlite3', platform: :mri

  gem 'activerecord-jdbcsqlite3-adapter',
      git: 'https://github.com/jruby/activerecord-jdbc-adapter',
      branch: 'rails-5',
      platform: :jruby

  if ENV['JSONAPI_RESOURCES_PATH']
    gem 'jsonapi-resources', path: ENV['JSONAPI_RESOURCES_PATH'], require: false
  else
    gem 'jsonapi-resources', git: 'https://github.com/cerebris/jsonapi-resources', require: false
  end

end

# prepare active_record database
require 'active_record'

class NullLogger < Logger
  def initialize(*_args)
  end

  def add(*_args, &_block)
  end
end

ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
ActiveRecord::Base.logger = ENV['SILENT'] ? NullLogger.new : Logger.new(STDOUT)
ActiveRecord::Migration.verbose = !ENV['SILENT']

ActiveRecord::Schema.define do
  # Add your schema here
  create_table :options, force: true do |t|
    t.integer :optionable_id
    t.string :optionable_type
    t.integer :maintainer_id
    t.boolean :enabled, default: false, null: false
  end

  create_table :androids, force: true do |t|
    t.string :version_name
  end

  create_table :users, force: true do |t|
    t.string :name
  end
end

# create models
class Option < ActiveRecord::Base
  belongs_to :optionable, polymorphic: true, required: false
  belongs_to :maintainer, class_name: 'User', required: false
end

class Android < ActiveRecord::Base
  has_one :option, as: :optionable
end

class User < ActiveRecord::Base
  has_one :maintained_option
end

# prepare rails app
require 'action_controller/railtie'
# require 'action_view/railtie'
require 'jsonapi-resources'

class ApplicationController < ActionController::Base
end

# prepare jsonapi resources and controllers
class OptionsController < ApplicationController
  include JSONAPI::ActsAsResourceController
end

class OptionResource < JSONAPI::Resource
  attribute :enabled
  has_one :optionable, polymorphic: true, class_name: 'Android'
  has_one :maintainer, class_name: 'User'
end

class AndroidResource < JSONAPI::Resource
  attribute :version_name
end

class UserResource < JSONAPI::Resource
  attribute :name
end

class TestApp < Rails::Application
  config.root = File.dirname(__FILE__)
  config.logger = ENV['SILENT'] ? NullLogger.new : Logger.new(STDOUT)
  Rails.logger = config.logger

  secrets.secret_token = 'secret_token'
  secrets.secret_key_base = 'secret_key_base'

  config.eager_load = false
end

# initialize app
Rails.application.initialize!

JSONAPI.configure do |config|
  config.json_key_format = :underscored_key
  config.route_format = :underscored_key
end

# draw routes
Rails.application.routes.draw do
  jsonapi_resources :options, only: [:show, :update]
end

# prepare tests
require 'minitest/autorun'
require 'rack/test'

# Replace this with the code necessary to make your test fail.
class BugTest < Minitest::Test
  include Rack::Test::Methods

  def json_api_headers
    {'Accept' => JSONAPI::MEDIA_TYPE, 'CONTENT_TYPE' => JSONAPI::MEDIA_TYPE}
  end

  def test_patch_link_option_with_android_include_optionable
    android = Android.create! version_name: '1.0'
    option = Option.create!
    json_request = {
        data: {
            id: option.id.to_s,
            type: 'options',
            relationships: {
                optionable: {
                    data: {
                        id: android.id.to_s,
                        type: 'androids'
                    }
                }
            }
        }
    }
    patch "/options/#{option.id}?include=optionable", json_request.to_json, json_api_headers
    assert last_response.ok?
    expected_response = {
        data: {
            id: option.id.to_s,
            type: 'options',
            links: {
                self: "http://example.org/options/#{option.id}"
            },
            attributes: {
                enabled: false
            },
            relationships: {
                optionable: {
                    links: {
                        self: "http://example.org/options/#{option.id}/relationships/optionable",
                        related: "http://example.org/options/#{option.id}/optionable"
                    },
                    data: {
                        id: android.id.to_s,
                        type: 'androids'
                    }
                },
                maintainer: {
                    links: {
                        self: "http://example.org/options/#{option.id}/relationships/maintainer",
                        related: "http://example.org/options/#{option.id}/maintainer"
                    }
                }
            }
        },
        included: [
            {
                id: android.id.to_s,
                type: 'androids',
                links: {
                    self: "http://example.org/androids/#{android.id}"
                },
                attributes: {
                    version_name: android.version_name
                }
            }
        ]
    }
    assert_equal expected_response, last_response_json
    assert_equal android, option.reload.optionable
  end

  def test_patch_unlink_option_from_android_include_optionable
    android = Android.create! version_name: '1.0'
    option = Option.create! optionable: android
    json_request = {
        data: {
            id: option.id.to_s,
            type: 'options',
            relationships: {
                optionable: {
                    data: nil
                }
            }
        }
    }
    patch "/options/#{option.id}?include=optionable", json_request.to_json, json_api_headers
    assert last_response.ok?
    expected_response = {
        data: {
            id: option.id.to_s,
            type: 'options',
            links: {
                self: "http://example.org/options/#{option.id}"
            },
            attributes: {
                enabled: false
            },
            relationships: {
                optionable: {
                    links: {
                        self: "http://example.org/options/#{option.id}/relationships/optionable",
                        related: "http://example.org/options/#{option.id}/optionable"
                    },
                    data: nil
                },
                maintainer: {
                    links: {
                        self: "http://example.org/options/#{option.id}/relationships/maintainer",
                        related: "http://example.org/options/#{option.id}/maintainer"
                    }
                }
            }
        }
    }
    assert_equal expected_response, last_response_json
    assert_equal nil, option.reload.optionable
  end

  def test_fetch_option_linked_with_android_include_optionable
    android = Android.create! version_name: '1.0'
    option = Option.create! optionable: android
    get "/options/#{option.id}?include=optionable", nil, json_api_headers
    assert last_response.ok?
    expected_response = {
        data: {
            id: option.id.to_s,
            type: 'options',
            links: {
                self: "http://example.org/options/#{option.id}"
            },
            attributes: {
                enabled: false
            },
            relationships: {
                optionable: {
                    links: {
                        self: "http://example.org/options/#{option.id}/relationships/optionable",
                        related: "http://example.org/options/#{option.id}/optionable"
                    },
                    data: {
                        id: android.id.to_s,
                        type: 'androids'
                    }
                },
                maintainer: {
                    links: {
                        self: "http://example.org/options/#{option.id}/relationships/maintainer",
                        related: "http://example.org/options/#{option.id}/maintainer"
                    }
                }
            }
        },
        included: [
            {
                id: android.id.to_s,
                type: 'androids',
                links: {
                    self: "http://example.org/androids/#{android.id}"
                },
                attributes: {
                    version_name: android.version_name
                }
            }
        ]
    }
    assert_equal expected_response, last_response_json
  end

  def test_fetch_option_not_linked_with_android_include_optionable
    option = Option.create!
    get "/options/#{option.id}?include=optionable", nil, json_api_headers
    assert last_response.ok?
    expected_response = {
        data: {
            id: option.id.to_s,
            type: 'options',
            links: {
                self: "http://example.org/options/#{option.id}"
            },
            attributes: {
                enabled: false
            },
            relationships: {
                optionable: {
                    links: {
                        self: "http://example.org/options/#{option.id}/relationships/optionable",
                        related: "http://example.org/options/#{option.id}/optionable"
                    },
                    data: nil
                },
                maintainer: {
                    links: {
                        self: "http://example.org/options/#{option.id}/relationships/maintainer",
                        related: "http://example.org/options/#{option.id}/maintainer"
                    }
                }
            }
        }
    }
    assert_equal expected_response, last_response_json
  end

  def test_fetch_option_not_linked_with_maintainer_include_maintainer
    option = Option.create!
    get "/options/#{option.id}?include=maintainer", nil, json_api_headers
    assert last_response.ok?
    expected_response = {
        data: {
            id: option.id.to_s,
            type: 'options',
            links: {
                self: "http://example.org/options/#{option.id}"
            },
            attributes: {
                enabled: false
            },
            relationships: {
                optionable: {
                    links: {
                        self: "http://example.org/options/#{option.id}/relationships/optionable",
                        related: "http://example.org/options/#{option.id}/optionable"
                    }
                },
                maintainer: {
                    links: {
                        self: "http://example.org/options/#{option.id}/relationships/maintainer",
                        related: "http://example.org/options/#{option.id}/maintainer"
                    },
                    data: nil
                }
            }
        }
    }
    assert_equal expected_response, last_response_json
  end

  def test_fetch_option_linked_with_maintainer_include_maintainer
    user = User.create! name: 'John Doe'
    option = Option.create! maintainer: user
    get "/options/#{option.id}?include=maintainer", nil, json_api_headers
    assert last_response.ok?
    expected_response = {
        data: {
            id: option.id.to_s,
            type: 'options',
            links: {
                self: "http://example.org/options/#{option.id}"
            },
            attributes: {
                enabled: false
            },
            relationships: {
                optionable: {
                    links: {
                        self: "http://example.org/options/#{option.id}/relationships/optionable",
                        related: "http://example.org/options/#{option.id}/optionable"
                    }
                },
                maintainer: {
                    links: {
                        self: "http://example.org/options/#{option.id}/relationships/maintainer",
                        related: "http://example.org/options/#{option.id}/maintainer"
                    },
                    data: {
                        id: user.id.to_s,
                        type: 'users'
                    }
                }
            }
        },
        included: [
            {
                id: user.id.to_s,
                type: 'users',
                links: {
                    self: "http://example.org/users/#{user.id}"
                },
                attributes: {
                    name: user.name
                }
            }
        ]
    }
    assert_equal expected_response, last_response_json
  end

  private

  def last_response_json
    JSON.parse(last_response.body).deep_symbolize_keys
  end

  def app
    Rails.application
  end
end
```