### PR TITLE
Travis: update rubies in matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ env:
   - "RAILS_VERSION=master"
 rvm:
   - 2.1.10
-  - 2.2.7
-  - 2.3.4
-  - 2.4.1
+  - 2.2.8
+  - 2.3.5
+  - 2.4.2
 matrix:
   exclude:
     - rvm: 2.1.10


### PR DESCRIPTION
This PR uses the latest-released MRI rubies `rvm` can supply.