### PR TITLE
Rename controller actions that begin with `get_`

### DIFF
--- a/lib/jsonapi/acts_as_resource_controller.rb
+++ b/lib/jsonapi/acts_as_resource_controller.rb
@@ -51,12 +51,24 @@ module JSONAPI
       process_request
     end
 
-    def get_related_resource
+    def show_related_resource
       process_request
     end
 
-    def get_related_resources
+    def index_related_resources
       process_request
+    end
+
+    def get_related_resource
+      ActiveSupport::Deprecation.warn "In #{self.class.name} you exposed a `get_related_resource`"\
+                                      " action. Please use `show_related_resource` instead."
+      show_related_resource
+    end
+
+    def get_related_resources
+      ActiveSupport::Deprecation.warn "In #{self.class.name} you exposed a `get_related_resources`"\
+                                      " action. Please use `index_related_resource` instead."
+      index_related_resources
     end
 
     def process_request

--- a/lib/jsonapi/request_parser.rb
+++ b/lib/jsonapi/request_parser.rb
@@ -37,7 +37,7 @@ module JSONAPI
 
     def transactional?
       case params[:action]
-        when 'index', 'get_related_resource', 'get_related_resources', 'show', 'show_relationship'
+        when 'index', 'show_related_resource', 'index_related_resources', 'show', 'show_relationship'
           return false
         else
           return true
@@ -80,7 +80,7 @@ module JSONAPI
       )
     end
 
-    def setup_get_related_resource_action(params, resource_klass)
+    def setup_show_related_resource_action(params, resource_klass)
       source_klass = Resource.resource_klass_for(params.require(:source))
       source_id = source_klass.verify_key(params.require(source_klass._as_parent_key), @context)
 
@@ -101,7 +101,7 @@ module JSONAPI
       )
     end
 
-    def setup_get_related_resources_action(params, resource_klass)
+    def setup_index_related_resources_action(params, resource_klass)
       source_klass = Resource.resource_klass_for(params.require(:source))
       source_id = source_klass.verify_key(params.require(source_klass._as_parent_key), @context)
 

--- a/lib/jsonapi/routing_ext.rb
+++ b/lib/jsonapi/routing_ext.rb
@@ -221,7 +221,7 @@ module ActionDispatch
 
           match formatted_relationship_name, controller: options[:controller],
                 relationship: relationship.name, source: resource_type_with_module_prefix(source._type),
-                action: 'get_related_resource', via: [:get]
+                action: 'show_related_resource', via: [:get]
         end
 
         def jsonapi_related_resources(*relationship)
@@ -238,7 +238,7 @@ module ActionDispatch
           match formatted_relationship_name,
                 controller: options[:controller],
                 relationship: relationship.name, source: resource_type_with_module_prefix(source._type),
-                action: 'get_related_resources', via: [:get]
+                action: 'index_related_resources', via: [:get]
         end
 
         protected

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -1951,26 +1951,26 @@ class PostsControllerTest < ActionController::TestCase
                        }
   end
 
-  def test_get_related_resources_sorted
-    assert_cacheable_get :get_related_resources, params: {person_id: '1001', relationship: 'posts', source:'people', sort: 'title' }
+  def test_index_related_resources_sorted
+    assert_cacheable_get :index_related_resources, params: {person_id: '1001', relationship: 'posts', source:'people', sort: 'title' }
     assert_response :success
     assert_equal 'JR How To', json_response['data'][0]['attributes']['title']
     assert_equal 'New post', json_response['data'][2]['attributes']['title']
-    assert_cacheable_get :get_related_resources, params: {person_id: '1001', relationship: 'posts', source:'people', sort: '-title' }
+    assert_cacheable_get :index_related_resources, params: {person_id: '1001', relationship: 'posts', source:'people', sort: '-title' }
     assert_response :success
     assert_equal 'New post', json_response['data'][0]['attributes']['title']
     assert_equal 'JR How To', json_response['data'][2]['attributes']['title']
   end
 
