### PR TITLE
Pass `rel_opts` when filtering records for record count

### DIFF
--- a/lib/jsonapi/processor.rb
+++ b/lib/jsonapi/processor.rb
@@ -197,7 +197,7 @@ module JSONAPI
           (paginator && paginator.class.requires_record_count) ||
           (JSONAPI.configuration.top_level_meta_include_page_count))
         related_resource_records = source_resource.public_send("records_for_" + relationship_type)
-        records = resource_klass.filter_records(verified_filters, {},
+        records = resource_klass.filter_records(verified_filters, rel_opts,
                                                 related_resource_records)
 
         record_count = resource_klass.count_records(records)

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -2754,6 +2754,45 @@ class Api::V2::BooksControllerTest < ActionController::TestCase
   end
 end
 
+class Api::V2::BooksControllerTest < ActionController::TestCase
+  def test_get_related_resources_with_filters
+    $test_user = Person.find(5)
+    original_config = JSONAPI.configuration.dup
+    JSONAPI.configuration.top_level_meta_include_record_count = true
+    JSONAPI.configuration.json_key_format = :dasherized_key
+    assert_cacheable_get :get_related_resources,
+                         params: {
+                           author_id: '1',
+                           relationship: 'books',
+                           source: 'api/v2/authors',
+                           filter: { fiction: 'true' }
+                         }
+    assert_response :success
+    assert_equal 1, json_response['meta']['record-count']
+  ensure
+    JSONAPI.configuration = original_config
+  end
+
+  def test_get_related_resources_with_filters_2
+    # Admin user can find an author's banned books
+    $test_user = Person.find(5)
+    original_config = JSONAPI.configuration.dup
+    JSONAPI.configuration.top_level_meta_include_record_count = true
+    JSONAPI.configuration.json_key_format = :dasherized_key
+    assert_cacheable_get :get_related_resources,
+                         params: {
+                           author_id: '1',
+                           relationship: 'books',
+                           source: 'api/v2/authors',
+                           filter: { banned: 'true' }
+                         }
+    assert_response :success
+    assert_equal 1, json_response['meta']['record-count']
+  ensure
+    JSONAPI.configuration = original_config
+  end
+end
+
 class BreedsControllerTest < ActionController::TestCase
   # Note: Breed names go through the TitleValueFormatter
 

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -1552,6 +1552,8 @@ module Api
           # Only book admins might filter for banned books
           if current_user && current_user.book_admin
             records.where('books.banned = ?', value[0] == 'true')
+          else
+            records
           end
         end
 


### PR DESCRIPTION
Naturally I uncovered this because it caused a more complex bug in my app.
The problem here is that if you have a filter which depends on something
that is set in, for example, the context, you will not have that context
when the filter is re-invoked for record count, which happens when the
record count configuration is active. This only happens when fetching
related resources.

In this case I add a test where we try to fetch an author's banned books,
of which there should be only one. However, because the prior code
discards the rel_opts and instead provides an empty hash (!) the filter
does not execute because it will only operate when an admin user is in
the context. The failing test then reports the record count as *3*, where it should be *1*. The change to the processor class solves this issue.