### PR TITLE
Support Whitelist Of Action Dispatch Exception

### DIFF
--- a/lib/jsonapi/acts_as_resource_controller.rb
+++ b/lib/jsonapi/acts_as_resource_controller.rb
@@ -278,7 +278,9 @@ module JSONAPI
             end
 
             # Store exception for other middlewares
-            request.env['action_dispatch.exception'] ||= e
+            unless JSONAPI.configuration.exception_class_action_dispatch_whitelisted?(e)
+              request.env['action_dispatch.exception'] ||= e
+            end
 
             internal_server_error = JSONAPI::Exceptions::InternalServerError.new(e)
             Rails.logger.error { "Internal Server Error: #{e.message} #{e.backtrace.join("\n")}" }

--- a/lib/jsonapi/configuration.rb
+++ b/lib/jsonapi/configuration.rb
@@ -28,6 +28,7 @@ module JSONAPI
                 :include_backtraces_in_errors,
                 :include_application_backtraces_in_errors,
                 :exception_class_whitelist,
+                :exception_class_action_dispatch_whitelist,
                 :whitelist_all_exceptions,
                 :always_include_to_one_linkage_data,
                 :always_include_to_many_linkage_data,
@@ -92,6 +93,10 @@ module JSONAPI
       # catch this error and render a 403 status code, you should add
       # the `Pundit::NotAuthorizedError` to the `exception_class_whitelist`.
       self.exception_class_whitelist = []
+
+      # List of classes that should not set in request.env['action_dispatch.exception'].
+      # For example, if you want JSON API resources to handle an error but not notify Rollbar.
+      self.exception_class_action_dispatch_whitelist = []
 
       # If enabled, will override configuration option `exception_class_whitelist`
       # and whitelist all exceptions.
@@ -219,6 +224,10 @@ module JSONAPI
         @exception_class_whitelist.flatten.any? { |k| e.class.ancestors.map(&:to_s).include?(k.to_s) }
     end
 
+    def exception_class_action_dispatch_whitelisted?(e)
+      @exception_class_action_dispatch_whitelist.flatten.any? { |k| e.class.ancestors.map(&:to_s).include?(k.to_s) }
+    end
+
     def default_processor_klass=(default_processor_klass)
       @default_processor_klass = default_processor_klass
     end
@@ -254,6 +263,8 @@ module JSONAPI
     attr_writer :include_application_backtraces_in_errors
 
     attr_writer :exception_class_whitelist
+
+    attr_writer :exception_class_action_dispatch_whitelist
 
     attr_writer :whitelist_all_exceptions
 

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -90,6 +90,25 @@ class PostsControllerTest < ActionController::TestCase
     JSONAPI.configuration.exception_class_whitelist = original_whitelist
   end
 
+  def test_exception_class_action_dispatch_whitelist
+    original_whitelist = JSONAPI.configuration.exception_class_action_dispatch_whitelist.dup
+    $PostProcessorRaisesErrors = true
+    # test that the operations dispatcher rescues the error when it
+    # has not been added to the exception_class_whitelist
+    assert_cacheable_get :index
+    assert_response 500
+    assert_not_nil @request.env['action_dispatch.exception']
+
+    @request.env['action_dispatch.exception'] = nil
+    JSONAPI.configuration.exception_class_action_dispatch_whitelist << PostsController::SpecialError
+    assert_cacheable_get :index
+    assert_response 500
+    assert_nil @request.env['action_dispatch.exception']
+  ensure
+    $PostProcessorRaisesErrors = false
+    JSONAPI.configuration.exception_class_action_dispatch_whitelist = original_whitelist
+  end
+
   def test_whitelist_all_exceptions
     original_config = JSONAPI.configuration.whitelist_all_exceptions
     $PostProcessorRaisesErrors = true


### PR DESCRIPTION
This PR introduces the configuration of `exception_class_action_dispatch_whitelist`. The problem this PR is trying to solve is that JSON API Resources does a great job of serializing errors into a JSON API response to the client. However, certain alerting frameworks report on the error placed in `action_dispatch.exception`. For example Rollbar does this [here](https://github.com/rollbar/rollbar-gem/blob/d3ca4fbeceee7621cbe8964ad1e160d247c84afe/lib/rollbar/middleware/rails/rollbar.rb#L26). 
The only way to handle the exception is to add it to `exception_class_whitelist`, but then we must basically re-implement what JSON API Resources already does so well in our `rescue_from` in the Controller.

By introducing this notion of whitelist, we allow JSON API to continue to respond to the error, but we can hide it from Rails and other downstream middleware, i.e. Rollbar. This lets us keep the baby while we toss out the bath water.

Related Issue
https://github.com/cerebris/jsonapi-resources/issues/1151

### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [x] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [x] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [x] I've added/updated tests for this change.

### New Feature Submissions:

- [x] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [x] My submission includes new tests.
- [x] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions