### PR TITLE
Allow to post existing relationships

### DIFF
--- a/lib/jsonapi/exceptions.rb
+++ b/lib/jsonapi/exceptions.rb
@@ -141,26 +141,6 @@ module JSONAPI
       end
     end
 
-
-    class HasManyRelationExists < Error
-      attr_accessor :id
-
-      def initialize(id, error_object_overrides = {})
-        @id = id
-        super(error_object_overrides)
-      end
-
-      def errors
-        [create_error_object(code: JSONAPI::RELATION_EXISTS,
-                             status: :bad_request,
-                             title: I18n.translate('jsonapi-resources.exceptions.has_many_relation.title',
-                                                   default: 'Relation exists'),
-                             detail: I18n.translate('jsonapi-resources.exceptions.has_many_relation.detail',
-                                                    default: "The relation to #{id} already exists.",
-                                                    id: id))]
-      end
-    end
-
     class BadRequest < Error
       def initialize(exception, error_object_overrides = {})
         @exception = exception

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -266,7 +266,9 @@ module JSONAPI
           end
           @reload_needed = true
         else
-          @model.public_send(relation_name) << related_resource._model
+          unless @model.public_send(relation_name).include?(related_resource._model)
+            @model.public_send(relation_name) << related_resource._model
+          end
         end
       end
 

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -238,14 +238,7 @@ module JSONAPI
 
     def _create_to_many_links(relationship_type, relationship_key_values, options)
       relationship = self.class._relationships[relationship_type]
-
-      # check if relationship_key_values are already members of this relationship
       relation_name = relationship.relation_name(context: @context)
-      existing_relations = @model.public_send(relation_name).where(relationship.primary_key => relationship_key_values)
-      if existing_relations.count > 0
-        # todo: obscure id so not to leak info
-        fail JSONAPI::Exceptions::HasManyRelationExists.new(existing_relations.first.id)
-      end
 
       if options[:reflected_source]
         @model.public_send(relation_name) << options[:reflected_source]._model

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -16,9 +16,6 @@ en:
       unsupported_media_type:
         title: 'Unsupported media type'
         detail: "All requests that create or update must use the '%{needed_media_type}' Content-Type. This request specified '%{media_type}.'"
-      has_many_relation:
-        title: 'Relation exists'
-        detail: "The relation to %{id} already exists."
       to_many_set_replacement_forbidden:
         title: 'Complete replacement forbidden'
         detail: 'Complete replacement forbidden for this relationship'

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -1508,8 +1508,9 @@ class PostsControllerTest < ActionController::TestCase
 
     post :create_relationship, params: {post_id: 3, relationship: 'tags', data: [{type: 'tags', id: 502}, {type: 'tags', id: 505}]}
 
-    assert_response :bad_request
-    assert_match /The relation to 502 already exists./, response.body
+    assert_response :no_content
+    post_object.reload
+    assert_equal [502,503,505], post_object.tag_ids
   end
 
   def test_update_relationship_to_many_missing_tags


### PR DESCRIPTION
### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [x] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [x] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [x] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [x] I've added/updated tests for this change.

### Bug fixes and Changes to Core Features:

- [x] I've included an explanation of what the changes do and why I'd like you to include them.
- [x] I've provided test(s) that fails without the change.

When adding  a relationship that already exists or multiple relationships of which at least one already exists, the response is a 400 Bad Request and the relationships are not updated/created. In our specific case we expected the API to behave differently and if I am not misinterpreting http://jsonapi.org, the expected response is actually a different one. 

To quote http://jsonapi.org/ (http://jsonapi.org/format/#crud-updating-to-many-relationships):

> If all of the specified resources can be added to, or are already present in, the relationship then the server MUST return a successful response.
Note: This approach ensures that a request is successful if the server’s state matches the requested state, and helps avoid pointless race conditions caused by multiple clients making the same changes to a relationship.

Fixes #1168

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions