### PR TITLE
Default to more restrictive backtrace configuration

### DIFF
--- a/lib/jsonapi/configuration.rb
+++ b/lib/jsonapi/configuration.rb
@@ -80,12 +80,12 @@ module JSONAPI
       self.use_text_errors = false
 
       # Whether or not to include exception backtraces in JSONAPI error
-      # responses.  Defaults to `false` in production, and `true` otherwise.
-      self.include_backtraces_in_errors = !Rails.env.production?
+      # responses.  Defaults to `false` in anything other than development or test.
+      self.include_backtraces_in_errors = (Rails.env.development? || Rails.env.test?)
 
       # Whether or not to include exception application backtraces in JSONAPI error
-      # responses.  Defaults to `false` in production, and `true` otherwise.
-      self.include_application_backtraces_in_errors = !Rails.env.production?
+      # responses.  Defaults to `false` in anything other than development or test.
+      self.include_application_backtraces_in_errors = (Rails.env.development? || Rails.env.test?)
 
       # List of classes that should not be rescued by the operations processor.
       # For example, if you use Pundit for authorization, you might


### PR DESCRIPTION
Needed to avoid exposing stack traces in non-production but non-development environments (e.g. "staging")

Fixes #1203

### All Submissions:

- [X] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [x] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [x] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [x] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [x] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [x] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions