### PR TITLE
write model into cache, fix Rails 5.2 deprecations (#1177)

### DIFF
--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -622,8 +622,8 @@ class Thing < ActiveRecord::Base
 end
 
 class RelatedThing < ActiveRecord::Base
-  belongs_to :from, class_name: Thing, foreign_key: :from_id
-  belongs_to :to, class_name: Thing, foreign_key: :to_id
+  belongs_to :from, class_name: 'Thing', foreign_key: :from_id
+  belongs_to :to, class_name: 'Thing', foreign_key: :to_id
 end
 
 class Question < ActiveRecord::Base

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -57,6 +57,9 @@ class TestApp < Rails::Application
     config.active_support.halt_callback_chains_on_return_false = false
     config.active_record.time_zone_aware_types = [:time, :datetime]
     config.active_record.belongs_to_required_by_default = false
+    if Rails::VERSION::MINOR >= 2
+      config.active_record.sqlite3.represent_boolean_as_integer = true
+    end
   end
 end
 


### PR DESCRIPTION
more: https://github.com/cerebris/jsonapi-resources/issues/1177