### PR TITLE
Wrap pluck fields with Arel.sql

### DIFF
--- a/lib/jsonapi/active_relation_resource_finder.rb
+++ b/lib/jsonapi/active_relation_resource_finder.rb
@@ -64,11 +64,11 @@ module JSONAPI
         records = find_records(filters, options)
 
         table_name = _model_class.table_name
-        pluck_fields = ["#{concat_table_field(table_name, _primary_key)} AS #{table_name}_#{_primary_key}"]
+        pluck_fields = [Arel.sql("#{concat_table_field(table_name, _primary_key)} AS #{table_name}_#{_primary_key}")]
 
         cache_field = attribute_to_model_field(:_cache_field) if options[:cache]
         if cache_field
-          pluck_fields << "#{concat_table_field(table_name, cache_field[:name])} AS #{table_name}_#{cache_field[:name]}"
+          pluck_fields << Arel.sql("#{concat_table_field(table_name, cache_field[:name])} AS #{table_name}_#{cache_field[:name]}")
         end
 
         model_fields = {}
@@ -76,7 +76,7 @@ module JSONAPI
         attributes.try(:each) do |attribute|
           model_field = attribute_to_model_field(attribute)
           model_fields[attribute] = model_field
-          pluck_fields << "#{concat_table_field(table_name, model_field[:name])} AS #{table_name}_#{model_field[:name]}"
+          pluck_fields << Arel.sql("#{concat_table_field(table_name, model_field[:name])} AS #{table_name}_#{model_field[:name]}")
         end
 
         fragments = {}
@@ -204,13 +204,13 @@ module JSONAPI
         records = related_klass.apply_filters(records, filters, filter_options)
 
         pluck_fields = [
-            "#{primary_key_field} AS #{_table_name}_#{_primary_key}",
-            "#{concat_table_field(table_alias, related_klass._primary_key)} AS #{table_alias}_#{related_klass._primary_key}"
+            Arel.sql("#{primary_key_field} AS #{_table_name}_#{_primary_key}"),
+            Arel.sql("#{concat_table_field(table_alias, related_klass._primary_key)} AS #{table_alias}_#{related_klass._primary_key}")
         ]
 
         cache_field = related_klass.attribute_to_model_field(:_cache_field) if options[:cache]
         if cache_field
-          pluck_fields << "#{concat_table_field(table_alias, cache_field[:name])} AS #{table_alias}_#{cache_field[:name]}"
+          pluck_fields << Arel.sql("#{concat_table_field(table_alias, cache_field[:name])} AS #{table_alias}_#{cache_field[:name]}")
         end
 
         model_fields = {}
@@ -218,7 +218,7 @@ module JSONAPI
         attributes.try(:each) do |attribute|
           model_field = related_klass.attribute_to_model_field(attribute)
           model_fields[attribute] = model_field
-          pluck_fields << "#{concat_table_field(table_alias, model_field[:name])} AS #{table_alias}_#{model_field[:name]}"
+          pluck_fields << Arel.sql("#{concat_table_field(table_alias, model_field[:name])} AS #{table_alias}_#{model_field[:name]}")
         end
 
         rows = records.pluck(*pluck_fields)
@@ -265,9 +265,9 @@ module JSONAPI
         related_type = concat_table_field(_table_name, relationship.polymorphic_type)
 
         pluck_fields = [
-          "#{primary_key} AS #{_table_name}_#{_primary_key}",
-          "#{related_key} AS #{_table_name}_#{relationship.foreign_key}",
-          "#{related_type} AS #{_table_name}_#{relationship.polymorphic_type}"
+            Arel.sql("#{primary_key} AS #{_table_name}_#{_primary_key}"),
+            Arel.sql("#{related_key} AS #{_table_name}_#{relationship.foreign_key}"),
+            Arel.sql("#{related_type} AS #{_table_name}_#{relationship.polymorphic_type}")
         ]
 
         relations = relationship.polymorphic_relations


### PR DESCRIPTION
Needed to avoid "DEPRECATION WARNING: Dangerous query method..."
See https://github.com/rails/rails/issues/32995



### All Submissions:

- [ ] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions