### PR TITLE
Remove unnecessary `distinct` from query in `Resource::find_fragments`

### DIFF
--- a/lib/jsonapi/active_relation_resource_finder.rb
+++ b/lib/jsonapi/active_relation_resource_finder.rb
@@ -149,7 +149,7 @@ module JSONAPI
         end
 
         fragments = {}
-        rows = records.distinct.pluck(*pluck_fields)
+        rows = records.pluck(*pluck_fields)
         rows.collect do |row|
           rid = JSONAPI::ResourceIdentity.new(resource_klass, pluck_fields.length == 1 ? row : row[0])
 


### PR DESCRIPTION
`SELECT` queries ordering by fields not being selected cannot be distinct in most newer versions of databases. This can potentially cause a database error such as one like this for MySQL:
```
Expression #1 of ORDER BY clause is not in SELECT list, references column 'some_database.users.name' which is not in SELECT list; this is incompatible with DISTINCT
```

### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [x] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions