### PR TITLE
Introduce `Resource.retrieve_records`

### DIFF
--- a/lib/jsonapi/processor.rb
+++ b/lib/jsonapi/processor.rb
@@ -578,14 +578,10 @@ module JSONAPI
 
         # fill in the missed resources, it there are any
         unless missed_ids.empty?
-          filters = {resource_klass._primary_key => missed_ids}
-          find_opts = {
-              context: context,
-              fields: find_options[:fields] }
+          missed_records = resource_klass.retrieve_records(missed_ids, find_options)
+          missed_resources = resource_klass.resources_for(missed_records, context)
 
-          found_resources = resource_klass.find(filters, find_opts)
-
-          found_resources.each do |resource|
+          missed_resources.each do |resource|
             relationship_data = resource_set[resource_klass][resource.id][:relationships]
 
             if resource_klass.caching?

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -732,6 +732,10 @@ module JSONAPI
         _model_class.all
       end
 
+      def retrieve_records(ids, options = {})
+        _model_class.where(_primary_key => ids)
+      end
+
       def resources_for(records, context)
         records.collect do |record|
           resource_for(record, context)

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -1450,6 +1450,10 @@ module BreedResourceFinder
       end
       breeds
     end
+
+    def retrieve_records(ids, options = {})
+      find_records_by_keys(ids, options)
+    end
   end
 end
 


### PR DESCRIPTION
Allows the processor to retrieve records without further filtering,
which will have taken place earlier in the `find_fragments` and
`find_related_fragments`. This fixes issues where `records` has been
overridden and interferes with getting included
records (and already filtered by the find fragment step).



### All Submissions:

- [ ] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions