### PR TITLE
Fix inconsistent type of filters

### DIFF
--- a/lib/jsonapi/processor.rb
+++ b/lib/jsonapi/processor.rb
@@ -197,7 +197,7 @@ module JSONAPI
           (paginator && paginator.class.requires_record_count) ||
           (JSONAPI.configuration.top_level_meta_include_page_count))
         related_resource_records = source_resource.public_send("records_for_" + relationship_type)
-        records = resource_klass.filter_records(filters, {},
+        records = resource_klass.filter_records(verified_filters, {},
                                                 related_resource_records)
 
         record_count = resource_klass.count_records(records)

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -2674,6 +2674,26 @@ class Api::V5::AuthorsControllerTest < ActionController::TestCase
   end
 end
 
+class Api::V2::BooksControllerTest < ActionController::TestCase
+  def test_get_related_resources_with_filters
+    $test_user = Person.find(5)
+    original_config = JSONAPI.configuration.dup
+    JSONAPI.configuration.top_level_meta_include_record_count = true
+    JSONAPI.configuration.json_key_format = :dasherized_key
+    assert_cacheable_get :get_related_resources,
+                         params: {
+                           author_id: '1',
+                           relationship: 'books',
+                           source: 'api/v2/authors',
+                           filter: { fiction: 'true' }
+                         }
+    assert_response :success
+    assert_equal 1, json_response['meta']['record-count']
+  ensure
+    JSONAPI.configuration = original_config
+  end
+end
+
 class BreedsControllerTest < ActionController::TestCase
   # Note: Breed names go through the TitleValueFormatter
 

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -141,6 +141,7 @@ ActiveRecord::Schema.define do
     t.string :title
     t.string :isbn
     t.boolean :banned, default: false
+    t.boolean :fiction, default: false
     t.timestamps null: false
   end
 
@@ -1460,10 +1461,11 @@ module Api
     class PreferencesResource < PreferencesResource; end
     class PersonResource < PersonResource; end
     class PostResource < PostResource; end
+    class AuthorResource < AuthorResource; end
 
     class BookResource < JSONAPI::Resource
       attribute "title"
-      attributes :isbn, :banned
+      attributes :isbn, :banned, :fiction
 
       paginator :offset
 
@@ -1484,6 +1486,7 @@ module Api
 
       filters :book_comments
       filter :banned, apply: :apply_filter_banned
+      filter :fiction, apply: :apply_filter_fiction
 
       class << self
         def books
@@ -1516,6 +1519,9 @@ module Api
           end
         end
 
+        def apply_filter_fiction(records, value, _options)
+          records.where('books.fiction = ?', value[0] == 'true')
+        end
       end
     end
 

--- a/test/fixtures/book_authors.yml
+++ b/test/fixtures/book_authors.yml
@@ -9,3 +9,7 @@ book_author_2_1:
 book_author_2_2:
   book_id: 2
   person_id: 2
+
+book_author_601_1:
+  book_id: 601
+  person_id: 1

--- a/test/fixtures/books.yml
+++ b/test/fixtures/books.yml
@@ -4,4 +4,5 @@ book_<%= book_num %>:
   title: Book <%= book_num %>
   isbn: 12345-<%= book_num %>-6789
   banned: <%= book_num > 600 && book_num < 700 %>
+  fiction: <%= book_num > 600 && book_num < 700 %>
 <% end %>

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -289,6 +289,7 @@ TestApp.routes.draw do
 
       jsonapi_resource :preferences, except: [:create, :destroy]
 
+      jsonapi_resources :authors
       jsonapi_resources :books
       jsonapi_resources :book_comments
     end


### PR DESCRIPTION
Another issue we run into is where the type of the `value` passed to a custom filter proc/method is sometimes just the bare value, not an array-wrapped value. This is because the framework does not pass verified_filters to filter records even though it was already calculated previously in `show_related_resources`.

I would have just manifested this bug by using the existing `banned` filter on the books related to the author, but cannot because of the second (bug?) that `rel_opts` is not passed to `filter_records`, so the `current_user.book_admin` is not available. The manifestation there is that due to a poorly-written filter, `records` is nullified and `.sort` is called on nil. Therefore I replicated the `banned` filter, but less the admin check.

The manifest bug is that the `meta: { record_count: 2 }` where it should be 1. It's not consistent with the length of the `data` collection. With the fix, the bug does not happen anymore. In our platform we have a much more serious crash where a bad type is sanitized and used in a query param. 