### PR TITLE
Add specialized `records` methods, and `find_to_populate_by_keys`

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -464,6 +464,12 @@ module JSONAPI
         # :nocov:
       end
 
+      def find_to_populate_by_keys(_keys, _options = {})
+        # :nocov:
+        raise 'Abstract ResourceFinder method called. Ensure that a ResourceFinder has been set.'
+        # :nocov:
+      end
+
       def find_fragments(_filters, _options = {})
         # :nocov:
         raise 'Abstract ResourceFinder method called. Ensure that a ResourceFinder has been set.'

--- a/lib/jsonapi/resource_set.rb
+++ b/lib/jsonapi/resource_set.rb
@@ -91,7 +91,7 @@ module JSONAPI
       # Step Four find any of the missing resources and join them into the result
       missed_resource_ids.each_pair do |resource_klass, ids|
         find_opts = {context: context, fields: find_options[:fields]}
-        found_resources = resource_klass.find_by_keys(ids, find_opts)
+        found_resources = resource_klass.find_to_populate_by_keys(ids, find_opts)
 
         found_resources.each do |resource|
           relationship_data = @resource_klasses[resource_klass][resource.id][:relationships]

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -1527,6 +1527,10 @@ module BreedResourceFinder
       resource_for(record, options[:context])
     end
 
+    def find_to_populate_by_keys(keys, options = {})
+      find_by_keys(keys, options)
+    end
+
     def find_by_keys(keys, options = {})
       records = find_breeds_by_keys(keys, options)
       resources_for(records, options[:context])


### PR DESCRIPTION
Specialized records methods allow the system to avoid duplicating
expensive permission checks for records that have already been found.
This is needed because of the new multiphase approach building up the
result set.

WIP for testing and wording review. I think this needs tests to ensure correct usage, but I'm not sure of the best way to handle this.

### All Submissions:

- [ ] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions