### PR TITLE
Fixes #936 add ability to define custom sorting

### DIFF
--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -3952,4 +3952,37 @@ class IndicatorsControllerTest < ActionController::TestCase
     assert_equal indicator_2.id.to_s, json_response['data'].first['id']
     assert_equal 2, json_response['data'].size
   end
+
+end
+
+class RobotsControllerTest < ActionController::TestCase
+
+  def teardown
+    Robot.delete_all
+  end
+
+  def test_fetch_robots_with_sort_by_name
+    Robot.create! name: 'John', version: 1
+    Robot.create! name: 'jane', version: 1
+    assert_cacheable_get :index, params: {sort: 'name'}
+    assert_response :success
+    assert_equal 'John', json_response['data'].first['attributes']['name']
+  end
+
+  def test_fetch_robots_with_sort_by_lower_name
+    Robot.create! name: 'John', version: 1
+    Robot.create! name: 'jane', version: 1
+    assert_cacheable_get :index, params: {sort: 'lower_name'}
+    assert_response :success
+    assert_equal 'jane', json_response['data'].first['attributes']['name']
+  end
+
+  def test_fetch_robots_with_sort_by_version
+    Robot.create! name: 'John', version: 1
+    Robot.create! name: 'jane', version: 2
+    assert_cacheable_get :index, params: {sort: 'version'}
+    assert_response 400
+    assert_equal 'version is not a valid sort criteria for robots', json_response['errors'].first['detail']
+  end
+
 end

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -350,6 +350,12 @@ ActiveRecord::Schema.define do
     t.integer :indicator_id, null: false
     t.timestamps null: false
   end
+
+  create_table :robots, force: true do |t|
+    t.string :name
+    t.integer :version
+    t.timestamps null: false
+  end
 end
 
 ### MODELS
@@ -725,6 +731,9 @@ class Widget < ActiveRecord::Base
   belongs_to :indicator
 end
 
+class Robot < ActiveRecord::Base
+end
+
 ### CONTROLLERS
 class AuthorsController < JSONAPI::ResourceControllerMetal
 end
@@ -1019,6 +1028,9 @@ class WidgetsController < JSONAPI::ResourceController
 end
 
 class IndicatorsController < JSONAPI::ResourceController
+end
+
+class RobotsController < JSONAPI::ResourceController
 end
 
 ### RESOURCES
@@ -2184,6 +2196,15 @@ class WorkerResource < JSONAPI::Resource
   has_one :access_card
 
   attribute :name
+end
+
+class RobotResource < ::JSONAPI::Resource
+  attribute :name
+  attribute :version, sortable: false
+
+  sort :lower_name, apply: ->(records, direction, _context) do
+    records.order("LOWER(robots.name) #{direction}")
+  end
 end
 
 ### PORO Data - don't do this in a production app

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -400,6 +400,7 @@ TestApp.routes.draw do
   jsonapi_resources :workers, only: [:show]
   jsonapi_resources :widgets, only: [:index]
   jsonapi_resources :indicators, only: [:index]
+  jsonapi_resources :robots, only: [:index]
 
   mount MyEngine::Engine => "/boomshaka", as: :my_engine
   mount ApiV2Engine::Engine => "/api_v2", as: :api_v2_engine


### PR DESCRIPTION
add `sort` and `sorts` class methods for define sorting (no need to override `sortable_fields` anymore)

