### PR TITLE
Cherrypicks into 0.9 - fixes #909 add possibility to set generic validation error

### DIFF
--- a/lib/jsonapi/exceptions.rb
+++ b/lib/jsonapi/exceptions.rb
@@ -448,11 +448,12 @@ module JSONAPI
     end
 
     class ValidationErrors < Error
-      attr_reader :error_messages, :error_metadata, :resource_relationships
+      attr_reader :error_messages, :error_metadata, :resource_relationships, :resource_class
 
       def initialize(resource, error_object_overrides = {})
         @error_messages = resource.model_error_messages
         @error_metadata = resource.validation_error_metadata
+        @resource_class = resource.class
         @resource_relationships = resource.class._relationships.keys
         @key_formatter = JSONAPI.configuration.key_formatter
         super(error_object_overrides)
@@ -474,7 +475,7 @@ module JSONAPI
         create_error_object(code: JSONAPI::VALIDATION_ERROR,
                             status: :unprocessable_entity,
                             title: message,
-                            detail: "#{format_key(attr_key)} - #{message}",
+                            detail: detail(attr_key, message),
                             source: { pointer: pointer(attr_key) },
                             meta: metadata_for(attr_key, message))
       end
@@ -484,13 +485,22 @@ module JSONAPI
         error_metadata[attr_key] ? error_metadata[attr_key][message] : nil
       end
 
+      def detail(attr_key, message)
+        general_error?(attr_key) ? message : "#{format_key(attr_key)} - #{message}"
+      end
+
       def pointer(attr_or_relationship_name)
+        return '/data' if general_error?(attr_or_relationship_name)
         formatted_attr_or_relationship_name = format_key(attr_or_relationship_name)
         if resource_relationships.include?(attr_or_relationship_name)
           "/data/relationships/#{formatted_attr_or_relationship_name}"
         else
           "/data/attributes/#{formatted_attr_or_relationship_name}"
         end
+      end
+
+      def general_error?(attr_key)
+        attr_key.to_sym == :base && !resource_class._has_attribute?(attr_key)
       end
     end
 

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -911,6 +911,10 @@ module JSONAPI
         default_attribute_options.merge(@_attributes[attr])
       end
 
+      def _has_attribute?(attr)
+        @_attributes.keys.include?(attr.to_sym)
+      end
+
       def _updatable_relationships
         @_relationships.map { |key, _relationship| key }
       end


### PR DESCRIPTION
Context from gitter:

https://github.com/cerebris/jsonapi-resources/issues/909

![image](https://user-images.githubusercontent.com/3760568/44874172-f067b880-ac5f-11e8-9f2c-7a7d762ab587.png)

![image](https://user-images.githubusercontent.com/3760568/44874190-f9588a00-ac5f-11e8-95ff-129737fbe5d0.png)

### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [x] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions