### PR TITLE
Update ruby and rails versions for travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,15 @@
 language: ruby
 sudo: false
 env:
-  - "RAILS_VERSION=4.2.8"
-  - "RAILS_VERSION=5.0.2"
-  - "RAILS_VERSION=5.1.0"
+  - "RAILS_VERSION=4.2.10"
+  - "RAILS_VERSION=5.0.7"
+  - "RAILS_VERSION=5.1.6"
+  - "RAILS_VERSION=5.2.1"
   - "RAILS_VERSION=master"
 rvm:
-  - 2.1.10
-  - 2.2.7
-  - 2.3.4
-  - 2.4.1
+  - 2.3.7
+  - 2.4.4
+  - 2.5.1
 matrix:
-  exclude:
-    - rvm: 2.1.10
-      env: "RAILS_VERSION=5.0.2"
-    - rvm: 2.1.10
-      env: "RAILS_VERSION=5.1.0"
-    - rvm: 2.1.10
-      env: "RAILS_VERSION=master"
   allow_failures:
     - env: "RAILS_VERSION=master"


### PR DESCRIPTION
Update travis to use latest ruby and rails versions. Removes deprecated ruby versions.

Fixes #1184

### All Submissions:

- [ ] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions