### PR TITLE
Improve caching performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ coverage
 test/log
 test_db
 test_db-journal
+.idea
+*.iml

--- a/lib/jsonapi/resource_set.rb
+++ b/lib/jsonapi/resource_set.rb
@@ -5,14 +5,25 @@ module JSONAPI
 
     attr_reader :resource_klasses, :populated
 
-    def initialize(resource_id_tree)
+    def initialize(resource_id_tree = nil)
       @populated = false
-      @resource_klasses = flatten_resource_id_tree(resource_id_tree)
+      @resource_klasses = resource_id_tree.nil? ? {} : flatten_resource_id_tree(resource_id_tree)
     end
 
     def populate!(serializer, context, find_options)
+      # For each resource klass we want to generate the caching key
+
+      # Hash for collecting types and ids
+      # @type [Hash<Class<Resource>, Id[]]]
+      missed_resource_ids = {}
+
+      # Array for collecting CachedResponseFragment::Lookups
+      # @type [Lookup[]]
+      lookups = []
+
+
+      # Step One collect all of the lookups for the cache, or keys that don't require cache access
       @resource_klasses.each_key do |resource_klass|
-        missed_ids = []
 
         serializer_config_key = serializer.config_key(resource_klass).gsub("/", "_")
         context_json = resource_klass.attribute_caching_context(context).to_json
@@ -20,65 +31,124 @@ module JSONAPI
         context_key = "ATTR-CTX-#{context_b64.gsub("/", "_")}"
 
         if resource_klass.caching?
-          cache_ids = []
-
-          @resource_klasses[resource_klass].each_pair do |k, v|
+          cache_ids = @resource_klasses[resource_klass].map do |(k, v)|
             # Store the hashcode of the cache_field to avoid storing objects and to ensure precision isn't lost
             # on timestamp types (i.e. string conversions dropping milliseconds)
-            cache_ids.push([k, resource_klass.hash_cache_field(v[:cache_id])])
+            [k, resource_klass.hash_cache_field(v[:cache_id])]
           end
 
-          found_resources = CachedResponseFragment.fetch_cached_fragments(
+          lookups.push(
+            CachedResponseFragment::Lookup.new(
               resource_klass,
               serializer_config_key,
-              cache_ids,
-              context)
-
-          found_resources.each do |found_result|
-            resource = found_result[1]
-            if resource.nil?
-              missed_ids.push(found_result[0])
-            else
-              @resource_klasses[resource_klass][resource.id][:resource] = resource
-            end
-          end
+              context,
+              context_key,
+              cache_ids
+            )
+          )
         else
-          missed_ids = @resource_klasses[resource_klass].keys
+          missed_resource_ids[resource_klass] ||= {}
+          missed_resource_ids[resource_klass] = @resource_klasses[resource_klass].keys
         end
+      end
 
-        # fill in any missed resources
-        unless missed_ids.empty?
-          find_opts = {
-              context: context,
-              fields: find_options[:fields] }
+      if lookups.any?
+        raise "You've declared some Resources as caching without providing a caching store" if JSONAPI.configuration.resource_cache.nil?
 
-          found_resources = resource_klass.find_by_keys(missed_ids, find_opts)
+        # Step Two execute the cache lookup
+        found_resources = CachedResponseFragment.lookup(lookups, context)
+      else
+        found_resources = {}
+      end
 
-          found_resources.each do |resource|
-            relationship_data = @resource_klasses[resource_klass][resource.id][:relationships]
 
-            if resource_klass.caching?
-              (id, cr) = CachedResponseFragment.write(
-                  resource_klass,
-                  resource,
-                  serializer,
-                  serializer_config_key,
-                  context,
-                  context_key,
-                  relationship_data)
+      # Step Three collect the results and collect hit/miss stats
+      stats = {}
+      found_resources.each do |resource_klass, resources|
+        resources.each do |id, cached_resource|
+          stats[resource_klass] ||= {}
 
-              @resource_klasses[resource_klass][id][:resource] = cr
-            else
-              @resource_klasses[resource_klass][resource.id][:resource] = resource
-            end
+          if cached_resource.nil?
+            stats[resource_klass][:misses] ||= 0
+            stats[resource_klass][:misses] += 1
+
+            # Collect misses
+            missed_resource_ids[resource_klass] ||= []
+            missed_resource_ids[resource_klass].push(id)
+          else
+            stats[resource_klass][:hits] ||= 0
+            stats[resource_klass][:hits] += 1
+
+            register_resource(resource_klass, cached_resource)
           end
         end
       end
-      @populated = true
+
+      report_stats(stats)
+
+      writes = []
+
+      # Step Four find any of the missing resources and join them into the result
+      missed_resource_ids.each_pair do |resource_klass, ids|
+        find_opts = {context: context, fields: find_options[:fields]}
+        found_resources = resource_klass.find_by_keys(ids, find_opts)
+
+        found_resources.each do |resource|
+          relationship_data = @resource_klasses[resource_klass][resource.id][:relationships]
+
+          if resource_klass.caching?
+
+            serializer_config_key = serializer.config_key(resource_klass).gsub("/", "_")
+            context_json = resource_klass.attribute_caching_context(context).to_json
+            context_b64 = JSONAPI.configuration.resource_cache_digest_function.call(context_json)
+            context_key = "ATTR-CTX-#{context_b64.gsub("/", "_")}"
+
+            writes.push(CachedResponseFragment::Write.new(
+              resource_klass,
+              resource,
+              serializer,
+              serializer_config_key,
+              context,
+              context_key,
+              relationship_data
+            ))
+          end
+
+          register_resource(resource_klass, resource)
+        end
+      end
+
+      # Step Five conditionally write to the cache
+      CachedResponseFragment.write(writes) unless JSONAPI.configuration.resource_cache.nil?
+
+      mark_populated!
       self
     end
 
+    def mark_populated!
+      @populated = true
+    end
+
+    def register_resource(resource_klass, resource, primary = false)
+      @resource_klasses[resource_klass] ||= {}
+      @resource_klasses[resource_klass][resource.id] ||= {primary: resource.try(:primary) || primary, relationships: {}}
+      @resource_klasses[resource_klass][resource.id][:resource] = resource
+    end
+
     private
+
+    def report_stats(stats)
+      return unless JSONAPI.configuration.resource_cache_usage_report_function || JSONAPI.configuration.resource_cache.nil?
+
+      stats.each_pair do |resource_klass, stat|
+        JSONAPI.configuration.resource_cache_usage_report_function.call(
+          resource_klass.name,
+          stat[:hits] || 0,
+          stat[:misses] || 0
+        )
+      end
+    end
+
     def flatten_resource_id_tree(resource_id_tree, flattened_tree = {})
       resource_id_tree.fragments.each_pair do |resource_rid, fragment|
 
@@ -87,7 +157,7 @@ module JSONAPI
 
         flattened_tree[resource_klass] ||= {}
 
-        flattened_tree[resource_klass][id] ||= { primary: fragment.primary, relationships: {} }
+        flattened_tree[resource_klass][id] ||= {primary: fragment.primary, relationships: {}}
         flattened_tree[resource_klass][id][:cache_id] ||= fragment.cache
 
         fragment.related.try(:each_pair) do |relationship_name, related_rids|


### PR DESCRIPTION
This commit improves the performance of the fragment cache by batching
all reads and writes to single caching operations.

### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [x] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### Bug fixes and Changes to Core Features:

- [x] I've included an explanation of what the changes do and why I'd like you to include them.
- [x] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions