### PR TITLE
Custom foreign key

### DIFF
--- a/lib/jsonapi/configuration.rb
+++ b/lib/jsonapi/configuration.rb
@@ -32,7 +32,8 @@ module JSONAPI
                 :resource_cache,
                 :default_resource_cache_field,
                 :resource_cache_digest_function,
-                :resource_cache_usage_report_function
+                :resource_cache_usage_report_function,
+                :relationship_forgien_key
 
     def initialize
       #:underscored_key, :camelized_key, :dasherized_key, or custom
@@ -43,6 +44,9 @@ module JSONAPI
 
       #:integer, :uuid, :string, or custom (provide a proc)
       self.resource_key_type = :integer
+
+      # optioanl set the default relationship foreign_key
+      self.relationship_forgien_key = 'id'
 
       # optional request features
       self.allow_include = true
@@ -175,6 +179,10 @@ module JSONAPI
 
     def resource_key_type=(key_type)
       @resource_key_type = key_type
+    end
+
+    def relationship_forgien_key=(foreign_key)
+      @relationship_forgien_key = foreign_key
     end
 
     def route_formatter

--- a/lib/jsonapi/relationship.rb
+++ b/lib/jsonapi/relationship.rb
@@ -22,6 +22,10 @@ module JSONAPI
       @primary_key ||= resource_klass._primary_key
     end
 
+    def relationship_forgien_key
+      @relationship_forgien_key ||= JSONAPI.configuration.relationship_forgien_key
+    end
+
     def resource_klass
       @resource_klass ||= @parent_resource.resource_for(@class_name)
     end
@@ -66,7 +70,7 @@ module JSONAPI
       def initialize(name, options = {})
         super
         @class_name = options.fetch(:class_name, name.to_s.camelize)
-        @foreign_key ||= "#{name}_id".to_sym
+        @foreign_key ||= "#{name}_#{relationship_forgien_key}".to_sym
         @foreign_key_on = options.fetch(:foreign_key_on, :self)
       end
 
@@ -85,7 +89,7 @@ module JSONAPI
       def initialize(name, options = {})
         super
         @class_name = options.fetch(:class_name, name.to_s.camelize.singularize)
-        @foreign_key ||= "#{name.to_s.singularize}_ids".to_sym
+        @foreign_key ||= "#{name.to_s.singularize}_#{relationship_forgien_key}s".to_sym
         @reflect = options.fetch(:reflect, true) == true
         @inverse_relationship = options.fetch(:inverse_relationship, parent_resource._type.to_s.singularize.to_sym) if parent_resource
       end

--- a/lib/jsonapi/resources/version.rb
+++ b/lib/jsonapi/resources/version.rb
@@ -1,5 +1,5 @@
 module JSONAPI
   module Resources
-    VERSION = '0.9.1.beta1'
+    VERSION = '0.9.0'
   end
 end

--- a/lib/jsonapi/resources/version.rb
+++ b/lib/jsonapi/resources/version.rb
@@ -1,5 +1,5 @@
 module JSONAPI
   module Resources
-    VERSION = '0.9.0'
+    VERSION = '0.9.1.beta1'
   end
 end


### PR DESCRIPTION
I have recently been working on a project where the foreign key is not always `id` but is `guid`. This is a problem because currently, the following lines are hardcoded to `id`

https://github.com/cerebris/jsonapi-resources/blob/master/lib/jsonapi/relationship.rb#L89
https://github.com/cerebris/jsonapi-resources/blob/master/lib/jsonapi/relationship.rb#L89

This PR is backported to `release-0-9` but I would be happy to port it forward to `master`.

