### PR TITLE
Fixes #1094 #1097 fix sorting by nested relationships

### DIFF
--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -3911,3 +3911,45 @@ class BlogPostsControllerTest < ActionController::TestCase
     JSONAPI.configuration = original_config
   end
 end
+
+class WidgetsControllerTest < ActionController::TestCase
+  def teardown
+    Widget.delete_all
+    Indicator.delete_all
+    Agency.delete_all
+  end
+
+  def test_fetch_widgets_sort_by_agency_name
+    agency_1 = Agency.create! name: 'beta'
+    agency_2 = Agency.create! name: 'alpha'
+    indicator_1 = Indicator.create! name: 'bar', agency: agency_1
+    indicator_2 = Indicator.create! name: 'foo', agency: agency_2
+    Widget.create! name: 'bar', indicator: indicator_1
+    widget = Widget.create! name: 'foo', indicator: indicator_2
+    assert_cacheable_get :index, params: {sort: 'indicator.agency.name'}
+    assert_response :success
+    assert_equal widget.id.to_s, json_response['data'].first['id']
+  end
+end
+
+class IndicatorsControllerTest < ActionController::TestCase
+  def teardown
+    Widget.delete_all
+    Indicator.delete_all
+    Agency.delete_all
+  end
+
+  def test_fetch_indicators_sort_by_widgets_name
+    agency = Agency.create! name: 'test'
+    indicator_1 = Indicator.create! name: 'bar', agency: agency
+    indicator_2 = Indicator.create! name: 'foo', agency: agency
+    Widget.create! name: 'omega', indicator: indicator_1
+    Widget.create! name: 'beta', indicator: indicator_1
+    Widget.create! name: 'alpha', indicator: indicator_2
+    Widget.create! name: 'zeta', indicator: indicator_2
+    assert_cacheable_get :index, params: {sort: 'widgets.name'}
+    assert_response :success
+    assert_equal indicator_2.id.to_s, json_response['data'].first['id']
+    assert_equal 2, json_response['data'].size
+  end
+end

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -333,6 +333,23 @@ ActiveRecord::Schema.define do
     t.integer :access_card_id, null: false
     t.timestamps null: false
   end
+
+  create_table :agencies, force: true do |t|
+    t.string :name
+    t.timestamps null: false
+  end
+
+  create_table :indicators, force: true do |t|
+    t.string :name
+    t.integer :agency_id, null: false
+    t.timestamps null: false
+  end
+
+  create_table :widgets, force: true do |t|
+    t.string :name
+    t.integer :indicator_id, null: false
+    t.timestamps null: false
+  end
 end
 
 ### MODELS
@@ -368,7 +385,7 @@ class Post < ActiveRecord::Base
   has_many :special_post_tags, source: :tag
   has_many :special_tags, through: :special_post_tags, source: :tag
   belongs_to :section
-  has_one :parent_post, class_name: 'Post', foreign_key: 'parent_post_id'
+  belongs_to :parent_post, class_name: 'Post', foreign_key: 'parent_post_id'
 
   validates :author, presence: true
   validates :title, length: { maximum: 35 }
@@ -696,6 +713,18 @@ class Worker < ActiveRecord::Base
   belongs_to :access_card
 end
 
+class Agency < ActiveRecord::Base
+end
+
+class Indicator < ActiveRecord::Base
+  belongs_to :agency
+  has_many :widgets
+end
+
+class Widget < ActiveRecord::Base
+  belongs_to :indicator
+end
+
 ### CONTROLLERS
 class AuthorsController < JSONAPI::ResourceControllerMetal
 end
@@ -984,6 +1013,12 @@ class AccessCardsController < BaseController
 end
 
 class WorkersController < BaseController
+end
+
+class WidgetsController < JSONAPI::ResourceController
+end
+
+class IndicatorsController < JSONAPI::ResourceController
 end
 
 ### RESOURCES
@@ -1990,6 +2025,29 @@ class BlogPostResource < JSONAPI::Resource
   attribute :body
 
   filter :name
+end
+
+class AgencyResource < JSONAPI::Resource
+  attributes :name
+end
+
+class IndicatorResource < JSONAPI::Resource
+  attributes :name
+  has_one :agency
+  has_many :widgets
+
+  def self.sortable_fields(_context = nil)
+    super + [:'widgets.name']
+  end
+end
+
+class WidgetResource < JSONAPI::Resource
+  attributes :name
+  has_one :indicator
+
+  def self.sortable_fields(_context = nil)
+    super + [:'indicator.agency.name']
+  end
 end
 
 # CustomProcessors

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -398,6 +398,8 @@ TestApp.routes.draw do
   jsonapi_resources :keepers, only: [:show]
   jsonapi_resources :storages
   jsonapi_resources :workers, only: [:show]
