### PR TITLE
Apply records_for_RELATIONSHIP method on polymorphic to many linkage

### DIFF
--- a/test/unit/serializer/polymorphic_serializer_test.rb
+++ b/test/unit/serializer/polymorphic_serializer_test.rb
@@ -130,6 +130,73 @@ class PolymorphismTest < ActionDispatch::IntegrationTest
     )
   end
 
+  def test_sti_polymorphic_to_many_serialization_with_custom_polymorphic_records
+    person_resource = PersonResource.new(@person, nil)
+    serializer = JSONAPI::ResourceSerializer.new(
+      PersonResource,
+      include: %w(vehicles)
+    )
+
+    def person_resource.records_for_vehicles(opts = {})
+      @model.vehicles.none
+    end
+
+    serialized_data = serializer.serialize_to_hash(person_resource)
+
+    assert_hash_equals(
+      {
+        data: {
+          id: '1',
+          type: 'people',
+          links: {
+            self: '/people/1'
+          },
+          attributes: {
+            name: 'Joe Author',
+            email: 'joe@xyz.fake',
+            dateJoined: '2013-08-07 16:25:00 -0400'
+          },
+          relationships: {
+            comments: {
+              links: {
+                self: '/people/1/relationships/comments',
+                related: '/people/1/comments'
+              }
+            },
+            posts: {
+              links: {
+                self: '/people/1/relationships/posts',
+                related: '/people/1/posts'
+              }
+            },
+            vehicles: {
+              links: {
+                self: '/people/1/relationships/vehicles',
+                related: '/people/1/vehicles'
+              },
+              :data => []
+            },
+            preferences: {
+              links: {
+                self: '/people/1/relationships/preferences',
+                related: '/people/1/preferences'
+              }
+            },
+            hairCut: {
+              links: {
+                self: '/people/1/relationships/hairCut',
+                related: '/people/1/hairCut'
+              }
+            }
+          }
+        }
+      },
+      serialized_data
+    )
+  end
+
+
+
   def test_polymorphic_belongs_to_serialization
     serialized_data = JSONAPI::ResourceSerializer.new(
       PictureResource,


### PR DESCRIPTION
This closes #1238. Currently we can use `records_for_RELATIONSHIP` to control the included
records. But that change doesn't apply to the linkage data. So we'll get a consistent result between included records and linkage data. This PR fixes the issue.

### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [x] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [x] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [x] I've added/updated tests for this change.

### Bug fixes and Changes to Core Features:

- [x] I've included an explanation of what the changes do and why I'd like you to include them.
- [x] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions