### PR TITLE
Implement Included Resource Filtering

### DIFF
--- a/lib/jsonapi/include_directives.rb
+++ b/lib/jsonapi/include_directives.rb
@@ -40,6 +40,16 @@ module JSONAPI
       delve_paths(get_includes(@include_directives_hash, false))
     end
 
+    def merge_filter(relation, filter)
+      config = include_config(relation.to_sym)
+      config[:include_filters] ||= {}
+      config[:include_filters].merge!(filter)
+    end
+
+    def include_config(relation)
+      @include_directives_hash[:include_related][relation]
+    end
+
     private
 
     def get_related(current_path)

--- a/lib/jsonapi/request_parser.rb
+++ b/lib/jsonapi/request_parser.rb
@@ -257,7 +257,6 @@ module JSONAPI
         if included_resource_name
           relationship = resource_klass._relationship(included_resource_name || '')
 
-
           unless relationship
             return @errors.concat(Exceptions::FilterNotAllowed.new(filter_method).errors)
           end
@@ -266,7 +265,7 @@ module JSONAPI
             return @errors.concat(Exceptions::FilterNotAllowed.new(filter_method).errors)
           end
 
-          unless @include_directives.model_includes.include?(relationship.name.to_sym)
+          unless @include_directives.include_config(relationship.name.to_sym).present?
             return @errors.concat(Exceptions::FilterNotAllowed.new(filter_method).errors)
           end
 

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -741,6 +741,9 @@ module JSONAPI
           next memo unless relationship && relationship.is_a?(JSONAPI::Relationship::ToMany)
           filtering_resource = relationship.resource_klass
 
+          # Don't try to merge where clauses when relation isn't already being joined to query.
+          next memo unless config[:include_in_join]
+
           filters = config[:include_filters]
           next memo unless filters
 

--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -411,7 +411,9 @@ module JSONAPI
           end
         end
       else
-        options = { filters: include_directives.include_directives.dig(:include_related, relationship.name.to_sym, :include_filters) || {} }
+        include_config = include_directives.include_config(relationship.name.to_sym) if include_directives
+        include_filters = include_config[:include_filters] if include_config
+        options = { filters: include_filters || {} }
         source.public_send(relationship.name, options).map do |value|
           [relationship.type, value.id]
         end

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -2577,6 +2577,50 @@ class BooksControllerTest < ActionController::TestCase
   end
 end
 
+class Api::V5::PaintersControllerTest < ActionController::TestCase
+  def test_index_with_included_resources_with_filters
+    # There are two painters, but by filtering the included relationship, the
+    # painters are limited due to the join, thus only the painter with oil
+    # paintings is returned.
+    get :index, params: { include: 'paintings', filter: { 'paintings.category' => 'oil' } }
+    assert_response :success
+    assert_equal 1, json_response['data'].size, 'Size of data is wrong'
+    assert_equal '1', json_response['data'][0]['id']
+    assert_equal 2, json_response['included'].size, 'Size of included data is wrong'
+    assert_equal '4', json_response['included'][0]['id']
+    assert_equal '5', json_response['included'][1]['id']
+  end
+
+  def test_index_with_filters_and_included_resources_with_filters
+    get :index, params: { include: 'paintings', filter: { 'name' => 'Wyspianski', 'paintings.category' => 'oil' } }
+
+    assert_response :success
+    assert_equal 1, json_response['data'].size
+    assert_equal '1', json_response['data'][0]['id']
+    assert_equal 2, json_response['included'].size
+    assert_equal '4', json_response['included'][0]['id']
+  end
+
+  def test_index_with_filters_and_included_resources_with_multiple_filters
+    # Painting 5 is the genuine, but painting 6 is a fake. Verify that multiple nested filters are merged and only the oil painting is returned.
+    get :index, params: { include: 'paintings', filter: { 'name' => 'Wyspianski', 'paintings.category' => 'oil', 'paintings.title' => 'Motherhood' } }
+
+    assert_response :success
+    assert_equal 1, json_response['data'].size
+    assert_equal '1', json_response['data'][0]['id']
+    assert_equal 1, json_response['included'].size
+    assert_equal '5', json_response['included'][0]['id']
+  end
+
+  def test_show_with_filters_and_included_resources_with_filters
+    get :show, params: { id: 1, include: 'paintings', filter: { 'paintings.category' => 'oil' } }
+    assert_response :success
+    assert_equal '1', json_response['data']['id']
+    assert_equal 2, json_response['included'].size
+    assert_equal '4', json_response['included'][0]['id']
+  end
+end
+
 class Api::V5::AuthorsControllerTest < ActionController::TestCase
   def test_get_person_as_author
     assert_cacheable_get :index, params: {filter: {id: '1'}}

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -1055,6 +1055,7 @@ class TagResource < JSONAPI::Resource
   attributes :name
 
   has_many :posts
+  filter :name
   # Not including the planets relationship so they don't get output
   #has_many :planets
 end

--- a/test/fixtures/collectors.yml
+++ b/test/fixtures/collectors.yml
@@ -1,0 +1,9 @@
+collector_1:
+  id: 1
+  name: "Alice"
+  painting_id: 4
+
+collector_2:
+  id: 2
+  name: "Bob"
+  painting_id: 4

--- a/test/fixtures/painters.yml
+++ b/test/fixtures/painters.yml
@@ -1,0 +1,7 @@
+painter_1:
+  id: 1
+  name: "Wyspianski"
+
+painter_2:
+  id: 2
+  name: "Matejko"

--- a/test/fixtures/paintings.yml
+++ b/test/fixtures/paintings.yml
@@ -1,0 +1,35 @@
+painting_1:
+  id: 1
+  title: "Rejtan"
+  category: "historic"
+  painter_id: 2
+
+painting_2:
+  id: 2
+  title: "Stanczyk"
+  category: "fantasy"
+  painter_id: 2
+
+painting_3:
+  id: 3
+  title: "Macierzynstwo"
+  category: "pastel"
+  painter_id: 1
+
+painting_4:
+  id: 4
+  title: "Helenka"
+  category: "oil"
+  painter_id: 1
+
+painting_5:
+  id: 5
+  title: "Motherhood"
+  category: "oil"
+  painter_id: 1
+
+painting_6:
+  id: 6
+  title: "Motherhood"
+  category: "fake"
+  painter_id: 1

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -324,7 +324,7 @@ TestApp.routes.draw do
     namespace :v5 do
       jsonapi_resources :posts do
       end
-
+      jsonapi_resources :painters
       jsonapi_resources :authors
       jsonapi_resources :expense_entries
       jsonapi_resources :iso_currencies

--- a/test/unit/serializer/serializer_test.rb
+++ b/test/unit/serializer/serializer_test.rb
@@ -251,6 +251,46 @@ class SerializerTest < ActionDispatch::IntegrationTest
     )
   end
 
+  def test_serializer_filtered_include
+    painter = Painter.find(1)
+    include_directives = JSONAPI::IncludeDirectives.new(Api::V5::PainterResource, ['paintings'])
+    include_directives.merge_filter('paintings', category: ['oil'])
+    serialized = JSONAPI::ResourceSerializer.new(
+      Api::V5::PainterResource,
+      include_directives: include_directives,
+      fields: {painters: [:id], paintings: [:id]}
+    ).serialize_to_hash(Api::V5::PainterResource.new(painter, nil))
+
+    assert_hash_equals(
+      {
+        data: {
+          type: 'painters',
+          id: '1',
+          links: {
+            self: '/api/v5/painters/1'
+          },
+        },
+        included: [
+          {
+            type: 'paintings',
+            id: '4',
+            links: {
+              self: '/api/v5/paintings/4'
+            }
+          },
+          {
+            type: 'paintings',
+            id: '5',
+            links: {
+              self: '/api/v5/paintings/5'
+            }
+          }
+        ]
+      },
+      serialized
+    )
+  end
+
   def test_serializer_key_format
     serialized = JSONAPI::ResourceSerializer.new(
       PostResource,


### PR DESCRIPTION
Inspirational Credit and original code: @beniutek

Closes #890
Closes #844
Closes #896
Closes #314 

After much thrashing and some time out in the wilderness with our forked version, I came back here to finish the job, also noticing some bizarre behavior stemming from the original implementation.

Bizarreness:
The loop in the serializer which goes through included resources and adds them to the included resources cache is taking advantage of active record association cacheing such that if any modification of the scope happened during the loading of the primary resource `data`, then the included resources would also follow suit. However, this is broken if certain things are done to the association scope in the `records_for(relation)` public method, which may be overridden in the resource. When such happens, the touched-scope in the cache is lost and the records are retrieved anew. Under those conditions, the blasé attitude of the serializer towards the RequestParser's findings re: filtering results in the queries being re-run without filter, thus you may get more included records than you bargained for if you've tripped over the ActiveRecord Association cache.