-  def test_get_related_resources_default_sorted
-    assert_cacheable_get :get_related_resources, params: {person_id: '1001', relationship: 'posts', source:'people'}
+  def test_index_related_resources_default_sorted
+    assert_cacheable_get :index_related_resources, params: {person_id: '1001', relationship: 'posts', source:'people'}
     assert_response :success
     assert_equal 'New post', json_response['data'][0]['attributes']['title']
     assert_equal 'JR How To', json_response['data'][2]['attributes']['title']
   end
 
-  def test_get_related_resources_has_many_filtered
-    assert_cacheable_get :get_related_resources, params: {person_id: '1001', relationship: 'posts', source:'people', filter: { title: 'JR How To' } }
+  def test_index_related_resources_has_many_filtered
+    assert_cacheable_get :index_related_resources, params: {person_id: '1001', relationship: 'posts', source:'people', filter: { title: 'JR How To' } }
     assert_response :success
     assert_equal 'JR How To', json_response['data'][0]['attributes']['title']
     assert_equal 1, json_response['data'].size
@@ -2494,8 +2494,8 @@ class PeopleControllerTest < ActionController::TestCase
     assert_response :bad_request
   end
 
-  def test_invalid_filter_value_for_get_related_resources
-    assert_cacheable_get :get_related_resources, params: {
+  def test_invalid_filter_value_for_index_related_resources
+    assert_cacheable_get :index_related_resources, params: {
           hair_cut_id: 1,
           relationship: 'people',
           source: 'hair_cuts',
@@ -2513,11 +2513,11 @@ class PeopleControllerTest < ActionController::TestCase
     assert_equal 'Joe Author', json_response['data'][0]['attributes']['name']
   end
 
-  def test_get_related_resource_no_namespace
+  def test_show_related_resource_no_namespace
     original_config = JSONAPI.configuration.dup
     JSONAPI.configuration.json_key_format = :dasherized_key
     JSONAPI.configuration.route_format = :underscored_key
-    assert_cacheable_get :get_related_resource, params: {post_id: '2', relationship: 'author', source:'posts'}
+    assert_cacheable_get :show_related_resource, params: {post_id: '2', relationship: 'author', source:'posts'}
     assert_response :success
 
     assert_hash_equals(
@@ -2579,19 +2579,19 @@ class PeopleControllerTest < ActionController::TestCase
     JSONAPI.configuration = original_config
   end
 
-  def test_get_related_resource_includes
+  def test_show_related_resource_includes
     original_config = JSONAPI.configuration.dup
     JSONAPI.configuration.json_key_format = :dasherized_key
     JSONAPI.configuration.route_format = :underscored_key
-    assert_cacheable_get :get_related_resource, params: {post_id: '2', relationship: 'author', source:'posts', include: 'posts'}
+    assert_cacheable_get :show_related_resource, params: {post_id: '2', relationship: 'author', source:'posts', include: 'posts'}
     assert_response :success
     assert_equal 'posts', json_response['included'][0]['type']
   ensure
     JSONAPI.configuration = original_config
   end
 
-  def test_get_related_resource_nil
-    get :get_related_resource, params: {post_id: '17', relationship: 'author', source:'posts'}
+  def test_show_related_resource_nil
+    get :show_related_resource, params: {post_id: '17', relationship: 'author', source:'posts'}
     assert_response :success
     assert_hash_equals json_response,
                        {
@@ -3390,10 +3390,10 @@ class Api::V2::BooksControllerTest < ActionController::TestCase
     book_comment.delete
   end
 
-  def test_get_related_resources_pagination
+  def test_index_related_resources_pagination
     Api::V2::BookResource.paginator :offset
 
-    assert_cacheable_get :get_related_resources, params: {author_id: '1003', relationship: 'books', source:'api/v2/authors'}
+    assert_cacheable_get :index_related_resources, params: {author_id: '1003', relationship: 'books', source:'api/v2/authors'}
     assert_response :success
     assert_equal 10, json_response['data'].size
     assert_equal 3, json_response['links'].size
@@ -3525,8 +3525,8 @@ class Api::V1::PlanetsControllerTest < ActionController::TestCase
 end
 
 class Api::V1::MoonsControllerTest < ActionController::TestCase
-  def test_get_related_resource
-    assert_cacheable_get :get_related_resource, params: {crater_id: 'S56D', relationship: 'moon', source: "api/v1/craters"}
+  def test_show_related_resource
+    assert_cacheable_get :show_related_resource, params: {crater_id: 'S56D', relationship: 'moon', source: "api/v1/craters"}
     assert_response :success
     assert_hash_equals({
                          data: {
@@ -3541,12 +3541,12 @@ class Api::V1::MoonsControllerTest < ActionController::TestCase
                        }, json_response)
   end
 
-  def test_get_related_resources_with_select_some_db_columns
+  def test_index_related_resources_with_select_some_db_columns
     Api::V1::MoonResource.paginator :paged
     original_config = JSONAPI.configuration.dup
     JSONAPI.configuration.top_level_meta_include_record_count = true
     JSONAPI.configuration.json_key_format = :dasherized_key
-    assert_cacheable_get :get_related_resources, params: {planet_id: '1', relationship: 'moons', source: 'api/v1/planets'}
+    assert_cacheable_get :index_related_resources, params: {planet_id: '1', relationship: 'moons', source: 'api/v1/planets'}
     assert_response :success
     assert_equal 1, json_response['meta']['record-count']
   ensure
@@ -3564,8 +3564,8 @@ class Api::V1::CratersControllerTest < ActionController::TestCase
     assert_nil json_response['included']
   end
 
-  def test_get_related_resources
-    assert_cacheable_get :get_related_resources, params: {moon_id: '1', relationship: 'craters', source: "api/v1/moons"}
+  def test_index_related_resources
+    assert_cacheable_get :index_related_resources, params: {moon_id: '1', relationship: 'craters', source: "api/v1/moons"}
     assert_response :success
     assert_hash_equals({
                          data: [
@@ -3587,9 +3587,9 @@ class Api::V1::CratersControllerTest < ActionController::TestCase
                        }, json_response)
   end
 
-  def test_get_related_resources_filtered
+  def test_index_related_resources_filtered
     $test_user = Person.find(1001)
-    assert_cacheable_get :get_related_resources,
+    assert_cacheable_get :index_related_resources,
                          params: {
                              moon_id: '1',
                              relationship: 'craters',

--- a/test/integration/routes/routes_test.rb
+++ b/test/integration/routes/routes_test.rb
@@ -78,7 +78,7 @@ class RoutesTest < ActionDispatch::IntegrationTest
   # Polymorphic
   # ToDo: refute this routing. Polymorphic relationships can't support a shared set of filters or includes so
   # this this route is no longer supported
-  # def test_routing_polymorphic_get_related_resource
+  # def test_routing_polymorphic_show_related_resource
   #   assert_routing(
   #     {
   #       path: '/pictures/1/imageable',
@@ -88,7 +88,7 @@ class RoutesTest < ActionDispatch::IntegrationTest
   #       relationship: 'imageable',
   #       source: 'pictures',
   #       controller: 'imageables',
-  #       action: 'get_related_resource',
+  #       action: 'show_related_resource',
   #       picture_id: '1'
   #     }
   #   )

--- a/test/unit/serializer/polymorphic_serializer_test.rb
+++ b/test/unit/serializer/polymorphic_serializer_test.rb
@@ -346,7 +346,7 @@
 #     )
 #   end
 #
-#   def test_polymorphic_get_related_resource
+#   def test_polymorphic_show_related_resource
 #     get '/pictures/1/imageable', headers: { 'Accept' => JSONAPI::MEDIA_TYPE }
 #     serialized_data = JSON.parse(response.body)
 #       assert_hash_equals(


### PR DESCRIPTION
The following methods were renamed to comply with Rubocop's
`Style/AccessorMethodName` rule:

* `get_related_resource` -> `show_related_resource`
* `get_related_resources` -> `index_related_resources`

Fixes gh-1131