### PR TITLE
Allow setting of the resource finder on a per resource basis

### DIFF
--- a/lib/jsonapi/configuration.rb
+++ b/lib/jsonapi/configuration.rb
@@ -17,7 +17,7 @@ module JSONAPI
                 :default_paginator,
                 :default_page_size,
                 :maximum_page_size,
-                :resource_finder,
+                :default_resource_finder,
                 :default_processor_klass,
                 :use_text_errors,
                 :top_level_links_include_pagination,
@@ -109,7 +109,7 @@ module JSONAPI
       # The default ResourceFinder is the ActiveRelationResourceFinder which provides
       # access to ActiveRelation backed models. Custom ResourceFinders can be specified
       # in order to support other ORMs.
-      self.resource_finder = JSONAPI::ActiveRelationResourceFinder
+      self.default_resource_finder = JSONAPI::ActiveRelationResourceFinder
 
       # The default Operation Processor to use if one is not defined specifically
       # for a Resource.
@@ -225,8 +225,8 @@ module JSONAPI
       @default_processor_klass = default_processor_klass
     end
 
-    def resource_finder=(resource_finder)
-      @resource_finder = resource_finder
+    def default_resource_finder=(default_resource_finder)
+      @default_resource_finder = default_resource_finder
     end
 
     def allow_include=(allow_include)

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -423,7 +423,7 @@ module JSONAPI
 
         check_reserved_resource_name(subclass._type, subclass.name)
 
-        subclass.include JSONAPI.configuration.resource_finder if JSONAPI.configuration.resource_finder
+        subclass.include JSONAPI.configuration.default_resource_finder if JSONAPI.configuration.default_resource_finder
       end
 
       # A ResourceFinder is a mixin that adds functionality to find Resources and Resource Fragments

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -1557,8 +1557,10 @@ module BreedResourceFinder
   end
 end
 
-JSONAPI.configuration.default_resource_finder = BreedResourceFinder
 class BreedResource < JSONAPI::Resource
+
+  resource_finder BreedResourceFinder
+
   attribute :name, format: :title
 
   # This is unneeded, just here for testing
@@ -1569,7 +1571,6 @@ class BreedResource < JSONAPI::Resource
     return :accepted
   end
 end
-JSONAPI.configuration.default_resource_finder = JSONAPI::ActiveRelationResourceFinder
 
 class PlanetResource < JSONAPI::Resource
   attribute :name

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -1557,7 +1557,7 @@ module BreedResourceFinder
   end
 end
 
-JSONAPI.configuration.resource_finder = BreedResourceFinder
+JSONAPI.configuration.default_resource_finder = BreedResourceFinder
 class BreedResource < JSONAPI::Resource
   attribute :name, format: :title
 
@@ -1569,7 +1569,7 @@ class BreedResource < JSONAPI::Resource
     return :accepted
   end
 end
-JSONAPI.configuration.resource_finder = JSONAPI::ActiveRelationResourceFinder
+JSONAPI.configuration.default_resource_finder = JSONAPI::ActiveRelationResourceFinder
 
 class PlanetResource < JSONAPI::Resource
   attribute :name


### PR DESCRIPTION
This gets us closer to supporting alternate resource finders. This should work with multiple resource finders as long as relationships do not span the different data stores.

I wanted to keep the resource finders as mix-ins to allow existing code to override the `records` and other methods. In order to support a default resource finder and allow setting this with a method in the resource class definition the mix-in needed to delay loading. This was accomplished with `method_missing` to load the resource finder if it isn't loaded.

### All Submissions:

- [ ] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions