### PR TITLE
[wip] the most naive solution for #1118

### DIFF
--- a/lib/jsonapi/routing_ext.rb
+++ b/lib/jsonapi/routing_ext.rb
@@ -66,6 +66,7 @@ module ActionDispatch
         def jsonapi_relationships(options = {})
           res = JSONAPI::Resource.resource_klass_for(resource_type_with_module_prefix(@resource_type))
           res._relationships.each do |relationship_name, relationship|
+            options = options.merge(relationship.options.slice(:controller))
             if relationship.is_a?(JSONAPI::Relationship::ToMany)
               jsonapi_links(relationship_name, options)
               jsonapi_related_resources(relationship_name, options)


### PR DESCRIPTION
allow to pass controller option when defining `has_many`, or `has_one` relation

e.g.
```` ruby
  has_many :kudos_given, class_name: 'Mm::Kudo', controller: 'mm/kudos'
````

It is working, still not test provided, as I do not now what would the desired implementation for the solution.