+  jsonapi_resources :widgets, only: [:index]
+  jsonapi_resources :indicators, only: [:index]
 
   mount MyEngine::Engine => "/boomshaka", as: :my_engine
   mount ApiV2Engine::Engine => "/api_v2", as: :api_v2_engine


### PR DESCRIPTION
Fixes #1094, #1097, and #1086
works with sqlite and pg
proof:
```ruby
begin
  require 'bundler/inline'
  require 'bundler'
rescue LoadError => e
  STDERR.puts 'Bundler version 1.10 or later is required. Please update your Bundler'
  raise e
end

gemfile(true, ui: ENV['SILENT'] ? Bundler::UI::Silent.new : Bundler::UI::Shell.new) do
  source 'https://rubygems.org'

  gem 'rails', require: false

  if ENV['JSONAPI_RESOURCES_PG']
    gem 'pg'
  else
    gem 'sqlite3', platform: :mri

    gem 'activerecord-jdbcsqlite3-adapter',
        git: 'https://github.com/jruby/activerecord-jdbc-adapter',
        branch: 'rails-5',
        platform: :jruby
  end


  if ENV['JSONAPI_RESOURCES_PATH']
    gem 'jsonapi-resources', path: ENV['JSONAPI_RESOURCES_PATH'], require: false
  elsif ENV['JSONAPI_RESOURCES_GEM']
    gem 'jsonapi-resources'
  else
    gem 'jsonapi-resources', git: 'https://github.com/cerebris/jsonapi-resources', require: false
  end

end

# prepare active_record database
require 'active_record'

class NullLogger < Logger
  def initialize(*_args)
  end

  def add(*_args, &_block)
  end
end

# establish database connection
if ENV['JSONAPI_RESOURCES_PG']
  db_name = 'tmp_bug_report_table'
  system("psql -c 'DROP DATABASE IF EXISTS #{db_name};'")
  system("psql -c 'CREATE DATABASE #{db_name};'")
  ActiveRecord::Base.establish_connection(adapter: 'postgresql', database: db_name)
else
  ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
end

# specify logger
ActiveRecord::Base.logger = ENV['SILENT'] ? NullLogger.new : Logger.new(STDOUT)
ActiveRecord::Migration.verbose = !ENV['SILENT']

# define database schema
ActiveRecord::Schema.define do
  # Add your schema here
  create_table :agencies, force: true do |t|
    t.string :name
  end

  create_table :indicators, force: true do |t|
    t.string :name
    t.integer :agency_id
  end

  create_table :widgets, force: true do |t|
    t.string :name
    t.integer :indicator_id
  end
end

# create models
class Agency < ActiveRecord::Base
end

class Indicator < ActiveRecord::Base
  belongs_to :agency
  has_many :widgets
end

class Widget < ActiveRecord::Base
  belongs_to :indicator
end

# prepare rails app
require 'action_controller/railtie'
# require 'action_view/railtie'
require 'jsonapi-resources'

class ApplicationController < ActionController::Base
end

# prepare jsonapi resources and controllers
class WidgetsController < ApplicationController
  include JSONAPI::ActsAsResourceController
end

class IndicatorsController < ApplicationController
  include JSONAPI::ActsAsResourceController
end

class AgencyResource < JSONAPI::Resource
  attributes :name
end

class IndicatorResource < JSONAPI::Resource
  attributes :name
  has_one :agency
  has_many :widgets

  def self.sortable_fields(_context = nil)
    super + [:'widgets.name']
  end
end

class WidgetResource < JSONAPI::Resource
  attributes :name
  has_one :indicator

  def self.sortable_fields(_context = nil)
    super + [:'indicator.agency.name']
  end
end

class TestApp < Rails::Application
  config.root = File.dirname(__FILE__)
  config.logger = ENV['SILENT'] ? NullLogger.new : Logger.new(STDOUT)
  Rails.logger = config.logger

  secrets.secret_token = 'secret_token'
  secrets.secret_key_base = 'secret_key_base'

  config.eager_load = false
end

# initialize app
Rails.application.initialize!

JSONAPI.configure do |config|
  config.json_key_format = :underscored_key
  config.route_format = :underscored_key
end

# draw routes
Rails.application.routes.draw do
  jsonapi_resources :widgets, only: [:index]
  jsonapi_resources :indicators, only: [:index]
end

# prepare tests
require 'minitest/autorun'
require 'rack/test'

# Replace this with the code necessary to make your test fail.
class BugTest < Minitest::Test
  include Rack::Test::Methods

  def teardown
    Widget.delete_all
    Indicator.delete_all
    Agency.delete_all
  end

  def test_fetch_widgets_sort_by_agency_name
    agency_1 = Agency.create! name: 'beta'
    agency_2 = Agency.create! name: 'alpha'
    indicator_1 = Indicator.create! name: 'bar', agency: agency_1
    indicator_2 = Indicator.create! name: 'foo', agency: agency_2
    Widget.create! name: 'bar', indicator: indicator_1
    widget = Widget.create! name: 'foo', indicator: indicator_2
    get '/widgets', {sort: 'indicator.agency.name'}, json_api_headers
    assert last_response.ok?
    assert_equal widget.id.to_s, last_response_json[:data].first[:id]
  end

  def test_fetch_indicators_sort_by_widgets_name
    indicator_1 = Indicator.create! name: 'bar'
    indicator_2 = Indicator.create! name: 'foo'
    Widget.create! name: 'omega', indicator: indicator_1
    Widget.create! name: 'beta', indicator: indicator_1
    Widget.create! name: 'alpha', indicator: indicator_2
    Widget.create! name: 'zeta', indicator: indicator_2
    get '/indicators', {sort: 'widgets.name'}, json_api_headers
    assert last_response.ok?
    assert_equal indicator_2.id.to_s, last_response_json[:data].first[:id]
    assert_equal 2, last_response_json[:data].size
  end

  private

  def json_api_headers
    {'Accept' => JSONAPI::MEDIA_TYPE, 'CONTENT_TYPE' => JSONAPI::MEDIA_TYPE}
  end

  def last_response_json
    JSON.parse(last_response.body).deep_symbolize_keys
  end

  def app
    Rails.application
  end
end
```
log
```
I, [2017-09-09T23:08:02.963967 #31190]  INFO -- : Started GET "/widgets?sort=indicator.agency.name" for 127.0.0.1 at 2017-09-09 23:08:02 +0300
I, [2017-09-09T23:08:02.968393 #31190]  INFO -- : Processing by WidgetsController#index as HTML
I, [2017-09-09T23:08:02.968482 #31190]  INFO -- :   Parameters: {"sort"=>"indicator.agency.name"}
D, [2017-09-09T23:08:02.978318 #31190] DEBUG -- :    (0.3ms)  SELECT widgets.id FROM "widgets" LEFT JOIN indicators AS indicator_sorting ON indicator_sorting.id = widgets.indicator_id
LEFT JOIN agencies AS agency_sorting ON agency_sorting.id = indicator_sorting.agency_id ORDER BY agency_sorting.name asc
D, [2017-09-09T23:08:02.980497 #31190] DEBUG -- :   Widget Load (0.5ms)  SELECT "widgets".* FROM "widgets" WHERE "widgets"."id" IN (2, 1)
I, [2017-09-09T23:08:02.986526 #31190]  INFO -- :   Rendering text template
I, [2017-09-09T23:08:02.986704 #31190]  INFO -- :   Rendered text template (0.0ms)
I, [2017-09-09T23:08:02.986959 #31190]  INFO -- : Completed 200 OK in 18ms (Views: 3.7ms)

I, [2017-09-09T23:25:34.064896 #352]  INFO -- : Started GET "/indicators?sort=widgets.name" for 127.0.0.1 at 2017-09-09 23:25:34 +0300
I, [2017-09-09T23:25:34.066527 #352]  INFO -- : Processing by IndicatorsController#index as HTML
I, [2017-09-09T23:25:34.066575 #352]  INFO -- :   Parameters: {"sort"=>"widgets.name"}
D, [2017-09-09T23:25:34.068725 #352] DEBUG -- :    (0.2ms)  SELECT indicators.id FROM "indicators" LEFT JOIN widgets AS widgets_sorting ON widgets_sorting.indicator_id = indicators.id ORDER BY widgets_sorting.name asc
D, [2017-09-09T23:25:34.069531 #352] DEBUG -- :   Indicator Load (0.1ms)  SELECT "indicators".* FROM "indicators" WHERE "indicators"."id" IN (4, 1, 3, 2)
I, [2017-09-09T23:25:34.070867 #352]  INFO -- :   Rendering text template
I, [2017-09-09T23:25:34.070933 #352]  INFO -- :   Rendered text template (0.0ms)
I, [2017-09-09T23:25:34.071043 #352]  INFO -- : Completed 200 OK in 4ms (Views: 0.3ms)
```