### PR TITLE
Reset _model_class cache when calling model_name

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -568,6 +568,9 @@ module JSONAPI
       def model_name(model, options = {})
         @_model_name = model.to_sym
 
+        # Reset _model_class cache
+        @model_class = nil
+
         model_hint(model: @_model_name, resource: self) unless options[:add_model_hint] == false
 
         rebuild_relationships(_relationships)

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -128,6 +128,7 @@ class ResourceTest < ActiveSupport::TestCase
 
   def test_model
     assert_equal(PostResource._model_class, Post)
+    assert_equal(Api::V7::CustomerResource._model_class, Api::V7::Customer)
   end
 
   def test_module_path


### PR DESCRIPTION
This allows actually redefining model_name for the resources
that were inherited from some other resource.

See this commit https://github.com/cerebris/jsonapi-resources/commit/280ccea0cd06762f443b4ff61edd9278388ce0e1

### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [x] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [x] I've added/updated tests for this change.

### Bug fixes and Changes to Core Features:

- [x] I've included an explanation of what the changes do and why I'd like you to include them.
- [x] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions