### PR TITLE
Check upgrade

### DIFF
--- a/lib/jsonapi-resources.rb
+++ b/lib/jsonapi-resources.rb
@@ -1,3 +1,4 @@
+require 'jsonapi/resources/railtie'
 require 'jsonapi/naive_cache'
 require 'jsonapi/compiled_json'
 require 'jsonapi/resource'

--- a/lib/jsonapi/active_relation_resource_finder.rb
+++ b/lib/jsonapi/active_relation_resource_finder.rb
@@ -25,9 +25,8 @@ module JSONAPI
 
         paginator = options[:paginator]
 
-        records = find_records(records: records(options),
-                               sort_criteria: sort_criteria,
-                               filters: filters,
+        records = apply_request_settings_to_records(records: records(options),
+                               sort_criteria: sort_criteria,filters: filters,
                                join_manager: join_manager,
                                paginator: paginator,
                                options: options)
@@ -45,7 +44,7 @@ module JSONAPI
         join_manager = JoinManager.new(resource_klass: self,
                                     filters: filters)
 
-        records = find_records(records: records(options),
+        records = apply_request_settings_to_records(records: records(options),
                                filters: filters,
                                join_manager: join_manager,
                                options: options)
@@ -100,7 +99,7 @@ module JSONAPI
 
         paginator = options[:paginator]
 
-        records = find_records(records: records(options),
+        records = apply_request_settings_to_records(records: records(options),
                                filters: filters,
                                sort_criteria: sort_criteria,
                                paginator: paginator,
@@ -229,7 +228,7 @@ module JSONAPI
                                     source_relationship: relationship,
                                     filters: filters)
 
-        records = find_records(records: records(options),
+        records = apply_request_settings_to_records(records: records(options),
                                resource_klass: related_klass,
                                primary_keys: source_rid.id,
                                join_manager: join_manager,
@@ -306,13 +305,13 @@ module JSONAPI
       end
 
       def find_record_by_key(key, options = {})
-        record = find_records(records: records(options), primary_keys: key, options: options).first
+        record = apply_request_settings_to_records(records: records(options), primary_keys: key, options: options).first
         fail JSONAPI::Exceptions::RecordNotFound.new(key) if record.nil?
         record
       end
 
       def find_records_by_keys(keys, options = {})
-        find_records(records: records(options), primary_keys: keys, options: options)
+        apply_request_settings_to_records(records: records(options), primary_keys: keys, options: options)
       end
 
       def find_related_monomorphic_fragments(source_rids, relationship, options, connect_source_identity)
@@ -337,7 +336,7 @@ module JSONAPI
 
         paginator = options[:paginator] if source_rids.count == 1
 
-        records = find_records(records: records(options),
+        records = apply_request_settings_to_records(records: records(options),
                                resource_klass: resource_klass,
                                sort_criteria: sort_criteria,
                                primary_keys: source_ids,
@@ -464,7 +463,7 @@ module JSONAPI
 
         # Note: We will sort by the source table. Without using unions we can't sort on a polymorphic relationship
         # in any manner that makes sense
-        records = find_records(records: records(options),
+        records = apply_request_settings_to_records(records: records(options),
                                resource_klass: resource_klass,
                                sort_primary: true,
                                primary_keys: source_ids,
@@ -615,7 +614,7 @@ module JSONAPI
         related_fragments
       end
 
-      def find_records(records:,
+      def apply_request_settings_to_records(records:,
                        join_manager: JoinManager.new(resource_klass: self),
                        resource_klass: self,
                        filters: {},

--- a/lib/jsonapi/resources/railtie.rb
+++ b/lib/jsonapi/resources/railtie.rb
@@ -1,0 +1,9 @@
+module JSONAPI
+  module Resources
+    class Railtie < Rails::Railtie
+      rake_tasks do
+        load 'tasks/check_upgrade.rake'
+      end
+    end
+  end
+end

--- a/lib/tasks/check_upgrade.rake
+++ b/lib/tasks/check_upgrade.rake
@@ -1,0 +1,52 @@
+require 'rake'
+require 'jsonapi-resources'
+
+namespace :jsonapi do
+  namespace :resources do
+    desc 'Checks application for orphaned overrides'
+    task :check_upgrade => :environment do
+      Rails.application.eager_load!
+
+      resource_klasses = ObjectSpace.each_object(Class).select { |klass| klass < JSONAPI::Resource}
+
+      puts "Checking #{resource_klasses.count} resources"
+
+      issues_found = 0
+
+      klasses_with_deprecated = resource_klasses.select { |klass| klass.methods.include?(:find_records) }
+      unless klasses_with_deprecated.empty?
+        puts "  Found the following resources the still implement `find_records`:"
+        klasses_with_deprecated.each { |klass| puts "    #{klass}"}
+        puts "  The `find_records` method is no longer called by JR. Please review and ensure your functionality is ported over."
+
+        issues_found = issues_found + klasses_with_deprecated.length
+      end
+
+      klasses_with_deprecated = resource_klasses.select { |klass| klass.methods.include?(:records_for) }
+      unless klasses_with_deprecated.empty?
+        puts "  Found the following resources the still implement `records_for`:"
+        klasses_with_deprecated.each { |klass| puts "    #{klass}"}
+        puts "  The `records_for` method is no longer called by JR. Please review and ensure your functionality is ported over."
+
+        issues_found = issues_found + klasses_with_deprecated.length
+      end
+
+      klasses_with_deprecated = resource_klasses.select { |klass| klass.methods.include?(:apply_includes) }
+      unless klasses_with_deprecated.empty?
+        puts "  Found the following resources the still implement `apply_includes`:"
+        klasses_with_deprecated.each { |klass| puts "    #{klass}"}
+        puts "  The `apply_includes` method is no longer called by JR. Please review and ensure your functionality is ported over."
+
+        issues_found = issues_found + klasses_with_deprecated.length
+      end
+
+      if issues_found > 0
+        puts "Finished inspection. #{issues_found} issues found that may impact upgrading. Please address these issues. "
+      else
+        puts "Finished inspection with no issues found. Note this is only a cursory check for method overrides that will no \n" \
+             "longer be called by JSONAPI::Resources. This check in no way assures your code will continue to function as \n" \
+             "it did before the upgrade. Please do adequate testing before using in production."
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a rake task, `jsonapi:resources:check_upgrade` that inspects resources for orphaned method overrides.

Currently the check looks for `find_records`, `records_for`, and `apply_includes`. Others may be added if they are found to be needed.

Use of this will be added to the upgrade guide.

### All Submissions:

- [ ] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions