### PR TITLE
added application backtrace feature

### DIFF
--- a/lib/jsonapi/configuration.rb
+++ b/lib/jsonapi/configuration.rb
@@ -26,6 +26,7 @@ module JSONAPI
                 :top_level_meta_page_count_key,
                 :allow_transactions,
                 :include_backtraces_in_errors,
+                :include_application_backtraces_in_errors,
                 :exception_class_whitelist,
                 :whitelist_all_exceptions,
                 :always_include_to_one_linkage_data,
@@ -79,6 +80,10 @@ module JSONAPI
       # Whether or not to include exception backtraces in JSONAPI error
       # responses.  Defaults to `false` in production, and `true` otherwise.
       self.include_backtraces_in_errors = !Rails.env.production?
+
+      # Whether or not to include exception application backtraces in JSONAPI error
+      # responses.  Defaults to `false` in production, and `true` otherwise.
+      self.include_application_backtraces_in_errors = !Rails.env.production?
 
       # List of classes that should not be rescued by the operations processor.
       # For example, if you use Pundit for authorization, you might
@@ -245,6 +250,8 @@ module JSONAPI
     attr_writer :allow_transactions
 
     attr_writer :include_backtraces_in_errors
+
+    attr_writer :include_application_backtraces_in_errors
 
     attr_writer :exception_class_whitelist
 

--- a/lib/jsonapi/exceptions.rb
+++ b/lib/jsonapi/exceptions.rb
@@ -49,6 +49,12 @@ module JSONAPI
           meta[:backtrace] = exception.backtrace
         end
 
+        if JSONAPI.configuration.include_application_backtraces_in_errors
+          meta ||= Hash.new
+          meta[:exception] ||= exception.message
+          meta[:application_backtrace] = exception.backtrace.select{|line| line =~ /#{Rails.root}/}
+        end
+
         [create_error_object(code: JSONAPI::INTERNAL_SERVER_ERROR,
                              status: :internal_server_error,
                              title: I18n.t('jsonapi-resources.exceptions.internal_server_error.title',

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -126,16 +126,35 @@ class PostsControllerTest < ActionController::TestCase
     JSONAPI.configuration.include_backtraces_in_errors = true
     assert_cacheable_get :index
     assert_response 500
-    assert_includes @response.body, "backtrace", "expected backtrace in error body"
+    assert_includes @response.body, '"backtrace"', "expected backtrace in error body"
 
     JSONAPI.configuration.include_backtraces_in_errors = false
     assert_cacheable_get :index
     assert_response 500
-    refute_includes @response.body, "backtrace", "expected backtrace in error body"
+    refute_includes @response.body, '"backtrace"', "expected backtrace in error body"
 
   ensure
     $PostProcessorRaisesErrors = false
     JSONAPI.configuration.include_backtraces_in_errors = original_config
+  end
+
+  def test_exception_includes_application_backtrace_when_enabled
+    original_config = JSONAPI.configuration.include_application_backtraces_in_errors
+    $PostProcessorRaisesErrors = true
+
+    JSONAPI.configuration.include_application_backtraces_in_errors = true
+    assert_cacheable_get :index
+    assert_response 500
+    assert_includes @response.body, '"application_backtrace"', "expected application backtrace in error body"
+
+    JSONAPI.configuration.include_application_backtraces_in_errors = false
+    assert_cacheable_get :index
+    assert_response 500
+    refute_includes @response.body, '"application_backtrace"', "expected application backtrace in error body"
+
+  ensure
+    $PostProcessorRaisesErrors = false
+    JSONAPI.configuration.include_application_backtraces_in_errors = original_config
   end
 
   def test_on_server_error_block_callback_with_exception

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -513,7 +513,7 @@ class ActionController::TestCase
     ActiveSupport::Notifications.subscribed(normal_query_callback, 'sql.active_record') do
       get action, *args
     end
-    non_caching_response = json_response_sans_backtraces
+    non_caching_response = json_response_sans_all_backtraces
     non_caching_status = response.status
 
     # Don't let all the cache-testing requests mess with assert_query_count
@@ -565,7 +565,7 @@ class ActionController::TestCase
         )
         assert_equal(
           non_caching_response.pretty_inspect,
-          json_response_sans_backtraces.pretty_inspect,
+          json_response_sans_all_backtraces.pretty_inspect,
           "Cache (mode: #{mode}) #{phase} response body must match normal response"
         )
         assert_operator(
@@ -605,12 +605,13 @@ class ActionController::TestCase
 
   private
 
-  def json_response_sans_backtraces
+  def json_response_sans_all_backtraces
     return nil if response.body.to_s.strip.empty?
 
     r = json_response.dup
     (r["errors"] || []).each do |err|
       err["meta"].delete("backtrace") if err.has_key?("meta")
+      err["meta"].delete("application_backtrace") if err.has_key?("meta")
     end
     return r
   end


### PR DESCRIPTION
Adds application backtrace, enabled by default when not running on production. Helpful during debugging.

![screen shot 2017-11-30 at 11 59 32 am](https://user-images.githubusercontent.com/1445068/33452121-fed0dc42-d5c5-11e7-9d64-5d99fd71a05d.png)
