### PR TITLE
Fix deprecation warning re: sqlite representing boolean as integer.

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -51,6 +51,7 @@ class TestApp < Rails::Application
 
   ActiveRecord::Schema.verbose = false
   config.active_record.schema_format = :none
+  config.active_record.sqlite3.represent_boolean_as_integer = true
   config.active_support.test_order = :random
 
   if Rails::VERSION::MAJOR >= 5

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -51,13 +51,15 @@ class TestApp < Rails::Application
 
   ActiveRecord::Schema.verbose = false
   config.active_record.schema_format = :none
-  config.active_record.sqlite3.represent_boolean_as_integer = true
   config.active_support.test_order = :random
 
   if Rails::VERSION::MAJOR >= 5
     config.active_support.halt_callback_chains_on_return_false = false
     config.active_record.time_zone_aware_types = [:time, :datetime]
     config.active_record.belongs_to_required_by_default = false
+    if Rails::VERSION::MINOR >= 2
+      config.active_record.sqlite3.represent_boolean_as_integer = true
+    end
   end
 end
 


### PR DESCRIPTION
Run tests in the default configuration. Deprecation warning should not show.

fixes #1178