### PR TITLE
Allow pagination for nested resources but not for included resources

### DIFF
--- a/lib/jsonapi/processor.rb
+++ b/lib/jsonapi/processor.rb
@@ -469,7 +469,9 @@ module JSONAPI
         find_related_resource_options[:sort_criteria] = relationship.resource_klass.default_sort
         find_related_resource_options[:cache] = resource_klass.caching?
 
-        related_identities = resource_klass.find_related_fragments(source_rids, relationship_name, find_related_resource_options)
+        related_identities = resource_klass.find_related_fragments(
+          source_rids, relationship_name, find_related_resource_options, key
+        )
 
         related_identities.each_pair do |identity, v|
           related[relationship_name][:resources][identity] =

--- a/test/unit/resource/active_relation_resource_finder_test.rb
+++ b/test/unit/resource/active_relation_resource_finder_test.rb
@@ -121,6 +121,36 @@ class ActiveRelationResourceFinderTest < ActiveSupport::TestCase
     assert_equal 2, related_identities[JSONAPI::ResourceIdentity.new(TagResource, 502)][:related][:tags].length
   end
 
+  def test_find_related_has_many_fragments_pagination
+    params = ActionController::Parameters.new(number: 2, size: 4)
+    options = { paginator: PagedPaginator.new(params) }
+    source_rids = [JSONAPI::ResourceIdentity.new(ARPostResource, 15)]
+
+    related_identities = ARPostResource.find_related_fragments(source_rids, 'tags', options)
+
+    assert_equal 1, related_identities.length
+    assert_equal JSONAPI::ResourceIdentity.new(TagResource, 516), related_identities.keys[0]
+    assert_equal JSONAPI::ResourceIdentity.new(TagResource, 516), related_identities.values[0][:identity]
+    assert related_identities.values[0].is_a?(Hash)
+    assert_equal 2, related_identities.values[0].length
+    assert_equal 1, related_identities.values[0][:related][:tags].length
+  end
+
+  def test_find_related_has_many_fragments_pagination_included_key
+    params = ActionController::Parameters.new(number: 2, size: 4)
+    options = { paginator: PagedPaginator.new(params) }
+    source_rids = [JSONAPI::ResourceIdentity.new(ARPostResource, 15)]
+
+    related_identities = ARPostResource.find_related_fragments(source_rids, 'tags', options, :tags)
+
+    assert_equal 5, related_identities.length
+    assert_equal JSONAPI::ResourceIdentity.new(TagResource, 502), related_identities.keys[0]
+    assert_equal JSONAPI::ResourceIdentity.new(TagResource, 502), related_identities.values[0][:identity]
+    assert related_identities.values[0].is_a?(Hash)
+    assert_equal 2, related_identities.values[0].length
+    assert_equal 1, related_identities.values[0][:related][:tags].length
+  end
+
   def test_find_related_has_many_fragments_cache_field
     options = { cache: true }
     source_rids = [JSONAPI::ResourceIdentity.new(ARPostResource, 1),
@@ -200,7 +230,7 @@ class ActiveRelationResourceFinderTest < ActiveSupport::TestCase
   end
 
   def test_find_related_polymorphic_fragments_cache_field_attributes
-    options = { cache: true , attributes: [:name] }
+    options = { cache: true, attributes: [:name] }
     source_rids = [JSONAPI::ResourceIdentity.new(PictureResource, 1),
                    JSONAPI::ResourceIdentity.new(PictureResource, 2),
                    JSONAPI::ResourceIdentity.new(PictureResource, 20)]


### PR DESCRIPTION
### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [x] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [x] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [x] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [x] I've added/updated tests for this change.

### Bug fixes and Changes to Core Features:

- [x] I've included an explanation of what the changes do and why I'd like you to include them.
- [x] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions

Fixes #1162. The issue is that nested resources as well as included resources use `find_related_monomorphic_fragments` in a similar fashion. If we query nested resources, we want pagination to have an effect on the nested resources. If we include resources (at least currently) we don't want the pagination for the main resource to have an effect on the included resources. Thus, we have to differentiate between the two cases.

The issue in #1162 is that if some page of the main resource has only 1 resource, the condition to apply pagination (`source_rids.count == 1`) would be true and thus no includes are loaded.