### PR TITLE
Do not verify_filters in the RequestParser

### DIFF
--- a/lib/jsonapi/request_parser.rb
+++ b/lib/jsonapi/request_parser.rb
@@ -353,7 +353,7 @@ module JSONAPI
         relationship_type: relationship_type,
         source_klass: @source_klass,
         source_id: @source_id,
-        filters: @source_klass.verify_filters(@filters, @context),
+        filters: @filters,
         sort_criteria: @sort_criteria,
         paginator: @paginator,
         fields: @fields,


### PR DESCRIPTION
A prior change to allow filters to be passed to related resources was incompletely backported from `master` to the `release-0-9` branch (see: 3a691b29adb3e7aff0743ef59e44556bedb260c9). This completes the backport, which moves the `verify_filters` from the `RequestParser` down to the
`Processor`. When `verify_filters` happens in both places, we end up running `verify_filter` twice for each filter, which can result in the filter values being wrapped in nested Arrays.

fixes #1110