### PR TITLE
Allow marking relationships as async

### DIFF
--- a/lib/jsonapi/configuration.rb
+++ b/lib/jsonapi/configuration.rb
@@ -27,6 +27,7 @@ module JSONAPI
                 :whitelist_all_exceptions,
                 :always_include_to_one_linkage_data,
                 :always_include_to_many_linkage_data,
+                :relationships_async_default,
                 :cache_formatters,
                 :use_relationship_reflection,
                 :resource_cache,
@@ -91,6 +92,10 @@ module JSONAPI
       # NOTE: always_include_to_many_linkage_data is not currently implemented
       self.always_include_to_one_linkage_data = false
       self.always_include_to_many_linkage_data = false
+
+      # Relationship async default
+      # Allows to globally disable async relationships
+      self.relationships_async_default = true
 
       # The default Operation Processor to use if one is not defined specifically
       # for a Resource.
@@ -232,6 +237,8 @@ module JSONAPI
     attr_writer :always_include_to_one_linkage_data
 
     attr_writer :always_include_to_many_linkage_data
+
+    attr_writer :relationships_async_default
 
     attr_writer :raise_if_parameters_not_allowed
 

--- a/lib/jsonapi/relationship.rb
+++ b/lib/jsonapi/relationship.rb
@@ -2,7 +2,7 @@ module JSONAPI
   class Relationship
     attr_reader :acts_as_set, :foreign_key, :options, :name,
                 :class_name, :polymorphic, :always_include_linkage_data,
-                :parent_resource, :eager_load_on_include
+                :parent_resource, :eager_load_on_include, :async
 
     def initialize(name, options = {})
       @name = name.to_s
@@ -14,6 +14,7 @@ module JSONAPI
       @polymorphic = options.fetch(:polymorphic, false) == true
       @always_include_linkage_data = options.fetch(:always_include_linkage_data, false) == true
       @eager_load_on_include = options.fetch(:eager_load_on_include, true) == true
+      @async = options.fetch(:async, JSONAPI.configuration.relationships_async_default)
     end
 
     alias_method :polymorphic?, :polymorphic

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -476,6 +476,8 @@ class PostsControllerTest < ActionController::TestCase
     assert json_response['data'].is_a?(Hash)
     assert_equal 'New post', json_response['data']['attributes']['title']
     assert_equal 'A body!!!', json_response['data']['attributes']['body']
+    assert_hash_equals({links: {self: "http://test.host/posts/1/relationships/comments", related: "http://test.host/posts/1/comments"}},
+                       json_response['data']['relationships']['comments'])
     assert_nil json_response['included']
   end
 
@@ -2751,6 +2753,22 @@ class Api::V2::BooksControllerTest < ActionController::TestCase
     assert_equal 1, json_response['meta']['record-count']
   ensure
     JSONAPI.configuration = original_config
+  end
+
+  def test_show_single_with_non_async_relationships
+    assert_cacheable_get :show, params: {id: '1'}
+    assert_response :success
+    assert json_response['data'].is_a?(Hash)
+    assert_nil json_response['data']['relationships']['authors']
+  end
+
+  def test_show_single_with_non_async_relationships_and_include
+    assert_cacheable_get :show, params: {id: '1', include: 'authors'}
+    assert_response :success
+    assert json_response['data'].is_a?(Hash)
+    assert_equal 1, json_response['included'].size
+    assert_hash_equals({data: [{'type' => 'people', 'id' => '1'}]},
+                       json_response['data']['relationships']['authors'])
   end
 end
 

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -1503,7 +1503,7 @@ module Api
 
       paginator :offset
 
-      has_many "authors"
+      has_many "authors", async: false
 
       has_many "book_comments", relation_name: -> (options = {}) {
         context = options[:context]


### PR DESCRIPTION
### Description

This change introduces an option to mark relationships as non-async (globally and for each relationship separately) so the links to these relationships won't be included in the response.

It's meant to be used in conjunction with route definition that takes a custom block:

```ruby
jsonapi_resources(:posts, only: [:index, :show]) {
  # We don't call `jsonapi_related_resources` here
}
```

This is useful if one wants to avoid async requests to fetch the relationships and rather utilize sideloading.

Summary:

* Global config to allow marking relationships as non-async by default
* Do not return links for non-async relationships
* In a case when non-async relationship is not sideloaded, it does not have any data/links.
  In this case we don't want to mention it at all since ember-data currently resets previous known state.

### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [x] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [x] My submission includes new tests.
- [x] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions