### PR TITLE
Include directives may be nil if no includes are directed

### DIFF
--- a/lib/jsonapi/request_parser.rb
+++ b/lib/jsonapi/request_parser.rb
@@ -265,7 +265,7 @@ module JSONAPI
             return @errors.concat(Exceptions::FilterNotAllowed.new(filter_method).errors)
           end
 
-          unless @include_directives.include_config(relationship.name.to_sym).present?
+          unless @include_directives&.include_config(relationship.name.to_sym).present?
             return @errors.concat(Exceptions::FilterNotAllowed.new(filter_method).errors)
           end
 

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -2638,7 +2638,7 @@ class Api::V5::PaintersControllerTest < ActionController::TestCase
 
   def test_show_with_filters_and_no_included_resources
     get :show, params: { id: 1, filter: { 'paintings.category' => 'oil' } }
-    assert_response 400
+    assert_response :bad_request
     assert_equal('Filter not allowed', json_response['errors'][0]['title'])
     assert_equal('category is not allowed.', json_response['errors'][0]['detail'])
   end

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -2635,6 +2635,13 @@ class Api::V5::PaintersControllerTest < ActionController::TestCase
     assert_equal 2, json_response['included'].size
     assert_equal '4', json_response['included'][0]['id']
   end
+
+  def test_show_with_filters_and_no_included_resources
+    get :show, params: { id: 1, filter: { 'paintings.category' => 'oil' } }
+    assert_response 400
+    assert_equal('Filter not allowed', json_response['errors'][0]['title'])
+    assert_equal('category is not allowed.', json_response['errors'][0]['detail'])
+  end
 end
 
 class Api::V5::AuthorsControllerTest < ActionController::TestCase


### PR DESCRIPTION
If you attempt to filter an included resource, but didn't include anything, it will crash.

If you had included a different resource this would return an error response. With this change, we safe-navigate the `@include_directives`, avoiding a NoMethodError on nil.