### PR TITLE
Add ruby 2.6.1 testing and temporarily disable rails 6/master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,17 @@ env:
   - "RAILS_VERSION=5.0.7.1"
   - "RAILS_VERSION=5.1.6.1"
   - "RAILS_VERSION=5.2.2"
-  - "RAILS_VERSION=master"
+#  - "RAILS_VERSION=6.0.0.beta1"
+#  - "RAILS_VERSION=master"
 rvm:
   - 2.3.8
   - 2.4.5
   - 2.5.3
+  - 2.6.1
 matrix:
   allow_failures:
     - env: "RAILS_VERSION=master"
+    - env: "RAILS_VERSION=6.0.0.beta1"
+  exclude:
+    - rvm: 2.6.1
+      env: "RAILS_VERSION=4.2.11"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,6 +7,7 @@ require 'simplecov'
 # export RAILS_VERSION=4.2.6; bundle update rails; bundle exec rake test
 # export RAILS_VERSION=5.0.0; bundle update rails; bundle exec rake test
 # export RAILS_VERSION=5.1.0; bundle update rails; bundle exec rake test
+# export RAILS_VERSION=6.0.0.beta1; bundle update rails; bundle exec rake test
 
 # We are no longer having Travis test Rails 4.1.x., but you can try it with:
 # export RAILS_VERSION=4.1.0; bundle update rails; bundle exec rake test


### PR DESCRIPTION
This adds ruby 2.6.1 to the travis tests.

It also comments out the master and rails 6 tests, since they will fail until some changes are made to the code. There's no sense making the travis build take longer when rails 6 will surely fail. The PR to bring things into compliance with rails 6 will need to enable them again.

### All Submissions:

- [ ] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions