### PR TITLE
Continuation of #1217: Support creating polymorphic has-many relationships

### DIFF
--- a/jsonapi-resources.gemspec
+++ b/jsonapi-resources.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'concurrent-ruby-ext'
+  spec.add_development_dependency 'database_cleaner'
   spec.add_dependency 'activerecord', '>= 4.1'
   spec.add_dependency 'railties', '>= 4.1'
   spec.add_dependency 'concurrent-ruby'

--- a/lib/jsonapi/request_parser.rb
+++ b/lib/jsonapi/request_parser.rb
@@ -530,8 +530,10 @@ module JSONAPI
           links_object.each_pair do |type, keys|
             resource = self.resource_klass || Resource
             type_name = unformat_key(type).to_s
+
             relationship_resource_klass = resource.resource_for(relationship.class_name)
             relationship_klass = relationship_resource_klass._model_class
+
             linkage_object_resource_klass = resource.resource_for(type_name)
             linkage_object_klass = linkage_object_resource_klass._model_class
 
@@ -545,14 +547,14 @@ module JSONAPI
 
           add_result.call polymorphic_results
         else
-          if links_object.length > 1 || !links_object.has_key?(unformat_key(relationship.type).to_s)
+          relationship_type = unformat_key(relationship.type).to_s
+
+          if links_object.length > 1 || !links_object.has_key?(relationship_type)
             fail JSONAPI::Exceptions::TypeMismatch.new(links_object[:type])
           end
 
-          links_object.each_pair do |type, keys|
-            relationship_resource = Resource.resource_for(@resource_klass.module_path + unformat_key(type).to_s)
-            add_result.call relationship_resource.verify_keys(keys, @context)
-          end
+          relationship_resource = Resource.resource_for(@resource_klass.module_path + relationship_type)
+          add_result.call relationship_resource.verify_keys(links_object[relationship_type], @context)
         end
       end
     end

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -304,21 +304,23 @@ module JSONAPI
 
         @reload_needed = true
       elsif relationship.polymorphic?
-        relationship_resource_klass = self.class.resource_for(relationship_key_values[:type])
-        ids = relationship_key_values[:ids]
+        relationship_key_values.each do |relationship_key_value|
+          relationship_resource_klass = self.class.resource_for(relationship_key_value[:type])
+          ids = relationship_key_value[:ids]
 
-        related_records = relationship_resource_klass
-          .records
-          .where({relationship_resource_klass._primary_key => ids})
+          related_records = relationship_resource_klass
+            .records(options)
+            .where({relationship_resource_klass._primary_key => ids})
 
-        missed_ids = ids - related_records.map(&:id)
+          missed_ids = ids - related_records.pluck(relationship_resource_klass._primary_key)
 
-        if missed_ids.present?
-          fail JSONAPI::Exceptions::RecordNotFound.new(missed_ids)
+          if missed_ids.present?
+            fail JSONAPI::Exceptions::RecordNotFound.new(missed_ids)
+          end
+
+          relation_name = relationship.relation_name(context: @context)
+          @model.send("#{relation_name}") << related_records
         end
-
-        relation_name = relationship.relation_name(context: @context)
-        @model.send("#{relation_name}=", related_records)
 
         @reload_needed = true
       else

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -303,6 +303,15 @@ module JSONAPI
         _create_to_many_links(relationship_type, to_add, {})
 
         @reload_needed = true
+      elsif relationship.polymorphic?
+        relationship_resource_klass = self.class.resource_for(relationship_key_values[:type])
+        relationship_klass = relationship_resource_klass._model_class
+        related_records = relationship_klass.find(relationship_key_values[:ids])
+        relation_name = relationship.relation_name(context: @context)
+
+        @model.send("#{relation_name}=", related_records)
+
+        @reload_needed = true
       else
         send("#{relationship.foreign_key}=", relationship_key_values)
         @save_needed = true

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -1028,10 +1028,12 @@ class VehicleResource < JSONAPI::Resource
 end
 
 class CarResource < VehicleResource
+  model_name "Car"
   attributes :drive_layout
 end
 
 class BoatResource < VehicleResource
+  model_name "Boat"
   attributes :length_at_water_line
 end
 

--- a/test/integration/requests/request_test.rb
+++ b/test/integration/requests/request_test.rb
@@ -2,10 +2,15 @@ require File.expand_path('../../../test_helper', __FILE__)
 
 class RequestTest < ActionDispatch::IntegrationTest
   def setup
+    DatabaseCleaner.start
     JSONAPI.configuration.json_key_format = :underscored_key
     JSONAPI.configuration.route_format = :underscored_route
     Api::V2::BookResource.paginator :offset
     $test_user = Person.find(1)
+  end
+
+  def teardown
+    DatabaseCleaner.clean
   end
 
   def after_teardown

--- a/test/integration/requests/request_test.rb
+++ b/test/integration/requests/request_test.rb
@@ -211,6 +211,52 @@ class RequestTest < ActionDispatch::IntegrationTest
     assert_jsonapi_response 201
   end
 
+  def test_post_polymorphic
+    post '/people', params:
+      {
+        'data' => {
+          'type' => 'people',
+          'attributes' => {
+            'name' => 'Reo',
+            'email' => 'reo@xyz.fake',
+            'date_joined' => 'Thu, 01 Jan 2019 00:00:00 UTC +00:00',
+          },
+          'relationships' => {
+            'vehicles' => {'data' => [{'type' => 'car', 'id' => '1'}]},
+          }
+        }
+      }.to_json,
+      headers: {
+        'CONTENT_TYPE' => JSONAPI::MEDIA_TYPE,
+        'Accept' => JSONAPI::MEDIA_TYPE
+      }
+
+    assert_jsonapi_response 201
+  end
+
+  def test_post_polymorphic_invalid
+    post '/people', params:
+      {
+        'data' => {
+          'type' => 'people',
+          'attributes' => {
+            'name' => 'Reo',
+            'email' => 'reo@xyz.fake',
+            'date_joined' => 'Thu, 01 Jan 2019 00:00:00 UTC +00:00',
+          },
+          'relationships' => {
+            'vehicles' => {'data' => [{'type' => 'author', 'id' => '1'}]},
+          }
+        }
+      }.to_json,
+      headers: {
+        'CONTENT_TYPE' => JSONAPI::MEDIA_TYPE,
+        'Accept' => JSONAPI::MEDIA_TYPE
+      }
+
+    assert_jsonapi_response 400, msg: "Submitting a thing as a vehicle should raise a type mismatch error"
+  end
+
   def test_post_single_missing_data_contents
     post '/posts', params:
          {

--- a/test/integration/requests/request_test.rb
+++ b/test/integration/requests/request_test.rb
@@ -246,10 +246,10 @@ class RequestTest < ActionDispatch::IntegrationTest
     body = JSON.parse(response.body)
     person = Person.find(body.dig("data", "id"))
 
-    assert "Reo", person.name
-    assert 2, person.vehicles.count
-    assert Car, person.vehicles.first.class
-    assert Boat, person.vehicles.second.class
+    assert_equal "Reo", person.name
+    assert_equal 2, person.vehicles.count
+    assert_equal Car, person.vehicles.first.class
+    assert_equal Boat, person.vehicles.second.class
   end
 
   def test_post_polymorphic_invalid_with_wrong_type
@@ -545,10 +545,10 @@ class RequestTest < ActionDispatch::IntegrationTest
     body = JSON.parse(response.body)
     person = Person.find(body.dig("data", "id"))
 
-    assert "Reo", person.name
-    assert 2, person.vehicles.count
-    assert Car, person.vehicles.first.class
-    assert Boat, person.vehicles.second.class
+    assert_equal "Reo", person.name
+    assert_equal 2, person.vehicles.count
+    assert_equal Car, person.vehicles.first.class
+    assert_equal Boat, person.vehicles.second.class
   end
 
   def test_patch_polymorphic_invalid_with_wrong_type

--- a/test/integration/requests/request_test.rb
+++ b/test/integration/requests/request_test.rb
@@ -300,7 +300,7 @@ class RequestTest < ActionDispatch::IntegrationTest
         'Accept' => JSONAPI::MEDIA_TYPE
       }
 
-    assert_jsonapi_response 400, msg: "Submitting a thing as a vehicle should raise a type mismatch error"
+    assert_jsonapi_response 404, msg: "Submitting a thing as a vehicle should raise a record not found"
   end
 
   def test_post_single_missing_data_contents

--- a/test/integration/requests/request_test.rb
+++ b/test/integration/requests/request_test.rb
@@ -227,7 +227,12 @@ class RequestTest < ActionDispatch::IntegrationTest
             'date_joined' => 'Thu, 01 Jan 2019 00:00:00 UTC +00:00',
           },
           'relationships' => {
-            'vehicles' => {'data' => [{'type' => 'car', 'id' => '1'}]},
+            'vehicles' => {
+              'data' => [
+                {'type' => 'car', 'id' => '1'},
+                {'type' => 'boat', 'id' => '2'}
+              ]
+            }
           }
         }
       }.to_json,
@@ -242,8 +247,9 @@ class RequestTest < ActionDispatch::IntegrationTest
     person = Person.find(body.dig("data", "id"))
 
     assert "Reo", person.name
-    assert 1, person.vehicles.count
-    assert 1, person.vehicles.first.id
+    assert 2, person.vehicles.count
+    assert Car, person.vehicles.first.class
+    assert Boat, person.vehicles.second.class
   end
 
   def test_post_polymorphic_invalid_with_wrong_type

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,5 @@
 require 'simplecov'
+require 'database_cleaner'
 
 # To run tests with coverage:
 # COVERAGE=true bundle exec rake test
@@ -407,6 +408,8 @@ end
 ApiV2Engine::Engine.routes.draw do
   jsonapi_resources :people
 end
+
+DatabaseCleaner.strategy = :transaction
 
 # Ensure backward compatibility with Minitest 4
 Minitest::Test = MiniTest::Unit::TestCase unless defined?(Minitest::Test)


### PR DESCRIPTION
This is a continuation of #1217, which fixes its failing tests (thanks for @saravanak's hard work!). 

The cause of #1217's failure is data mutation between test cases: the integration test's post request creates a new record, and it fails other tests (under certain execution order). So my additional commit is to keep the database clean (with [database_cleaner](https://github.com/DatabaseCleaner/database_cleaner) before/after each integration test suite.


### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [x] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [x] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [x] I've included an explanation of what the changes do and why I'd like you to include them.
- [x] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions