### PR TITLE
fix regression in 0.9.5 server error when using filter with dot in name and custom applier

### DIFF
--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -2637,6 +2637,22 @@ class Api::V5::PaintersControllerTest < ActionController::TestCase
   end
 end
 
+class Api::V5::CollectorsControllerTest < ActionController::TestCase
+  def test_index_with_custom_filter_that_has_dot
+    get :index, params: {
+        filter: {
+            'name' => 'Alice',
+            'painting.title_equals': 'Helenka'
+        }
+    }
+
+    assert_response :success
+    assert_equal 1, json_response['data'].size
+    assert_equal '1', json_response['data'][0]['id']
+    refute json_response.key?('included')
+  end
+end
+
 class Api::V5::AuthorsControllerTest < ActionController::TestCase
   def test_get_person_as_author
     assert_cacheable_get :index, params: {filter: {id: '1'}}

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -899,6 +899,9 @@ module Api
 
     class PaintersController < JSONAPI::ResourceController
     end
+
+    class CollectorsController < JSONAPI::ResourceController
+    end
   end
 
   module V6
@@ -1667,6 +1670,11 @@ module Api
     class CollectorResource < JSONAPI::Resource
       attributes :name
       has_one :painting
+
+      filter :name
+      filter :'painting.title_equals', apply: -> (records, values, _opts) do
+        records.joins(:painting).where(paintings: { title: values })
+      end
     end
 
     class PainterResource < JSONAPI::Resource

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -329,6 +329,7 @@ TestApp.routes.draw do
       jsonapi_resources :posts do
       end
       jsonapi_resources :painters
+      jsonapi_resources :collectors
       jsonapi_resources :authors
       jsonapi_resources :expense_entries
       jsonapi_resources :iso_currencies


### PR DESCRIPTION
fixes #1214

### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [x] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions