### PR TITLE
Remove unused `:include` IncludeDirectives key

### DIFF
--- a/lib/jsonapi/include_directives.rb
+++ b/lib/jsonapi/include_directives.rb
@@ -4,14 +4,12 @@ module JSONAPI
     # For example ['posts.comments.tags']
     # will transform into =>
     # {
-    #   posts:{
-    #     include:true,
-    #     include_related:{
+    #   posts: {
+    #     include_related: {
     #       comments:{
-    #         include:true,
-    #         include_related:{
-    #           tags:{
-    #             include:true
+    #         include_related: {
+    #           tags: {
+    #             include_related: {}
     #           }
     #         }
     #       }
@@ -44,7 +42,7 @@ module JSONAPI
       path.segments.each do |segment|
         relationship_name = segment.relationship.name.to_sym
 
-        current[:include_related][relationship_name] ||= { include: true, include_related: {} }
+        current[:include_related][relationship_name] ||= { include_related: {} }
         current = current[:include_related][relationship_name]
       end
 

--- a/lib/jsonapi/processor.rb
+++ b/lib/jsonapi/processor.rb
@@ -429,8 +429,7 @@ module JSONAPI
     def load_included(resource_klass, source_resource_id_tree, include_related, options)
       source_rids = source_resource_id_tree.fragments.keys
 
-      include_related.try(:each_pair) do |key, value|
-        next unless value[:include]
+      include_related.try(:each_key) do |key|
         relationship = resource_klass._relationship(key)
         relationship_name = relationship.name.to_sym
 

--- a/test/unit/serializer/include_directives_test.rb
+++ b/test/unit/serializer/include_directives_test.rb
@@ -10,8 +10,7 @@ class IncludeDirectivesTest < ActiveSupport::TestCase
       {
         include_related: {
           posts: {
-            include: true,
-            include_related:{}
+            include_related: {}
           }
         }
       },
@@ -25,21 +24,43 @@ class IncludeDirectivesTest < ActiveSupport::TestCase
       {
         include_related: {
           posts: {
-            include: true,
-            include_related:{}
+            include_related: {}
           },
           comments: {
-            include: true,
-            include_related:{}
+            include_related: {}
           },
           expense_entries: {
-            include: true,
-            include_related:{}
+            include_related: {}
           }
         }
       },
       directives)
   end
+
+  def test_multiple_level_multiple_includes
+    directives = JSONAPI::IncludeDirectives.new(PersonResource, ['posts', 'posts.comments', 'comments', 'expense_entries']).include_directives
+
+    assert_hash_equals(
+      {
+        include_related: {
+          posts: {
+            include_related: {
+              comments: {
+                include_related: {}
+              }
+            }
+          },
+          comments: {
+            include_related: {}
+          },
+          expense_entries: {
+            include_related: {}
+          }
+        }
+      },
+      directives)
+  end
+
 
   def test_two_levels_include_full_path
     directives = JSONAPI::IncludeDirectives.new(PersonResource, ['posts.comments']).include_directives
@@ -48,11 +69,9 @@ class IncludeDirectivesTest < ActiveSupport::TestCase
       {
         include_related: {
           posts: {
-            include: true,
-            include_related:{
+            include_related: {
               comments: {
-                include: true,
-                include_related:{}
+                include_related: {}
               }
             }
           }
@@ -62,17 +81,15 @@ class IncludeDirectivesTest < ActiveSupport::TestCase
   end
 
   def test_two_levels_include_full_path_redundant
-    directives = JSONAPI::IncludeDirectives.new(PersonResource, ['posts','posts.comments']).include_directives
+    directives = JSONAPI::IncludeDirectives.new(PersonResource, ['posts', 'posts.comments']).include_directives
 
     assert_hash_equals(
       {
         include_related: {
           posts: {
-            include: true,
-            include_related:{
+            include_related: {
               comments: {
-                include: true,
-                include_related:{}
+                include_related: {}
               }
             }
           }
@@ -88,14 +105,11 @@ class IncludeDirectivesTest < ActiveSupport::TestCase
       {
         include_related: {
           posts: {
-            include: true,
-            include_related:{
+            include_related: {
               comments: {
-                include: true,
-                include_related:{
+                include_related: {
                   tags: {
-                    include: true,
-                    include_related:{}
+                    include_related: {}
                   }
                 }
               }


### PR DESCRIPTION
The `:include` option for IncludeDirectives is no longer being used. 

This was originally used for allowing included relationships that skipped intermediate relationships, as well as for not including resources when intermediate relationships were needed for join tracking. Both these uses are no longer handled by IncludeDirectives.

The IncludeDirectives could be further simplified by removing the `:include_related` intermediate hash now that `:include` is being removed. However this does remove the option of adding additional directions per include level (which is how it was being used in earlier versions). For now I think we should leave that option open

### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [x] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions