### PR TITLE
added optional route formatting feature

### DIFF
--- a/lib/jsonapi/link_builder.rb
+++ b/lib/jsonapi/link_builder.rb
@@ -115,7 +115,7 @@ module JSONAPI
       scopes = module_scopes_from_class(klass)
 
       unless scopes.empty?
-        "/#{ scopes.map{ |scope| format_route(scope.to_s.underscore) }.join('/') }/"
+        "/#{ scopes.map{ |scope| format_route(scope.to_s.underscore) }.compact.join('/') }/"
       else
         "/"
       end

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -1929,6 +1929,13 @@ module DasherizedNamespace
   end
 end
 
+module OptionalNamespace
+  module V1
+    class PersonResource < JSONAPI::Resource
+    end
+  end
+end
+
 module MyEngine
   module Api
     module V1
@@ -1945,6 +1952,13 @@ module MyEngine
   end
 
   module DasherizedNamespace
+    module V1
+      class PersonResource < JSONAPI::Resource
+      end
+    end
+  end
+
+  module OptionalNamespace
     module V1
       class PersonResource < JSONAPI::Resource
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -421,6 +421,12 @@ MyEngine::Engine.routes.draw do
       jsonapi_resources :people
     end
   end
+
+  namespace :optional_namespace, path: 'optional_namespace' do
+    namespace :v1, path: '' do
+      jsonapi_resources :people
+    end
+  end
 end
 
 ApiV2Engine::Engine.routes.draw do
@@ -667,6 +673,19 @@ class TitleValueFormatter < JSONAPI::ValueFormatter
 
     def unformat(value)
       value.to_s.downcase
+    end
+  end
+end
+
+class OptionalRouteFormatter < JSONAPI::RouteFormatter
+  class << self
+    def format(route)
+      return if route == 'v1'
+      super
+    end
+
+    def unformat(formatted_route)
+      super
     end
   end
 end

--- a/test/unit/serializer/link_builder_test.rb
+++ b/test/unit/serializer/link_builder_test.rb
@@ -302,6 +302,20 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
     assert_equal expected_link, builder.query_link(query)
   end
 
+  def test_query_link_for_regular_app_with_optional_scope
+    config = {
+        base_url: @base_url,
+        route_formatter: OptionalRouteFormatter,
+        primary_resource_klass: OptionalNamespace::V1::PersonResource
+    }
+
+    query         = { page: { offset: 0, limit: 12 } }
+    builder       = JSONAPI::LinkBuilder.new(config)
+    expected_link = "#{ @base_url }/optional_namespace/people?page%5Blimit%5D=12&page%5Boffset%5D=0"
+
+    assert_equal expected_link, builder.query_link(query)
+  end
+
   def test_query_link_for_engine
     config = {
       base_url: @base_url,
@@ -340,6 +354,20 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
     query         = { page: { offset: 0, limit: 12 } }
     builder       = JSONAPI::LinkBuilder.new(config)
     expected_link = "#{ @base_url }/boomshaka/dasherized-namespace/v1/people?page%5Blimit%5D=12&page%5Boffset%5D=0"
+
+    assert_equal expected_link, builder.query_link(query)
+  end
+
+  def test_query_link_for_engine_with_optional_scope
+    config = {
+        base_url: @base_url,
+        route_formatter: OptionalRouteFormatter,
+        primary_resource_klass: MyEngine::OptionalNamespace::V1::PersonResource
+    }
+
+    query         = { page: { offset: 0, limit: 12 } }
+    builder       = JSONAPI::LinkBuilder.new(config)
+    expected_link = "#{ @base_url }/boomshaka/optional_namespace/people?page%5Blimit%5D=12&page%5Boffset%5D=0"
 
     assert_equal expected_link, builder.query_link(query)
   end


### PR DESCRIPTION
Solves #1058 #591 #257 #159.

For when you have an implicit way of accessing a namespace (headers, subdomain, or other)

My use case is:
```
  # NOTE: api.yourapplication.test
  namespace :api, path: '', constraints: { subdomain: 'api' ) } do
    namespace :v1 do
      # ...
    end
  end
```

I created a custom route formatter class:

```
module YourApplication
  class CustomRouteFormatter < JSONAPI::RouteFormatter
    class << self
      def format(route)
        return if route == 'api'
        super
      end

      def unformat(formatted_route)
        super
      end
    end
  end
end
```

and referenced it in my base controller:

```
      def route_formatter
        YourApplication::CustomRouteFormatter
      end
```