proof of work and example:
```ruby
begin
  require 'bundler/inline'
  require 'bundler'
rescue LoadError => e
  STDERR.puts 'Bundler version 1.10 or later is required. Please update your Bundler'
  raise e
end

gemfile(true, ui: ENV['SILENT'] ? Bundler::UI::Silent.new : Bundler::UI::Shell.new) do
  source 'https://rubygems.org'

  gem 'rails', require: false

  if ENV['JSONAPI_RESOURCES_PG']
    gem 'pg'
  else
    gem 'sqlite3', platform: :mri

    gem 'activerecord-jdbcsqlite3-adapter',
        git: 'https://github.com/jruby/activerecord-jdbc-adapter',
        branch: 'rails-5',
        platform: :jruby
  end


  if ENV['JSONAPI_RESOURCES_PATH']
    gem 'jsonapi-resources', path: ENV['JSONAPI_RESOURCES_PATH'], require: false
  else
    gem 'jsonapi-resources', git: 'https://github.com/cerebris/jsonapi-resources', require: false
  end

end

# prepare active_record database
require 'active_record'

class NullLogger < Logger
  def initialize(*_args)
  end

  def add(*_args, &_block)
  end
end

# establish database connection
if ENV['JSONAPI_RESOURCES_PG']
  db_name = 'tmp_bug_report_table'
  system("psql -c 'DROP DATABASE IF EXISTS #{db_name};'")
  system("psql -c 'CREATE DATABASE #{db_name};'")
  ActiveRecord::Base.establish_connection(adapter: 'postgresql', database: db_name)
else
  ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
end

# specify logger
ActiveRecord::Base.logger = ENV['SILENT'] ? NullLogger.new : Logger.new(STDOUT)
ActiveRecord::Migration.verbose = !ENV['SILENT']

# define database schema
ActiveRecord::Schema.define do
  # Add your schema here
  create_table :user_roles, force: true do |t|
    t.boolean :allowed_to_buy, null: false, default: false
    t.boolean :allowed_to_sell, null: false, default: false
    t.boolean :approved, null: false, default: false
  end

  create_table :users, force: true do |t|
    t.integer :user_role_id
    t.string :name
    t.integer :age
  end
end

# create models
class UserRole < ActiveRecord::Base
end

class User < ActiveRecord::Base
  belongs_to :user_role, required: false
end

# prepare rails app
require 'action_controller/railtie'
# require 'action_view/railtie'
require 'jsonapi-resources'

class ApplicationController < ActionController::Base
end

# prepare jsonapi resources and controllers
class UsersController < ::ApplicationController
  include JSONAPI::ActsAsResourceController
end

class UserResource < ::JSONAPI::Resource
  attribute :name
  attribute :age, sortable: false
  has_one :user_role

  sorts :'user_role.allowed_to_buy', :'user_role.allowed_to_sell'

  sort :lower_name, apply: ->(records, direction, _context) do
    records.order("LOWER(users.name) #{direction}")
  end
end

class UserRoleResource < ::JSONAPI::Resource
  attributes :allowed_to_buy, :allowed_to_sell, :approved
end

class TestApp < Rails::Application
  config.root = File.dirname(__FILE__)
  config.logger = ENV['SILENT'] ? NullLogger.new : Logger.new(STDOUT)
  Rails.logger = config.logger

  secrets.secret_token = 'secret_token'
  secrets.secret_key_base = 'secret_key_base'

  config.eager_load = false
end

# initialize app
Rails.application.initialize!

JSONAPI.configure do |config|
  config.json_key_format = :underscored_key
  config.route_format = :underscored_key
end

# draw routes
Rails.application.routes.draw do
  jsonapi_resources :users
end

# prepare tests
require 'minitest/autorun'
require 'rack/test'

# Replace this with the code necessary to make your test fail.
class BugTest < Minitest::Test
  include Rack::Test::Methods

  def teardown
    User.delete_all
    UserRole.delete_all
  end

  def test_fetch_users_with_sort_by_name
    User.create! name: 'John', age: 18
    User.create! name: 'jane', age: 18
    request_params = {sort: 'name'}
    get '/users', request_params, json_api_headers
    assert_equal 200, last_response.status
    assert_equal 'John', last_response_json[:data].first[:attributes][:name]
  end

  def test_fetch_users_with_sort_by_lower_name
    User.create! name: 'John', age: 18
    User.create! name: 'jane', age: 18
    request_params = {sort: 'lower_name'}
    get '/users', request_params, json_api_headers
    assert_equal 200, last_response.status
    assert_equal 'jane', last_response_json[:data].first[:attributes][:name]
  end

  def test_fetch_users_with_sort_by_user_role_allowed_to_buy_and_allowed_to_sell
    role_1 = UserRole.create! allowed_to_buy: true, allowed_to_sell: true
    role_2 = UserRole.create! allowed_to_buy: true, allowed_to_sell: false
    User.create! name: 'Jane', age: 18, user_role: role_1
    user = User.create! name: 'John', age: 18, user_role: role_2
    request_params = {sort: 'user_role.allowed_to_buy,user_role.allowed_to_sell'}
    get '/users', request_params, json_api_headers
    assert_equal 200, last_response.status
    assert_equal user.id.to_s, last_response_json[:data].first[:id]
  end

  def test_fetch_users_with_sort_by_age
    User.create! name: 'John', age: 18
    User.create! name: 'jane', age: 19
    request_params = {sort: 'age'}
    get '/users', request_params, json_api_headers
    assert_equal 400, last_response.status
    assert_equal 'age is not a valid sort criteria for users', last_response_json[:errors].first[:detail]
  end

  def test_fetch_users_with_sort_by_user_role_approved
    User.create! name: 'John', age: 18
    User.create! name: 'jane', age: 19
    request_params = {sort: 'user_role.approved'}
    get '/users', request_params, json_api_headers
    assert_equal 400, last_response.status
    assert_equal 'user_role.approved is not a valid sort criteria for users', last_response_json[:errors].first[:detail]
  end

  private

  def json_api_headers
    {'Accept' => JSONAPI::MEDIA_TYPE, 'CONTENT_TYPE' => JSONAPI::MEDIA_TYPE}
  end

  def last_response_json
    JSON.parse(last_response.body).deep_symbolize_keys
  end

  def app
    Rails.application
  end
end
```
logs
```
I, [2017-09-09T22:42:49.245971 #28601]  INFO -- : Started GET "/users?sort=name" for 127.0.0.1 at 2017-09-09 22:42:49 +0300
I, [2017-09-09T22:42:49.246874 #28601]  INFO -- : Processing by UsersController#index as HTML
I, [2017-09-09T22:42:49.246931 #28601]  INFO -- :   Parameters: {"sort"=>"name"}
D, [2017-09-09T22:42:49.249071 #28601] DEBUG -- :    (0.2ms)  SELECT users.id FROM "users" ORDER BY "users"."name" ASC
D, [2017-09-09T22:42:49.250476 #28601] DEBUG -- :   User Load (0.4ms)  SELECT "users".* FROM "users" WHERE "users"."id" IN (1, 3, 5, 2, 4, 6)
I, [2017-09-09T22:42:49.252454 #28601]  INFO -- :   Rendering text template
I, [2017-09-09T22:42:49.252549 #28601]  INFO -- :   Rendered text template (0.0ms)
I, [2017-09-09T22:42:49.252659 #28601]  INFO -- : Completed 200 OK in 6ms (Views: 0.4ms)

I, [2017-09-09T22:42:49.215406 #28601]  INFO -- : Started GET "/users?sort=lower_name" for 127.0.0.1 at 2017-09-09 22:42:49 +0300
I, [2017-09-09T22:42:49.218654 #28601]  INFO -- : Processing by UsersController#index as HTML
I, [2017-09-09T22:42:49.218721 #28601]  INFO -- :   Parameters: {"sort"=>"lower_name"}
D, [2017-09-09T22:42:49.221246 #28601] DEBUG -- :    (0.2ms)  SELECT users.id FROM "users" ORDER BY LOWER(users.name) asc
D, [2017-09-09T22:42:49.222666 #28601] DEBUG -- :   User Load (0.3ms)  SELECT "users".* FROM "users" WHERE "users"."id" IN (2, 1)
I, [2017-09-09T22:42:49.226997 #28601]  INFO -- :   Rendering text template
I, [2017-09-09T22:42:49.227119 #28601]  INFO -- :   Rendered text template (0.0ms)
I, [2017-09-09T22:42:49.227346 #28601]  INFO -- : Completed 200 OK in 9ms (Views: 2.8ms)

, [2017-09-10T15:29:21.622159 #20907]  INFO -- : Started GET "/users?sort=user_role.allowed_to_buy%2Cuser_role.allowed_to_sell" for 127.0.0.1 at 2017-09-10 15:29:21 +0300
I, [2017-09-10T15:29:21.623171 #20907]  INFO -- : Processing by UsersController#index as HTML
I, [2017-09-10T15:29:21.623300 #20907]  INFO -- :   Parameters: {"sort"=>"user_role.allowed_to_buy,user_role.allowed_to_sell"}
D, [2017-09-10T15:29:21.627986 #20907] DEBUG -- :    (0.1ms)  SELECT users.id FROM "users" LEFT JOIN user_roles AS user_role_sorting ON user_role_sorting.id = users.user_role_id ORDER BY user_role_sorting.allowed_to_buy asc, user_role_sorting.allowed_to_sell asc
D, [2017-09-10T15:29:21.628703 #20907] DEBUG -- :   User Load (0.1ms)  SELECT "users".* FROM "users" WHERE "users"."id" IN (8, 7)
I, [2017-09-10T15:29:21.629592 #20907]  INFO -- :   Rendering text template
I, [2017-09-10T15:29:21.629645 #20907]  INFO -- :   Rendered text template (0.0ms)
I, [2017-09-10T15:29:21.629732 #20907]  INFO -- : Completed 200 OK in 6ms (Views: 0.3ms)

I, [2017-09-09T22:42:49.231572 #28601]  INFO -- : Started GET "/users?sort=age" for 127.0.0.1 at 2017-09-09 22:42:49 +0300
I, [2017-09-09T22:42:49.232813 #28601]  INFO -- : Processing by UsersController#index as HTML
I, [2017-09-09T22:42:49.232917 #28601]  INFO -- :   Parameters: {"sort"=>"age"}
I, [2017-09-09T22:42:49.239542 #28601]  INFO -- : Completed 400 Bad Request in 7ms (Views: 0.4ms)

I, [2017-09-10T15:29:21.606500 #20907]  INFO -- : Started GET "/users?sort=user_role.approved" for 127.0.0.1 at 2017-09-10 15:29:21 +0300
I, [2017-09-10T15:29:21.607188 #20907]  INFO -- : Processing by UsersController#index as HTML
I, [2017-09-10T15:29:21.607231 #20907]  INFO -- :   Parameters: {"sort"=>"user_role.approved"}
I, [2017-09-10T15:29:21.608326 #20907]  INFO -- : Completed 400 Bad Request in 1ms (Views: 0.2ms)
```