### PR TITLE
Route based links - master

### DIFF
--- a/lib/jsonapi/basic_resource.rb
+++ b/lib/jsonapi/basic_resource.rb
@@ -961,8 +961,15 @@ module JSONAPI
       end
 
       def exclude_links(exclude)
-        @_exclude_links = exclude.collect do |link|
-          link.to_sym
+        case exclude
+          when :default, "default"
+            @_exclude_links = [:self]
+          when :none, "none"
+            @_exclude_links = []
+          when Array
+            @_exclude_links = exclude.collect {|link| link.to_sym}
+          else
+            fail "Invalid exclude_links"
         end
       end
 

--- a/lib/jsonapi/basic_resource.rb
+++ b/lib/jsonapi/basic_resource.rb
@@ -423,7 +423,7 @@ module JSONAPI
         subclass.immutable(false)
         subclass.caching(_caching)
         subclass.singleton(singleton?, (_singleton_options.dup || {}))
-        subclass.build_default_links(_build_default_links)
+        subclass.exclude_links(_exclude_links)
         subclass.paginator(_paginator)
         subclass._attributes = (_attributes || {}).dup
         subclass.polymorphic(false)
@@ -960,16 +960,18 @@ module JSONAPI
         !@immutable
       end
 
-      def build_default_links(build)
-        @build_default_links = build
+      def exclude_links(exclude)
+        @_exclude_links = exclude.collect do |link|
+          link.to_sym
+        end
       end
 
-      def _build_default_links
-        @_build_default_links
+      def _exclude_links
+        @_exclude_links ||= []
       end
 
-      def build_default_links?
-        @_build_default_links.nil? || @_build_default_links == true
+      def exclude_link?(link)
+        _exclude_links.include?(link.to_sym)
       end
 
       def caching(val = true)

--- a/lib/jsonapi/basic_resource.rb
+++ b/lib/jsonapi/basic_resource.rb
@@ -422,6 +422,7 @@ module JSONAPI
         subclass.abstract(false)
         subclass.immutable(false)
         subclass.caching(_caching)
+        subclass.singleton(singleton?, (_singleton_options.dup || {}))
         subclass.build_default_links(_build_default_links)
         subclass.paginator(_paginator)
         subclass._attributes = (_attributes || {}).dup
@@ -629,6 +630,19 @@ module JSONAPI
         _model_hints[model.to_s.gsub('::', '/').underscore] = resource_type.to_s
       end
 
+      def singleton(*attrs)
+        @_singleton = (!!attrs[0] == attrs[0]) ? attrs[0] : true
+        @_singleton_options = attrs.extract_options!
+      end
+
+      def _singleton_options
+        @_singleton_options ||= {}
+      end
+
+      def singleton?
+        @_singleton ||= false
+      end
+
       def filters(*attrs)
         @_allowed_filters.merge!(attrs.inject({}) { |h, attr| h[attr] = {}; h })
       end
@@ -739,6 +753,24 @@ module JSONAPI
 
       def resource_key_type
         @_resource_key_type ||= JSONAPI.configuration.resource_key_type
+      end
+
+      # override to all resolution of masked ids to actual ids. Because singleton routes do not specify the id this
+      # will be needed to allow lookup of singleton resources. Alternately singleton resources can override
+      # `verify_key`
+      def singleton_key(context)
+        if @_singleton_options && @_singleton_options[:singleton_key]
+          strategy = @_singleton_options[:singleton_key]
+          case strategy
+            when Proc
+              key = strategy.call(context)
+            when Symbol, String
+              key = send(strategy, context)
+            else
+              raise "singleton_key must be a proc or function name"
+          end
+        end
+        key
       end
 
       def verify_key(key, context = nil)

--- a/lib/jsonapi/basic_resource.rb
+++ b/lib/jsonapi/basic_resource.rb
@@ -422,6 +422,7 @@ module JSONAPI
         subclass.abstract(false)
         subclass.immutable(false)
         subclass.caching(_caching)
+        subclass.build_default_links(_build_default_links)
         subclass.paginator(_paginator)
         subclass._attributes = (_attributes || {}).dup
         subclass.polymorphic(false)
@@ -925,6 +926,18 @@ module JSONAPI
 
       def mutable?
         !@immutable
+      end
+
+      def build_default_links(build)
+        @build_default_links = build
+      end
+
+      def _build_default_links
+        @_build_default_links
+      end
+
+      def build_default_links?
+        @_build_default_links.nil? || @_build_default_links == true
       end
 
       def caching(val = true)

--- a/lib/jsonapi/configuration.rb
+++ b/lib/jsonapi/configuration.rb
@@ -9,6 +9,7 @@ module JSONAPI
                 :route_format,
                 :raise_if_parameters_not_allowed,
                 :warn_on_route_setup_issues,
+                :warn_on_missing_routes,
                 :default_allow_include_to_one,
                 :default_allow_include_to_many,
                 :allow_sort,
@@ -57,6 +58,7 @@ module JSONAPI
       self.raise_if_parameters_not_allowed = true
 
       self.warn_on_route_setup_issues = true
+      self.warn_on_missing_routes = true
 
       # :none, :offset, :paged, or a custom paginator name
       self.default_paginator = :none
@@ -260,6 +262,8 @@ module JSONAPI
     attr_writer :raise_if_parameters_not_allowed
 
     attr_writer :warn_on_route_setup_issues
+
+    attr_writer :warn_on_missing_routes
 
     attr_writer :use_relationship_reflection
 

--- a/lib/jsonapi/link_builder.rb
+++ b/lib/jsonapi/link_builder.rb
@@ -2,32 +2,33 @@ module JSONAPI
   class LinkBuilder
     attr_reader :base_url,
                 :primary_resource_klass,
-                :route_formatter,
-                :engine_name
+                :engine,
+                :routes
 
     def initialize(config = {})
       @base_url               = config[:base_url]
       @primary_resource_klass = config[:primary_resource_klass]
-      @route_formatter        = config[:route_formatter]
-      @engine_name            = build_engine_name
+      @engine                 = build_engine
 
-      # Warning: These make LinkBuilder non-thread-safe. That's not a problem with the
-      # request-specific way it's currently used, though.
-      @resources_path_cache   = JSONAPI::NaiveCache.new do |source_klass|
-        formatted_module_path_from_class(source_klass) + format_route(source_klass._type.to_s)
+      if engine?
+        @routes = @engine.routes
+      else
+        @routes = Rails.application.routes
       end
+
+      # ToDo: Use NaiveCache for values. For this we need to not return nils and create composite keys which work
+      # as efficient cache lookups. This could be an array of the [source.identifier, relationship] since the
+      # ResourceIdentity will compare equality correctly
     end
 
     def engine?
-      !!@engine_name
+      !!@engine
     end
 
     def primary_resources_url
-      if engine?
-        engine_primary_resources_url
-      else
-        regular_primary_resources_url
-      end
+      @primary_resources_url_cached ||= "#{ base_url }#{ primary_resources_path }"
+    rescue NoMethodError
+      warn "primary_resources_url for #{@primary_resource_klass} could not be generated" if JSONAPI.configuration.warn_on_missing_routes
     end
 
     def query_link(query_params)
@@ -35,26 +36,33 @@ module JSONAPI
     end
 
     def relationships_related_link(source, relationship, query_params = {})
-      url = "#{ self_link(source) }/#{ route_for_relationship(relationship) }"
+      url_helper_name = related_url_helper_name(relationship)
+      url = call_url_helper(url_helper_name, source.id)
+      url = "#{ base_url }#{ url }"
       url = "#{ url }?#{ query_params.to_query }" if query_params.present?
       url
+    rescue NoMethodError
+      warn "related_link for #{relationship} could not be generated" if JSONAPI.configuration.warn_on_missing_routes
     end
 
     def relationships_self_link(source, relationship)
-      "#{ self_link(source) }/relationships/#{ route_for_relationship(relationship) }"
+      url_helper_name = relationship_self_url_helper_name(relationship)
+      url = call_url_helper(url_helper_name, source.id)
+      url = "#{ base_url }#{ url }"
+      url
+    rescue NoMethodError
+      warn "self_link for #{relationship} could not be generated" if JSONAPI.configuration.warn_on_missing_routes
     end
 
     def self_link(source)
-      if engine?
-        engine_resource_url(source)
-      else
-        regular_resource_url(source)
-      end
+      "#{ base_url }#{ resource_path(source) }"
+    rescue NoMethodError
+      warn "self_link for #{source.class} could not be generated" if JSONAPI.configuration.warn_on_missing_routes
     end
 
     private
 
-    def build_engine_name
+    def build_engine
       scopes = module_scopes_from_class(primary_resource_klass)
 
       begin
@@ -68,93 +76,77 @@ module JSONAPI
       end
     end
 
-    def engine_path_from_resource_class(klass)
-      path_name = engine_resources_path_name_from_class(klass)
-      engine_name.routes.url_helpers.public_send(path_name)
+    def call_url_helper(method, *args)
+      routes.url_helpers.public_send(method, args)
+    rescue NoMethodError => e
+      raise e
     end
 
-    def engine_primary_resources_path
-      engine_path_from_resource_class(primary_resource_klass)
+    def path_from_resource_class(klass)
+      url_helper_name = resources_url_helper_name_from_class(klass)
+      call_url_helper(url_helper_name)
     end
 
-    def engine_primary_resources_url
-      "#{ base_url }#{ engine_primary_resources_path }"
+    def resource_path(source)
+      url_helper_name = resource_url_helper_name_from_source(source)
+      call_url_helper(url_helper_name, source.id)
     end
 
-    def engine_resource_path(source)
-      resource_path_name = engine_resource_path_name_from_source(source)
-      engine_name.routes.url_helpers.public_send(resource_path_name, source.id)
+    def primary_resources_path
+      path_from_resource_class(primary_resource_klass)
     end
 
-    def engine_resource_path_name_from_source(source)
-      scopes         = module_scopes_from_class(source.class)[1..-1]
-      base_path_name = scopes.map { |scope| scope.underscore }.join("_")
-      end_path_name  = source.class._type.to_s.singularize
-      [base_path_name, end_path_name, "path"].reject(&:blank?).join("_")
+    def url_helper_name_from_parts(parts)
+      (parts << "path").reject(&:blank?).join("_")
     end
 
-    def engine_resource_url(source)
-      "#{ base_url }#{ engine_resource_path(source) }"
-    end
+    def resources_path_parts_from_class(klass)
+      if engine?
+        scopes = module_scopes_from_class(klass)[1..-1]
+      else
+        scopes = module_scopes_from_class(klass)
+      end
 
-    def engine_resources_path_name_from_class(klass)
-      scopes         = module_scopes_from_class(klass)[1..-1]
       base_path_name = scopes.map { |scope| scope.underscore }.join("_")
       end_path_name  = klass._type.to_s
-
-      if base_path_name.blank?
-        "#{ end_path_name }_path"
-      else
-        "#{ base_path_name }_#{ end_path_name }_path"
-      end
+      [base_path_name, end_path_name]
     end
 
-    def format_route(route)
-      route_formatter.format(route)
+    def resources_url_helper_name_from_class(klass)
+      url_helper_name_from_parts(resources_path_parts_from_class(klass))
     end
 
-    def formatted_module_path_from_class(klass)
-      scopes = module_scopes_from_class(klass)
-
-      unless scopes.empty?
-        "/#{ scopes.map{ |scope| format_route(scope.to_s.underscore) }.compact.join('/') }/"
+    def resource_path_parts_from_class(klass)
+      if engine?
+        scopes = module_scopes_from_class(klass)[1..-1]
       else
-        "/"
+        scopes = module_scopes_from_class(klass)
       end
+
+      base_path_name = scopes.map { |scope| scope.underscore }.join("_")
+      end_path_name  = klass._type.to_s.singularize
+      [base_path_name, end_path_name]
+    end
+
+    def resource_url_helper_name_from_source(source)
+       url_helper_name_from_parts(resource_path_parts_from_class(source.class))
+    end
+
+    def related_url_helper_name(relationship)
+      relationship_parts = resource_path_parts_from_class(relationship.parent_resource)
+      relationship_parts << relationship.name
+      url_helper_name_from_parts(relationship_parts)
+    end
+
+    def relationship_self_url_helper_name(relationship)
+      relationship_parts = resource_path_parts_from_class(relationship.parent_resource)
+      relationship_parts << "relationships"
+      relationship_parts << relationship.name
+      url_helper_name_from_parts(relationship_parts)
     end
 
     def module_scopes_from_class(klass)
       klass.name.to_s.split("::")[0...-1]
-    end
-
-    def regular_resources_path(source_klass)
-      @resources_path_cache.get(source_klass)
-    end
-
-    def regular_primary_resources_path
-      regular_resources_path(primary_resource_klass)
-    end
-
-    def regular_primary_resources_url
-      "#{ base_url }#{ regular_primary_resources_path }"
-    end
-
-    def regular_resource_path(source)
-      if source.is_a?(JSONAPI::CachedResponseFragment)
-        # :nocov:
-        "#{regular_resources_path(source.resource_klass)}/#{source.id}"
-        # :nocov:
-      else
-        "#{regular_resources_path(source.class)}/#{source.id}"
-      end
-    end
-
-    def regular_resource_url(source)
-      "#{ base_url }#{ regular_resource_path(source) }"
-    end
-
-    def route_for_relationship(relationship)
-      format_route(relationship.name)
     end
   end
 end

--- a/lib/jsonapi/operation_result.rb
+++ b/lib/jsonapi/operation_result.rb
@@ -100,7 +100,7 @@ module JSONAPI
     end
   end
 
-  class LinksObjectOperationResult < OperationResult
+  class RelationshipOperationResult < OperationResult
     attr_accessor :parent_resource, :relationship, :resource_ids
 
     def initialize(code, parent_resource, relationship, resource_ids, options = {})
@@ -112,7 +112,7 @@ module JSONAPI
 
     def to_hash(serializer = nil)
       if serializer
-        serializer.serialize_to_links_hash(parent_resource, relationship, resource_ids)
+        serializer.serialize_to_relationship_hash(parent_resource, relationship, resource_ids)
       else
         # :nocov:
         {}

--- a/lib/jsonapi/processor.rb
+++ b/lib/jsonapi/processor.rb
@@ -130,11 +130,11 @@ module JSONAPI
                                                        find_options,
                                                        nil)
 
-      return JSONAPI::LinksObjectOperationResult.new(:ok,
-                                                     parent_resource,
-                                                     resource_klass._relationship(relationship_type),
-                                                     resource_id_tree.fragments.keys,
-                                                     result_options)
+      return JSONAPI::RelationshipOperationResult.new(:ok,
+                                                      parent_resource,
+                                                      resource_klass._relationship(relationship_type),
+                                                      resource_id_tree.fragments.keys,
+                                                      result_options)
     end
 
     def show_related_resource

--- a/lib/jsonapi/relationship.rb
+++ b/lib/jsonapi/relationship.rb
@@ -119,7 +119,7 @@ module JSONAPI
 
       def to_s
         # :nocov: useful for debugging
-        "#{parent_resource._type}.#{name} => (#{belongs_to? ? 'ToOne' : 'BelongsToOne'}) #{resource_klass._type}"
+        "#{parent_resource}.#{name}(#{belongs_to? ? 'ToOne' : 'BelongsToOne'})"
         # :nocov:
       end
 
@@ -169,7 +169,7 @@ module JSONAPI
 
       def to_s
         # :nocov: useful for debugging
-        "#{parent_resource._type}.#{name} => (ToMany) #{resource_klass._type}"
+        "#{parent_resource}.#{name}(ToMany)"
         # :nocov:
       end
 

--- a/lib/jsonapi/relationship.rb
+++ b/lib/jsonapi/relationship.rb
@@ -137,7 +137,7 @@ module JSONAPI
 
       def to_s
         # :nocov: useful for debugging
-        "#{parent_resource}.#{name}(#{belongs_to? ? 'ToOne' : 'BelongsToOne'})"
+        "#{parent_resource}.#{name}(#{belongs_to? ? 'BelongsToOne' : 'ToOne'})"
         # :nocov:
       end
 

--- a/lib/jsonapi/relationship.rb
+++ b/lib/jsonapi/relationship.rb
@@ -26,7 +26,8 @@ module JSONAPI
       @allow_include = options[:allow_include]
       @class_name = nil
       @inverse_relationship = nil
-      @exclude_links = options[:exclude_links].try(:collect) { |link| link.to_sym }
+
+      exclude_links(options.fetch(:exclude_links, :none))
 
       # Custom methods are reserved for future use
       @custom_methods = options.fetch(:custom_methods, {})
@@ -100,8 +101,21 @@ module JSONAPI
       @options[:readonly]
     end
 
+    def exclude_links(exclude)
+      case exclude
+        when :default, "default"
+          @_exclude_links = [:self, :related]
+        when :none, "none"
+          @_exclude_links = []
+        when Array
+          @_exclude_links = exclude.collect {|link| link.to_sym}
+        else
+          fail "Invalid exclude_links"
+      end
+    end
+
     def _exclude_links
-      @exclude_links ||= []
+      @_exclude_links ||= []
     end
 
     def exclude_link?(link)

--- a/lib/jsonapi/relationship.rb
+++ b/lib/jsonapi/relationship.rb
@@ -26,7 +26,7 @@ module JSONAPI
       @allow_include = options[:allow_include]
       @class_name = nil
       @inverse_relationship = nil
-      @build_default_links = options[:build_default_links]
+      @exclude_links = options[:exclude_links].try(:collect) { |link| link.to_sym }
 
       # Custom methods are reserved for future use
       @custom_methods = options.fetch(:custom_methods, {})
@@ -100,8 +100,12 @@ module JSONAPI
       @options[:readonly]
     end
 
-    def build_default_links?
-      @build_default_links.nil? || @build_default_links
+    def _exclude_links
+      @exclude_links ||= []
+    end
+
+    def exclude_link?(link)
+      _exclude_links.include?(link.to_sym)
     end
 
     class ToOne < Relationship

--- a/lib/jsonapi/relationship.rb
+++ b/lib/jsonapi/relationship.rb
@@ -26,6 +26,7 @@ module JSONAPI
       @allow_include = options[:allow_include]
       @class_name = nil
       @inverse_relationship = nil
+      @build_default_links = options[:build_default_links]
 
       # Custom methods are reserved for future use
       @custom_methods = options.fetch(:custom_methods, {})
@@ -97,6 +98,10 @@ module JSONAPI
 
     def readonly?
       @options[:readonly]
+    end
+
+    def build_default_links?
+      @build_default_links.nil? || @build_default_links
     end
 
     class ToOne < Relationship

--- a/lib/jsonapi/request_parser.rb
+++ b/lib/jsonapi/request_parser.rb
@@ -81,6 +81,7 @@ module JSONAPI
     end
 
     def setup_show_related_resource_action(params, resource_klass)
+      resolve_singleton_id(params, resource_klass)
       source_klass = Resource.resource_klass_for(params.require(:source))
       source_id = source_klass.verify_key(params.require(source_klass._as_parent_key), @context)
 
@@ -102,6 +103,7 @@ module JSONAPI
     end
 
     def setup_index_related_resources_action(params, resource_klass)
+      resolve_singleton_id(params, resource_klass)
       source_klass = Resource.resource_klass_for(params.require(:source))
       source_id = source_klass.verify_key(params.require(source_klass._as_parent_key), @context)
 
@@ -128,6 +130,7 @@ module JSONAPI
     end
 
     def setup_show_action(params, resource_klass)
+      resolve_singleton_id(params, resource_klass)
       fields = parse_fields(resource_klass, params[:fields])
       include_directives = parse_include_directives(resource_klass, params[:include])
       id = params[:id]
@@ -144,6 +147,7 @@ module JSONAPI
     end
 
     def setup_show_relationship_action(params, resource_klass)
+      resolve_singleton_id(params, resource_klass)
       relationship_type = params[:relationship]
       parent_key = params.require(resource_klass._as_parent_key)
       include_directives = parse_include_directives(resource_klass, params[:include])
@@ -191,6 +195,7 @@ module JSONAPI
     end
 
     def setup_create_relationship_action(params, resource_klass)
+      resolve_singleton_id(params, resource_klass)
       parse_modify_relationship_action(:add, params, resource_klass)
     end
 
@@ -199,6 +204,7 @@ module JSONAPI
     end
 
     def setup_update_action(params, resource_klass)
+      resolve_singleton_id(params, resource_klass)
       fields = parse_fields(resource_klass, params[:fields])
       include_directives = parse_include_directives(resource_klass, params[:include])
 
@@ -232,6 +238,7 @@ module JSONAPI
     end
 
     def setup_destroy_action(params, resource_klass)
+      resolve_singleton_id(params, resource_klass)
       JSONAPI::Operation.new(
           :remove_resource,
           resource_klass,
@@ -240,6 +247,7 @@ module JSONAPI
     end
 
     def setup_destroy_relationship_action(params, resource_klass)
+      resolve_singleton_id(params, resource_klass)
       parse_modify_relationship_action(:remove, params, resource_klass)
     end
 
@@ -711,6 +719,13 @@ module JSONAPI
         JSONAPI::Operation.new(:remove_to_many_relationships, *operation_args)
       else
         JSONAPI::Operation.new(:remove_to_one_relationship, *operation_base_args)
+      end
+    end
+
+    def resolve_singleton_id(params, resource_klass)
+      if resource_klass.singleton? && params[:id].nil?
+        key = resource_klass.singleton_key(context)
+        params[:id] = key
       end
     end
 

--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -159,7 +159,7 @@ module JSONAPI
         obj_hash['attributes'] = source.attributes_json if source.attributes_json
 
         relationships = cached_relationships_hash(source, fetchable_fields, relationship_data)
-        obj_hash['relationships'] = relationships unless relationships.nil? || relationships.empty?
+        obj_hash['relationships'] = relationships unless relationships.blank?
 
         obj_hash['meta'] = source.meta_json if source.meta_json
       else
@@ -178,7 +178,7 @@ module JSONAPI
         obj_hash['attributes'] = attributes unless attributes.empty?
 
         relationships = relationships_hash(source, fetchable_fields, relationship_data)
-        obj_hash['relationships'] = relationships unless relationships.nil? || relationships.empty?
+        obj_hash['relationships'] = relationships unless relationships.blank?
 
         meta = meta_hash(source)
         obj_hash['meta'] = meta unless meta.empty?
@@ -270,7 +270,8 @@ module JSONAPI
             end
           end
 
-          hash[format_key(name)] = link_object(source, relationship, rids, include_data)
+          lo = link_object(source, relationship, rids, include_data)
+          hash[format_key(name)] = lo unless lo.blank?
         end
       end
     end

--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -93,19 +93,19 @@ module JSONAPI
       return serialize_resource_set_to_hash_plural(resource_set)
     end
 
-    def serialize_to_links_hash(source, requested_relationship, resource_ids)
+    def serialize_to_relationship_hash(source, requested_relationship, resource_ids)
       if requested_relationship.is_a?(JSONAPI::Relationship::ToOne)
         data = to_one_linkage(resource_ids[0])
       else
         data = to_many_linkage(resource_ids)
       end
 
-      links_hash = { 'data': data }
+      rel_hash = { 'data': data }
 
       links = default_relationship_links(source, requested_relationship)
-      links_hash['links'] = links unless links.blank?
+      rel_hash['links'] = links unless links.blank?
 
-      links_hash
+      rel_hash
     end
 
     def format_key(key)
@@ -270,8 +270,8 @@ module JSONAPI
             end
           end
 
-          lo = link_object(source, relationship, rids, include_data)
-          hash[format_key(name)] = lo unless lo.blank?
+          ro = relationship_object(source, relationship, rids, include_data)
+          hash[format_key(name)] = ro unless ro.blank?
         end
       end
     end
@@ -350,7 +350,7 @@ module JSONAPI
       }
     end
 
-    def link_object_to_one(source, relationship, rid, include_data)
+    def relationship_object_to_one(source, relationship, rid, include_data)
       link_object_hash = {}
 
       links = default_relationship_links(source, relationship)
@@ -360,7 +360,7 @@ module JSONAPI
       link_object_hash
     end
 
-    def link_object_to_many(source, relationship, rids, include_data)
+    def relationship_object_to_many(source, relationship, rids, include_data)
       link_object_hash = {}
 
       links = default_relationship_links(source, relationship)
@@ -369,11 +369,11 @@ module JSONAPI
       link_object_hash
     end
 
-    def link_object(source, relationship, rid, include_data)
+    def relationship_object(source, relationship, rid, include_data)
       if relationship.is_a?(JSONAPI::Relationship::ToOne)
-        link_object_to_one(source, relationship, rid, include_data)
+        relationship_object_to_one(source, relationship, rid, include_data)
       elsif relationship.is_a?(JSONAPI::Relationship::ToMany)
-        link_object_to_many(source, relationship, rid, include_data)
+        relationship_object_to_many(source, relationship, rid, include_data)
       end
     end
 

--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -243,7 +243,7 @@ module JSONAPI
 
     def links_hash(source)
       links = custom_links_hash(source)
-      if !links.key?('self') && source.class.build_default_links?
+      if !links.key?('self') && !source.class.exclude_link?(:self)
         links['self'] = link_builder.self_link(source)
       end
       links.compact
@@ -321,12 +321,10 @@ module JSONAPI
     end
 
     def default_relationship_links(source, relationship)
-      if relationship.build_default_links?
-        {
-          'self' => self_link(source, relationship),
-          'related' => related_link(source, relationship)
-        }.compact
-      end
+      links = {}
+      links['self'] = self_link(source, relationship) unless relationship.exclude_link?(:self)
+      links['related'] = related_link(source, relationship) unless relationship.exclude_link?(:related)
+      links.compact
     end
 
     def to_many_linkage(rids)

--- a/lib/jsonapi/response_document.rb
+++ b/lib/jsonapi/response_document.rb
@@ -118,10 +118,15 @@ module JSONAPI
         result.pagination_params.each_pair do |link_name, params|
           if result.is_a?(JSONAPI::RelatedResourcesSetOperationResult)
             relationship = result.source_resource.class._relationships[result._type.to_sym]
-            @top_level_links[link_name] = serializer.link_builder.relationships_related_link(result.source_resource, relationship, query_params(params))
+            if relationship.build_default_links?
+              link = serializer.link_builder.relationships_related_link(result.source_resource, relationship, query_params(params))
+            end
           else
-            @top_level_links[link_name] = serializer.query_link(query_params(params))
+            if serializer.link_builder.primary_resource_klass.build_default_links?
+              link = serializer.link_builder.query_link(query_params(params))
+            end
           end
+          @top_level_links[link_name] = link unless link.blank?
         end
       end
     end

--- a/lib/jsonapi/response_document.rb
+++ b/lib/jsonapi/response_document.rb
@@ -118,11 +118,11 @@ module JSONAPI
         result.pagination_params.each_pair do |link_name, params|
           if result.is_a?(JSONAPI::RelatedResourcesSetOperationResult)
             relationship = result.source_resource.class._relationships[result._type.to_sym]
-            if relationship.build_default_links?
+            unless relationship.exclude_link?(link_name)
               link = serializer.link_builder.relationships_related_link(result.source_resource, relationship, query_params(params))
             end
           else
-            if serializer.link_builder.primary_resource_klass.build_default_links?
+            unless serializer.link_builder.primary_resource_klass.exclude_link?(link_name)
               link = serializer.link_builder.query_link(query_params(params))
             end
           end

--- a/lib/jsonapi/routing_ext.rb
+++ b/lib/jsonapi/routing_ext.rb
@@ -154,7 +154,8 @@ module ActionDispatch
 
           if methods.include?(:show)
             match "relationships/#{formatted_relationship_name}", controller: options[:controller],
-                  action: 'show_relationship', relationship: link_type.to_s, via: [:get]
+                  action: 'show_relationship', relationship: link_type.to_s, via: [:get],
+                  as: "relationships/#{link_type}"
           end
 
           if res.mutable?
@@ -182,7 +183,8 @@ module ActionDispatch
 
           if methods.include?(:show)
             match "relationships/#{formatted_relationship_name}", controller: options[:controller],
-                  action: 'show_relationship', relationship: link_type.to_s, via: [:get]
+                  action: 'show_relationship', relationship: link_type.to_s, via: [:get],
+                  as: "relationships/#{link_type}"
           end
 
           if res.mutable?
@@ -221,7 +223,8 @@ module ActionDispatch
 
           match formatted_relationship_name, controller: options[:controller],
                 relationship: relationship.name, source: resource_type_with_module_prefix(source._type),
-                action: 'show_related_resource', via: [:get]
+                action: 'show_related_resource', via: [:get],
+                as: relationship_name
         end
 
         def jsonapi_related_resources(*relationship)
@@ -238,7 +241,8 @@ module ActionDispatch
           match formatted_relationship_name,
                 controller: options[:controller],
                 relationship: relationship.name, source: resource_type_with_module_prefix(source._type),
-                action: 'index_related_resources', via: [:get]
+                action: 'index_related_resources', via: [:get],
+                as: relationship_name
         end
 
         protected

--- a/lib/jsonapi/routing_ext.rb
+++ b/lib/jsonapi/routing_ext.rb
@@ -20,6 +20,10 @@ module ActionDispatch
           @resource_type = resources.first
           res = JSONAPI::Resource.resource_klass_for(resource_type_with_module_prefix(@resource_type))
 
+          unless res.singleton?
+            warn "Singleton routes created for non singleton resource #{res}. Links may not be generated correctly."
+          end
+
           options = resources.extract_options!.dup
           options[:controller] ||= @resource_type
           options.merge!(res.routing_resource_options)
@@ -79,6 +83,10 @@ module ActionDispatch
         def jsonapi_resources(*resources, &_block)
           @resource_type = resources.first
           res = JSONAPI::Resource.resource_klass_for(resource_type_with_module_prefix(@resource_type))
+
+          if res.singleton?
+            warn "Singleton resource #{res} should use `jsonapi_resource` instead."
+          end
 
           options = resources.extract_options!.dup
           options[:controller] ||= @resource_type

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -2751,6 +2751,24 @@ class BooksControllerTest < ActionController::TestCase
   end
 end
 
+class Api::V5::PostsControllerTest < ActionController::TestCase
+  def test_show_post_no_relationship_routes_exludes_relationships
+    assert_cacheable_get :show, params: {id: '1'}
+    assert_response :success
+    assert_nil json_response['data']['relationships']
+  end
+
+  def test_show_post_no_relationship_route_include
+    get :show, params: {id: '1', include: 'author'}
+    assert_response :success
+    assert_equal '1001', json_response['data']['relationships']['author']['data']['id']
+    assert_nil json_response['data']['relationships']['tags']
+    assert_equal '1001', json_response['included'][0]['id']
+    assert_equal 'people', json_response['included'][0]['type']
+    assert_equal 'joe@xyz.fake', json_response['included'][0]['attributes']['email']
+  end
+end
+
 class Api::V5::AuthorsControllerTest < ActionController::TestCase
   def test_get_person_as_author
     assert_cacheable_get :index, params: {filter: {id: '1001'}}
@@ -2950,12 +2968,16 @@ end
 
 class Api::V2::PreferencesControllerTest < ActionController::TestCase
   def test_show_singleton_resource_without_id
+    $test_user = Person.find(1001)
+
     assert_cacheable_get :show
     assert_response :success
   end
 
   def test_update_singleton_resource_without_id
     set_content_type_header!
+    $test_user = Person.find(1001)
+
     patch :update, params: {
       data: {
         id: "1",

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -2758,6 +2758,33 @@ class Api::V5::PostsControllerTest < ActionController::TestCase
     assert_nil json_response['data']['relationships']
   end
 
+  def test_exclude_resource_links
+    assert_cacheable_get :show, params: {id: '1'}
+    assert_response :success
+    assert_nil json_response['data']['relationships']
+    assert_equal 1, json_response['data']['links'].length
+
+    Api::V5::PostResource.exclude_links :default
+    assert_cacheable_get :show, params: {id: '1'}
+    assert_response :success
+    assert_nil json_response['data']['relationships']
+    assert_nil json_response['data']['links']
+
+    Api::V5::PostResource.exclude_links [:self]
+    assert_cacheable_get :show, params: {id: '1'}
+    assert_response :success
+    assert_nil json_response['data']['relationships']
+    assert_nil json_response['data']['links']
+
+    Api::V5::PostResource.exclude_links :none
+    assert_cacheable_get :show, params: {id: '1'}
+    assert_response :success
+    assert_nil json_response['data']['relationships']
+    assert_equal 1, json_response['data']['links'].length
+  ensure
+    Api::V5::PostResource.exclude_links :none
+  end
+
   def test_show_post_no_relationship_route_include
     get :show, params: {id: '1', include: 'author'}
     assert_response :success

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -1728,86 +1728,6 @@ class AuthorDetailResource < JSONAPI::Resource
   attributes :author_stuff
 end
 
-class SimpleCustomLinkResource < JSONAPI::Resource
-  model_name 'Post'
-  attributes :title, :body, :subject
-
-  def subject
-    @model.title
-  end
-
-  has_one :writer, foreign_key: 'author_id', class_name: 'Writer'
-  has_one :section
-  has_many :comments, acts_as_set: false
-
-  filters :writer
-
-  def custom_links(options)
-    { raw: options[:serializer].link_builder.self_link(self) + "/raw" }
-  end
-end
-
-class CustomLinkWithRelativePathOptionResource < JSONAPI::Resource
-  model_name 'Post'
-  attributes :title, :body, :subject
-
-  def subject
-    @model.title
-  end
-
-  has_one :writer, foreign_key: 'author_id', class_name: 'Writer'
-  has_one :section
-  has_many :comments, acts_as_set: false
-
-  filters :writer
-
-  def custom_links(options)
-    { raw: options[:serializer].link_builder.self_link(self) + "/super/duper/path.xml" }
-  end
-end
-
-class CustomLinkWithIfCondition < JSONAPI::Resource
-  model_name 'Post'
-  attributes :title, :body, :subject
-
-  def subject
-    @model.title
-  end
-
-  has_one :writer, foreign_key: 'author_id', class_name: 'Writer'
-  has_one :section
-  has_many :comments, acts_as_set: false
-
-  filters :writer
-
-  def custom_links(options)
-    if title == "JR Solves your serialization woes!"
-      {conditional_custom_link: options[:serializer].link_builder.self_link(self) + "/conditional/link.json"}
-    end
-  end
-end
-
-class CustomLinkWithLambda < JSONAPI::Resource
-  model_name 'Post'
-  attributes :title, :body, :subject, :created_at
-
-  def subject
-    @model.title
-  end
-
-  has_one :writer, foreign_key: 'author_id', class_name: 'Writer'
-  has_one :section
-  has_many :comments, acts_as_set: false
-
-  filters :writer
-
-  def custom_links(options)
-    {
-      link_to_external_api: "http://external-api.com/posts/#{ created_at.year }/#{ created_at.month }/#{ created_at.day }-#{ subject.gsub(' ', '-') }"
-    }
-  end
-end
-
 module Api
   module V1
     class WriterResource < JSONAPI::Resource
@@ -1840,6 +1760,15 @@ module Api
       end
 
       filters :writer
+
+      def custom_links(options)
+        self_link = options[:serializer].link_builder.self_link(self)
+        self_link ||= ''
+        {
+          'self' => self_link + '?secret=true',
+          'raw' => self_link + "/raw"
+        }
+      end
     end
 
     class PersonResource < PersonResource; end
@@ -1865,6 +1794,14 @@ end
 module Api
   module V2
     class PreferencesResource < PreferencesResource; end
+    class SectionResource < SectionResource; end
+    class TagResource < TagResource; end
+    class CommentResource < CommentResource; end
+    class VehicleResource < VehicleResource; end
+    class CarResource < CarResource; end
+    class BoatResource < BoatResource; end
+    class HairCutResource < HairCutResource; end
+    class ExpenseEntryResource < ExpenseEntryResource; end
 
     class PersonResource < PersonResource
       has_many :book_comments
@@ -2296,35 +2233,55 @@ end
 module MyEngine
   module Api
     module V1
+      class PostResource < PostResource
+      end
+
       class PersonResource < JSONAPI::Resource
+        has_many :posts
       end
     end
   end
 
   module AdminApi
     module V1
+      class PostResource < PostResource
+      end
+
       class PersonResource < JSONAPI::Resource
+        has_many :posts
       end
     end
   end
 
   module DasherizedNamespace
     module V1
+      class PostResource < PostResource
+      end
+
       class PersonResource < JSONAPI::Resource
+        has_many :posts
       end
     end
   end
 
   module OptionalNamespace
     module V1
+      class PostResource < PostResource
+      end
+
       class PersonResource < JSONAPI::Resource
+        has_many :posts
       end
     end
   end
 end
 
 module ApiV2Engine
+  class PostResource < PostResource
+  end
+
   class PersonResource < JSONAPI::Resource
+    has_many :posts
   end
 end
 

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -1994,7 +1994,7 @@ module Api
 
       has_one :author, class_name: 'Person', exclude_links: [:self, "related"]
       has_one :section, exclude_links: [:self, :related]
-      has_many :tags, acts_as_set: true, inverse_relationship: :posts, eager_load_on_include: false, exclude_links: [:self, :related]
+      has_many :tags, acts_as_set: true, inverse_relationship: :posts, eager_load_on_include: false, exclude_links: :default
       has_many :comments, acts_as_set: false, inverse_relationship: :post, exclude_links: ["self", :related]
     end
 

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -1992,10 +1992,10 @@ module Api
       attribute :title
       attribute :body
 
-      has_one :author, class_name: 'Person', build_default_links: false
-      has_one :section, build_default_links: false
-      has_many :tags, acts_as_set: true, inverse_relationship: :posts, eager_load_on_include: false, build_default_links: false
-      has_many :comments, acts_as_set: false, inverse_relationship: :post, build_default_links: false
+      has_one :author, class_name: 'Person', exclude_links: [:self, "related"]
+      has_one :section, exclude_links: [:self, :related]
+      has_many :tags, acts_as_set: true, inverse_relationship: :posts, eager_load_on_include: false, exclude_links: [:self, :related]
+      has_many :comments, acts_as_set: false, inverse_relationship: :post, exclude_links: ["self", :related]
     end
 
     class AuthorResource < JSONAPI::Resource

--- a/test/fixtures/people.yml
+++ b/test/fixtures/people.yml
@@ -30,6 +30,7 @@ e:
   email: lib@xyz.fake
   date_joined: <%= DateTime.parse('2013-11-30 4:20:00 UTC +00:00') %>
   book_admin: true
+  preferences_id: 55
 
 x:
   id: 1000

--- a/test/fixtures/preferences.yml
+++ b/test/fixtures/preferences.yml
@@ -1,6 +1,7 @@
 a:
   id: 1
   advanced_mode: false
+  nickname: Joe Schmoe
 
 b:
   id: 2
@@ -12,3 +13,8 @@ c:
 d:
   id: 4
   advanced_mode: false
+
+wilma:
+  id: 55
+  advanced_mode: true
+  nickname: Wilma

--- a/test/integration/requests/request_test.rb
+++ b/test/integration/requests/request_test.rb
@@ -5,6 +5,7 @@ class RequestTest < ActionDispatch::IntegrationTest
     DatabaseCleaner.start
     JSONAPI.configuration.json_key_format = :underscored_key
     JSONAPI.configuration.route_format = :underscored_route
+    JSONAPI.configuration.warn_on_missing_routes = false
     Api::V2::BookResource.paginator :offset
     $test_user = Person.find(1001)
   end
@@ -15,6 +16,7 @@ class RequestTest < ActionDispatch::IntegrationTest
 
   def after_teardown
     JSONAPI.configuration.route_format = :underscored_route
+    JSONAPI.configuration.warn_on_missing_routes = true
   end
 
   def test_get
@@ -188,7 +190,6 @@ class RequestTest < ActionDispatch::IntegrationTest
   def test_get_camelized_route_and_links
     original_config = JSONAPI.configuration.dup
     JSONAPI.configuration.json_key_format = :camelized_key
-    JSONAPI.configuration.route_format = :camelized_route
     assert_cacheable_jsonapi_get '/api/v4/expenseEntries/1/relationships/isoCurrency'
     assert_hash_equals({'links' => {
                          'self' => 'http://www.example.com/api/v4/expenseEntries/1/relationships/isoCurrency',

--- a/test/integration/requests/request_test.rb
+++ b/test/integration/requests/request_test.rb
@@ -1490,4 +1490,362 @@ class RequestTest < ActionDispatch::IntegrationTest
     assert_equal 'access_cards', included.first['type']
     assert_equal access_card.token, included.first['id']
   end
+
+
+  def test_get_resource_include_singleton_relationship
+    $original_test_user = $test_user
+    $test_user = Person.find(1005)
+
+    assert_cacheable_jsonapi_get '/api/v9/people/1005?include=preferences'
+    assert_jsonapi_response 200
+    assert_hash_equals json_response,
+                       {
+                         "data" => {
+                           "id" => "1005",
+                           "type" => "people",
+                           "links" => {
+                             "self" => "http://www.example.com/api/v9/people/1005"
+                           },
+                           "relationships" => {
+                             "preferences" => {
+                               "links" => {
+                                 "self" => "http://www.example.com/api/v9/people/1005/relationships/preferences",
+                                 "related" => "http://www.example.com/api/v9/people/1005/preferences"
+                               },
+                               "data" => {
+                                 "type" => "preferences",
+                                 "id" => "55"
+                               }
+                             }
+                           }
+                         },
+                         "included" => [
+                           {
+                             "id" => "55",
+                             "type" => "preferences",
+                             "attributes" => {
+                               "nickname" => "Wilma"
+                             },
+                             'relationships' => {
+                               'person' => {
+                                 "links" => {
+                                   "self" => "http://www.example.com/api/v9/preferences/relationships/person",
+                                   "related" => "http://www.example.com/api/v9/preferences/person"
+                                 }
+                               }
+                             },
+                             "links" => {
+                               "self" => "http://www.example.com/api/v9/preferences"
+                             }
+                           }
+                         ]
+                       }
+  ensure
+    $test_user = $original_test_user
+  end
+
+  def test_caching_included_singleton
+    original_config = JSONAPI.configuration.dup
+
+    Api::V9::PreferencesResource.caching(true)
+    Api::V9::PersonResource.caching(true)
+
+    JSONAPI.configuration.resource_cache = ActiveSupport::Cache::MemoryStore.new
+
+    $original_test_user = $test_user
+    $test_user = Person.find(1005)
+
+    get "/api/v9/people/#{$test_user.id}?include=preferences"
+    assert_jsonapi_response 200
+    assert_hash_equals json_response,
+                       {
+                         "data" => {
+                           "id" => "1005",
+                           "type" => "people",
+                           "links" => {
+                             "self" => "http://www.example.com/api/v9/people/1005"
+                           },
+                           "relationships" => {
+                             "preferences" => {
+                               "links" => {
+                                 "self" => "http://www.example.com/api/v9/people/1005/relationships/preferences",
+                                 "related" => "http://www.example.com/api/v9/people/1005/preferences"
+                               },
+                               "data" => {
+                                 "type" => "preferences",
+                                 "id" => "55"
+                               }
+                             }
+                           }
+                         },
+                         "included" => [
+                           {
+                             "id" => "55",
+                             "type" => "preferences",
+                             "attributes" => {
+                               "nickname" => "Wilma"
+                             },
+                             'relationships' => {
+                               'person' => {
+                                 "links" => {
+                                   "self" => "http://www.example.com/api/v9/preferences/relationships/person",
+                                   "related" => "http://www.example.com/api/v9/preferences/person"
+                                 }
+                               }
+                             },
+                             "links" => {
+                               "self" => "http://www.example.com/api/v9/preferences"
+                             }
+                           }
+                         ]
+                       }
+
+    $test_user = Person.find(1001)
+    assert_equal 2, JSONAPI.configuration.resource_cache.instance_variable_get(:@key_access).length
+
+    get "/api/v9/people/#{$test_user.id}?include=preferences"
+    assert_jsonapi_response 200
+    assert_hash_equals json_response,
+                       {
+                         "data" => {
+                           "id" => "1001",
+                           "type" => "people",
+                           "links" => {
+                             "self" => "http://www.example.com/api/v9/people/1001"
+                           },
+                           "relationships" => {
+                             "preferences" => {
+                               "links" => {
+                                 "self" => "http://www.example.com/api/v9/people/1001/relationships/preferences",
+                                 "related" => "http://www.example.com/api/v9/people/1001/preferences"
+                               },
+                               "data" => {
+                                 "type" => "preferences",
+                                 "id" => "1"
+                               }
+                             }
+                           }
+                         },
+                         "included" => [
+                           {
+                             "id" => "1",
+                             "type" => "preferences",
+                             "attributes" => {
+                               "nickname" => "Joe Schmoe"
+                             },
+                             'relationships' => {
+                               'person' => {
+                                 "links" => {
+                                   "self" => "http://www.example.com/api/v9/preferences/relationships/person",
+                                   "related" => "http://www.example.com/api/v9/preferences/person"
+                                 }
+                               }
+                             },
+                             "links" => {
+                               "self" => "http://www.example.com/api/v9/preferences"
+                             }
+                           }
+                         ]
+                       }
+
+    assert_equal 4, JSONAPI.configuration.resource_cache.instance_variable_get(:@key_access).length
+
+  ensure
+    JSONAPI.configuration = original_config
+    $test_user = $original_test_user
+
+    Api::V9::PreferencesResource.caching(false)
+    Api::V9::PersonResource.caching(false)
+  end
+
+  def test_caching_singleton_primary
+    original_config = JSONAPI.configuration.dup
+
+    Api::V9::PreferencesResource.caching(true)
+    Api::V9::PersonResource.caching(true)
+
+    JSONAPI.configuration.resource_cache = ActiveSupport::Cache::MemoryStore.new
+
+    $original_test_user = $test_user
+    $test_user = Person.find(1005)
+
+    get "/api/v9/preferences"
+    assert_jsonapi_response 200
+    assert_hash_equals json_response,
+                       {
+                         "data" => {
+                           "id" => "55",
+                           "type" => "preferences",
+                           "attributes" => {
+                             "nickname" => "Wilma"
+                           },
+                           'relationships' => {
+                             'person' => {
+                               "links" => {
+                                 "self" => "http://www.example.com/api/v9/preferences/relationships/person",
+                                 "related" => "http://www.example.com/api/v9/preferences/person"
+                               }
+                             }
+                           },
+                           "links" => {
+                             "self" => "http://www.example.com/api/v9/preferences"
+                           }
+                         }
+                       }
+
+    assert_equal 1, JSONAPI.configuration.resource_cache.instance_variable_get(:@key_access).length
+
+    $test_user = Person.find(1001)
+
+    get "/api/v9/preferences"
+    assert_jsonapi_response 200
+    assert_hash_equals json_response,
+                       {
+                         "data" => {
+                           "id" => "1",
+                           "type" => "preferences",
+                           "attributes" => {
+                             "nickname" => "Joe Schmoe"
+                           },
+                           'relationships' => {
+                             'person' => {
+                               "links" => {
+                                 "self" => "http://www.example.com/api/v9/preferences/relationships/person",
+                                 "related" => "http://www.example.com/api/v9/preferences/person"
+                               }
+                             }
+                           },
+                           "links" => {
+                             "self" => "http://www.example.com/api/v9/preferences"
+                           }
+                         }
+                       }
+
+    assert_equal 2, JSONAPI.configuration.resource_cache.instance_variable_get(:@key_access).length
+
+  ensure
+    JSONAPI.configuration = original_config
+    $test_user = $original_test_user
+
+    Api::V9::PreferencesResource.caching(false)
+    Api::V9::PersonResource.caching(false)
+  end
+
+  def test_patch_singleton
+    original_config = JSONAPI.configuration.dup
+
+    Api::V9::PreferencesResource.caching(true)
+    Api::V9::PersonResource.caching(true)
+
+    JSONAPI.configuration.resource_cache = ActiveSupport::Cache::MemoryStore.new
+
+    $original_test_user = $test_user
+    $test_user = Person.find(1001)
+
+    patch '/api/v9/preferences', params:
+      {
+        'data' => {
+          'type' => 'preferences',
+          'id' => '1',
+          'attributes' => {
+            'nickname' => 'Joey'
+          },
+          'relationships' => {
+            'person' => {
+              "links" => {
+                "self" => "http://www.example.com/api/v9/preferences/relationships/person",
+                "related" => "http://www.example.com/api/v9/preferences/person"
+              }
+            }
+          }
+        }
+      }.to_json,
+          headers: {
+            'CONTENT_TYPE' => JSONAPI::MEDIA_TYPE,
+            'Accept' => JSONAPI::MEDIA_TYPE
+          }
+
+    assert_equal 200, status
+    prefs = Preferences.find(1)
+    assert_equal 'Joey', prefs.nickname
+
+  ensure
+    JSONAPI.configuration = original_config
+    $test_user = $original_test_user
+
+    Api::V9::PreferencesResource.caching(false)
+    Api::V9::PersonResource.caching(false)
+  end
+
+  def test_create_singleton
+    original_config = JSONAPI.configuration.dup
+
+    Api::V9::PreferencesResource.caching(true)
+    Api::V9::PersonResource.caching(true)
+
+    JSONAPI.configuration.resource_cache = ActiveSupport::Cache::MemoryStore.new
+
+    $original_test_user = $test_user
+    $test_user = Person.find(1004)
+
+    assert_nil $test_user.preferences
+
+    post '/api/v9/preferences', params:
+      {
+        'data' => {
+          'type' => 'preferences',
+          'attributes' => {
+            'nickname' => 'Frank'
+          },
+          'relationships' => {
+            'person' => {'data' => {'type' => 'people', 'id' => '1004'}}
+          }
+        }
+      }.to_json,
+         headers: {
+           'CONTENT_TYPE' => JSONAPI::MEDIA_TYPE,
+           'Accept' => JSONAPI::MEDIA_TYPE
+         }
+
+    assert_equal 201, status
+    assert_equal 'Frank', json_response['data']['attributes']['nickname']
+
+  ensure
+    JSONAPI.configuration = original_config
+    $test_user = $original_test_user
+
+    Api::V9::PreferencesResource.caching(false)
+    Api::V9::PersonResource.caching(false)
+  end
+
+  def test_destroy_singleton
+    original_config = JSONAPI.configuration.dup
+
+    $original_test_user = $test_user
+    $test_user = Person.find(1005)
+
+    init_pref_count = Preferences.count
+    delete '/api/v9/preferences', headers: { 'Accept' => JSONAPI::MEDIA_TYPE }
+    assert_equal 204, status
+    assert_equal init_pref_count - 1, Preferences.count
+    assert_nil headers['Content-Type']
+  ensure
+    JSONAPI.configuration = original_config
+    $test_user = $original_test_user
+  end
+
+  def test_destroy_singleton_not_found
+    original_config = JSONAPI.configuration.dup
+
+    $original_test_user = $test_user
+    $test_user = Person.find(1003)
+
+    init_pref_count = Preferences.count
+    delete '/api/v9/preferences', headers: { 'Accept' => JSONAPI::MEDIA_TYPE }
+    assert_equal 404, status
+    assert_equal init_pref_count, Preferences.count
+  ensure
+    JSONAPI.configuration = original_config
+    $test_user = $original_test_user
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -285,8 +285,17 @@ TestApp.routes.draw do
   jsonapi_resources :doctors
   jsonapi_resources :patients
 
+  jsonapi_resources :access_cards
+  jsonapi_resources :response
+  jsonapi_resources :paragraph
+
+  jsonapi_resources :employees
+  jsonapi_resources :robots
+
   namespace :api do
     jsonapi_resources :boxes
+    jsonapi_resources :things
+    jsonapi_resources :users
 
     namespace :v1 do
       jsonapi_resources :people
@@ -303,6 +312,7 @@ TestApp.routes.draw do
       jsonapi_resources :craters
       jsonapi_resources :preferences
       jsonapi_resources :likes
+      jsonapi_resources :writers
     end
 
     JSONAPI.configuration.route_format = :underscored_route
@@ -316,6 +326,14 @@ TestApp.routes.draw do
       jsonapi_resources :authors
       jsonapi_resources :books
       jsonapi_resources :book_comments
+      #
+      jsonapi_resources :sections
+      jsonapi_resources :comments
+      jsonapi_resources :vehicles
+      jsonapi_resources :cars
+      jsonapi_resources :boats
+      jsonapi_resources :hair_cuts
+      jsonapi_resources :people
     end
 
     namespace :v3 do
@@ -368,6 +386,7 @@ TestApp.routes.draw do
       jsonapi_resources :customers
       jsonapi_resources :purchase_orders
       jsonapi_resources :line_items
+      jsonapi_resources :order_flags
     end
     JSONAPI.configuration.route_format = :underscored_route
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -264,7 +264,7 @@ TestApp.routes.draw do
   jsonapi_resources :planet_types
   jsonapi_resources :moons
   jsonapi_resources :craters
-  jsonapi_resources :preferences
+  jsonapi_resource :preferences
   jsonapi_resources :facts
   jsonapi_resources :categories
   jsonapi_resources :pictures
@@ -310,16 +310,14 @@ TestApp.routes.draw do
       jsonapi_resources :planet_types
       jsonapi_resources :moons
       jsonapi_resources :craters
-      jsonapi_resources :preferences
+      jsonapi_resource :preferences
       jsonapi_resources :likes
       jsonapi_resources :writers
     end
 
     JSONAPI.configuration.route_format = :underscored_route
     namespace :v2 do
-      jsonapi_resources :posts do
-        jsonapi_link :author, except: :destroy
-      end
+      jsonapi_resources :posts
 
       jsonapi_resource :preferences, except: [:create, :destroy]
 
@@ -365,12 +363,20 @@ TestApp.routes.draw do
 
     JSONAPI.configuration.route_format = :dasherized_route
     namespace :v5 do
+      jsonapi_resources :people
+
       jsonapi_resources :posts do
       end
       jsonapi_resources :painters
+      jsonapi_resources :paintings
+      jsonapi_resources :collectors
       jsonapi_resources :authors
+      jsonapi_resources :author_details
       jsonapi_resources :expense_entries
       jsonapi_resources :iso_currencies
+      jsonapi_resources :tags
+      jsonapi_resources :comments
+
 
       jsonapi_resources :employees
 
@@ -401,6 +407,11 @@ TestApp.routes.draw do
 
     namespace :v8 do
       jsonapi_resources :numeros_telefone
+    end
+
+    namespace :v9 do
+      jsonapi_resources :people
+      jsonapi_resource :preferences
     end
   end
 

--- a/test/unit/active_relation_resource_finder/join_manager_test.rb
+++ b/test/unit/active_relation_resource_finder/join_manager_test.rb
@@ -74,9 +74,9 @@ class JoinTreeTest < ActiveSupport::TestCase
 
 
   def test_add_joins_source_relationship_with_custom_apply
-    join_manager = JSONAPI::ActiveRelation::JoinManager.new(resource_klass: Api::V9::PostResource,
-                                                                          source_relationship: Api::V9::PostResource._relationship(:comments))
-    records = Api::V9::PostResource.records({})
+    join_manager = JSONAPI::ActiveRelation::JoinManager.new(resource_klass: Api::V10::PostResource,
+                                                                          source_relationship: Api::V10::PostResource._relationship(:comments))
+    records = Api::V10::PostResource.records({})
     records = join_manager.join(records, {})
 
     if Rails::VERSION::MAJOR >= 5 && Rails::VERSION::MINOR >= 2
@@ -95,8 +95,8 @@ class JoinTreeTest < ActiveSupport::TestCase
         'author' => ['1']
     }
 
-    join_manager = JSONAPI::ActiveRelation::JoinManager.new(resource_klass: Api::V9::PostResource, filters: filters)
-    records = Api::V9::PostResource.records({})
+    join_manager = JSONAPI::ActiveRelation::JoinManager.new(resource_klass: Api::V10::PostResource, filters: filters)
+    records = Api::V10::PostResource.records({})
     records = join_manager.join(records, {})
 
     if Rails::VERSION::MAJOR >= 5 && Rails::VERSION::MINOR >= 2
@@ -106,10 +106,10 @@ class JoinTreeTest < ActiveSupport::TestCase
     end
 
     assert_hash_equals({alias: 'posts', join_type: :root}, join_manager.source_join_details)
-    assert_hash_equals({alias: 'comments', join_type: :left}, join_manager.join_details_by_relationship(Api::V9::PostResource._relationship(:comments)))
-    assert_hash_equals({alias: 'authors_comments', join_type: :left}, join_manager.join_details_by_relationship(Api::V9::CommentResource._relationship(:author)))
-    assert_hash_equals({alias: 'tags', join_type: :left}, join_manager.join_details_by_relationship(Api::V9::CommentResource._relationship(:tags)))
-    assert_hash_equals({alias: 'people', join_type: :left}, join_manager.join_details_by_relationship(Api::V9::PostResource._relationship(:author)))
+    assert_hash_equals({alias: 'comments', join_type: :left}, join_manager.join_details_by_relationship(Api::V10::PostResource._relationship(:comments)))
+    assert_hash_equals({alias: 'authors_comments', join_type: :left}, join_manager.join_details_by_relationship(Api::V10::CommentResource._relationship(:author)))
+    assert_hash_equals({alias: 'tags', join_type: :left}, join_manager.join_details_by_relationship(Api::V10::CommentResource._relationship(:tags)))
+    assert_hash_equals({alias: 'people', join_type: :left}, join_manager.join_details_by_relationship(Api::V10::PostResource._relationship(:author)))
 
     # Now test with different order for the filters
     filters = {
@@ -118,8 +118,8 @@ class JoinTreeTest < ActiveSupport::TestCase
         'comments.tags' => ['1']
     }
 
-    join_manager = JSONAPI::ActiveRelation::JoinManager.new(resource_klass: Api::V9::PostResource, filters: filters)
-    records = Api::V9::PostResource.records({})
+    join_manager = JSONAPI::ActiveRelation::JoinManager.new(resource_klass: Api::V10::PostResource, filters: filters)
+    records = Api::V10::PostResource.records({})
     records = join_manager.join(records, {})
 
     # Note sql is in different order, but aliases should still be right
@@ -129,10 +129,10 @@ class JoinTreeTest < ActiveSupport::TestCase
       assert_equal 'SELECT "posts".* FROM "posts" LEFT OUTER JOIN "people" ON "people"."id" = "posts"."author_id" LEFT OUTER JOIN "comments" ON "comments"."post_id" = "posts"."id" LEFT OUTER JOIN "people" "authors_comments" ON "authors_comments"."id" = "comments"."author_id" LEFT OUTER JOIN "comments_tags" ON "comments_tags"."comment_id" = "comments"."id" LEFT OUTER JOIN "tags" ON "tags"."id" = "comments_tags"."tag_id" WHERE "comments"."approved" = \'t\' AND "author"."special" = \'t\'', records.to_sql
     end
     assert_hash_equals({alias: 'posts', join_type: :root}, join_manager.source_join_details)
-    assert_hash_equals({alias: 'comments', join_type: :left}, join_manager.join_details_by_relationship(Api::V9::PostResource._relationship(:comments)))
-    assert_hash_equals({alias: 'authors_comments', join_type: :left}, join_manager.join_details_by_relationship(Api::V9::CommentResource._relationship(:author)))
-    assert_hash_equals({alias: 'tags', join_type: :left}, join_manager.join_details_by_relationship(Api::V9::CommentResource._relationship(:tags)))
-    assert_hash_equals({alias: 'people', join_type: :left}, join_manager.join_details_by_relationship(Api::V9::PostResource._relationship(:author)))
+    assert_hash_equals({alias: 'comments', join_type: :left}, join_manager.join_details_by_relationship(Api::V10::PostResource._relationship(:comments)))
+    assert_hash_equals({alias: 'authors_comments', join_type: :left}, join_manager.join_details_by_relationship(Api::V10::CommentResource._relationship(:author)))
+    assert_hash_equals({alias: 'tags', join_type: :left}, join_manager.join_details_by_relationship(Api::V10::CommentResource._relationship(:tags)))
+    assert_hash_equals({alias: 'people', join_type: :left}, join_manager.join_details_by_relationship(Api::V10::PostResource._relationship(:author)))
 
     # Easier to read SQL to show joins are the same, but in different order
     # Pass 1
@@ -159,8 +159,8 @@ class JoinTreeTest < ActiveSupport::TestCase
         'author.foo' => ['1']
     }
 
-    join_manager = JSONAPI::ActiveRelation::JoinManager.new(resource_klass: Api::V9::PostResource, filters: filters)
-    records = Api::V9::PostResource.records({})
+    join_manager = JSONAPI::ActiveRelation::JoinManager.new(resource_klass: Api::V10::PostResource, filters: filters)
+    records = Api::V10::PostResource.records({})
     records = join_manager.join(records, {})
 
     if Rails::VERSION::MAJOR >= 5 && Rails::VERSION::MINOR >= 2
@@ -170,18 +170,18 @@ class JoinTreeTest < ActiveSupport::TestCase
     end
 
     assert_hash_equals({alias: 'posts', join_type: :root}, join_manager.source_join_details)
-    assert_hash_equals({alias: 'comments', join_type: :left}, join_manager.join_details_by_relationship(Api::V9::PostResource._relationship(:comments)))
-    assert_hash_equals({alias: 'authors_comments', join_type: :left}, join_manager.join_details_by_relationship(Api::V9::CommentResource._relationship(:author)))
-    assert_hash_equals({alias: 'tags', join_type: :left}, join_manager.join_details_by_relationship(Api::V9::CommentResource._relationship(:tags)))
-    assert_hash_equals({alias: 'people', join_type: :left}, join_manager.join_details_by_relationship(Api::V9::PostResource._relationship(:author)))
+    assert_hash_equals({alias: 'comments', join_type: :left}, join_manager.join_details_by_relationship(Api::V10::PostResource._relationship(:comments)))
+    assert_hash_equals({alias: 'authors_comments', join_type: :left}, join_manager.join_details_by_relationship(Api::V10::CommentResource._relationship(:author)))
+    assert_hash_equals({alias: 'tags', join_type: :left}, join_manager.join_details_by_relationship(Api::V10::CommentResource._relationship(:tags)))
+    assert_hash_equals({alias: 'people', join_type: :left}, join_manager.join_details_by_relationship(Api::V10::PostResource._relationship(:author)))
   end
 
   def test_add_joins_with_sub_relationship
     relationships = %w(author author.comments tags)
 
-    join_manager = JSONAPI::ActiveRelation::JoinManager.new(resource_klass: Api::V9::PostResource, relationships: relationships,
-                                                                          source_relationship: Api::V9::PostResource._relationship(:comments))
-    records = Api::V9::PostResource.records({})
+    join_manager = JSONAPI::ActiveRelation::JoinManager.new(resource_klass: Api::V10::PostResource, relationships: relationships,
+                                                                          source_relationship: Api::V10::PostResource._relationship(:comments))
+    records = Api::V10::PostResource.records({})
     records = join_manager.join(records, {})
 
     if Rails::VERSION::MAJOR >= 5 && Rails::VERSION::MINOR >= 2
@@ -191,10 +191,10 @@ class JoinTreeTest < ActiveSupport::TestCase
     end
 
     assert_hash_equals({alias: 'comments', join_type: :inner}, join_manager.source_join_details)
-    assert_hash_equals({alias: 'comments', join_type: :inner}, join_manager.join_details_by_relationship(Api::V9::PostResource._relationship(:comments)))
-    assert_hash_equals({alias: 'people', join_type: :left}, join_manager.join_details_by_relationship(Api::V9::CommentResource._relationship(:author)))
-    assert_hash_equals({alias: 'tags', join_type: :left}, join_manager.join_details_by_relationship(Api::V9::CommentResource._relationship(:tags)))
-    assert_hash_equals({alias: 'comments_people', join_type: :left}, join_manager.join_details_by_relationship(Api::V9::PersonResource._relationship(:comments)))
+    assert_hash_equals({alias: 'comments', join_type: :inner}, join_manager.join_details_by_relationship(Api::V10::PostResource._relationship(:comments)))
+    assert_hash_equals({alias: 'people', join_type: :left}, join_manager.join_details_by_relationship(Api::V10::CommentResource._relationship(:author)))
+    assert_hash_equals({alias: 'tags', join_type: :left}, join_manager.join_details_by_relationship(Api::V10::CommentResource._relationship(:tags)))
+    assert_hash_equals({alias: 'comments_people', join_type: :left}, join_manager.join_details_by_relationship(Api::V10::PersonResource._relationship(:comments)))
   end
 
   def test_add_joins_with_sub_relationship_and_filters

--- a/test/unit/resource/relationship_test.rb
+++ b/test/unit/resource/relationship_test.rb
@@ -107,4 +107,56 @@ class HasOneRelationshipTest < ActiveSupport::TestCase
     refute CallableBlogPostsResource._relationship(:comments).allow_include?(admin: false)
   end
 
+  def test_exclude_links_on_relationship
+    relationship = JSONAPI::Relationship::ToOne.new "foo", exclude_links: :none
+    assert_equal [], relationship._exclude_links
+    refute relationship.exclude_link?(:self)
+    refute relationship.exclude_link?("self")
+
+    relationship = JSONAPI::Relationship::ToOne.new "foo", exclude_links: :default
+    assert_equal [:self, :related], relationship._exclude_links
+    assert relationship.exclude_link?(:self)
+    assert relationship.exclude_link?("self")
+    assert relationship.exclude_link?(:related)
+    assert relationship.exclude_link?("related")
+
+    relationship = JSONAPI::Relationship::ToOne.new "foo", exclude_links: "none"
+    assert_equal [], relationship._exclude_links
+    refute relationship.exclude_link?(:self)
+    refute relationship.exclude_link?("self")
+
+    relationship = JSONAPI::Relationship::ToOne.new "foo", exclude_links: "default"
+    assert_equal [:self, :related], relationship._exclude_links
+    assert relationship.exclude_link?(:self)
+    assert relationship.exclude_link?("self")
+
+    relationship = JSONAPI::Relationship::ToOne.new "foo", exclude_links: :none
+    assert_equal [], relationship._exclude_links
+    refute relationship.exclude_link?(:self)
+    refute relationship.exclude_link?("self")
+
+    relationship = JSONAPI::Relationship::ToOne.new "foo", exclude_links: [:self]
+    assert_equal [:self], relationship._exclude_links
+    assert relationship.exclude_link?(:self)
+    assert relationship.exclude_link?("self")
+
+    relationship = JSONAPI::Relationship::ToOne.new "foo", exclude_links: :none
+    assert_equal [], relationship._exclude_links
+    refute relationship.exclude_link?(:self)
+    refute relationship.exclude_link?("self")
+
+    relationship = JSONAPI::Relationship::ToOne.new "foo", exclude_links: ["self", :related]
+    assert_equal [:self, :related], relationship._exclude_links
+    assert relationship.exclude_link?(:self)
+    assert relationship.exclude_link?("self")
+
+    relationship = JSONAPI::Relationship::ToOne.new "foo", exclude_links: []
+    assert_equal [], relationship._exclude_links
+    refute relationship.exclude_link?(:self)
+    refute relationship.exclude_link?("self")
+
+    assert_raises do
+      JSONAPI::Relationship::ToOne.new "foo", :self
+    end
+  end
 end

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -564,6 +564,60 @@ class ResourceTest < ActiveSupport::TestCase
     refute(PostResource.sortable_field?(:color))
   end
 
+  def test_exclude_links_on_resource
+    Api::V5::PostResource.exclude_links :none
+    assert_equal [], Api::V5::PostResource._exclude_links
+    refute Api::V5::PostResource.exclude_link?(:self)
+    refute Api::V5::PostResource.exclude_link?("self")
+
+    Api::V5::PostResource.exclude_links :default
+    assert_equal [:self], Api::V5::PostResource._exclude_links
+    assert Api::V5::PostResource.exclude_link?(:self)
+    assert Api::V5::PostResource.exclude_link?("self")
+
+    Api::V5::PostResource.exclude_links "none"
+    assert_equal [], Api::V5::PostResource._exclude_links
+    refute Api::V5::PostResource.exclude_link?(:self)
+    refute Api::V5::PostResource.exclude_link?("self")
+
+    Api::V5::PostResource.exclude_links "default"
+    assert_equal [:self], Api::V5::PostResource._exclude_links
+    assert Api::V5::PostResource.exclude_link?(:self)
+    assert Api::V5::PostResource.exclude_link?("self")
+
+    Api::V5::PostResource.exclude_links :none
+    assert_equal [], Api::V5::PostResource._exclude_links
+    refute Api::V5::PostResource.exclude_link?(:self)
+    refute Api::V5::PostResource.exclude_link?("self")
+
+    Api::V5::PostResource.exclude_links [:self]
+    assert_equal [:self], Api::V5::PostResource._exclude_links
+    assert Api::V5::PostResource.exclude_link?(:self)
+    assert Api::V5::PostResource.exclude_link?("self")
+
+    Api::V5::PostResource.exclude_links :none
+    assert_equal [], Api::V5::PostResource._exclude_links
+    refute Api::V5::PostResource.exclude_link?(:self)
+    refute Api::V5::PostResource.exclude_link?("self")
+
+    Api::V5::PostResource.exclude_links ["self"]
+    assert_equal [:self], Api::V5::PostResource._exclude_links
+    assert Api::V5::PostResource.exclude_link?(:self)
+    assert Api::V5::PostResource.exclude_link?("self")
+
+    Api::V5::PostResource.exclude_links []
+    assert_equal [], Api::V5::PostResource._exclude_links
+    refute Api::V5::PostResource.exclude_link?(:self)
+    refute Api::V5::PostResource.exclude_link?("self")
+
+    assert_raises do
+      Api::V5::PostResource.exclude_links :self
+    end
+
+  ensure
+    Api::V5::PostResource.exclude_links :none
+  end
+
   def test_singleton_options
     TestSingletonResource.singleton true
     assert TestSingletonResource.singleton?

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -58,6 +58,9 @@ class FelineResource < JSONAPI::Resource
   has_one :father, class_name: 'Cat'
 end
 
+class TestSingletonResource < JSONAPI::Resource
+end
+
 module MyModule
   class MyNamespacedResource < JSONAPI::Resource
     model_name "Person"
@@ -559,5 +562,30 @@ class ResourceTest < ActiveSupport::TestCase
     assert(PostResource.sortable_field?(:title))
     assert(PostResource.sortable_field?(:body))
     refute(PostResource.sortable_field?(:color))
+  end
+
+  def test_singleton_options
+    TestSingletonResource.singleton true
+    assert TestSingletonResource.singleton?
+    assert TestSingletonResource._singleton_options.blank?
+
+    TestSingletonResource.singleton false
+    refute TestSingletonResource.singleton?
+    assert TestSingletonResource._singleton_options.blank?
+
+    TestSingletonResource.singleton true, a: :b
+    assert TestSingletonResource.singleton?
+    refute TestSingletonResource._singleton_options.blank?
+    assert_equal :b, TestSingletonResource._singleton_options[:a]
+
+    TestSingletonResource.singleton false, c: :d
+    refute TestSingletonResource.singleton?
+    refute TestSingletonResource._singleton_options.blank?
+    assert_equal :d, TestSingletonResource._singleton_options[:c]
+
+    TestSingletonResource.singleton e: :f
+    assert TestSingletonResource.singleton?
+    refute TestSingletonResource._singleton_options.blank?
+    assert_equal :f, TestSingletonResource._singleton_options[:e]
   end
 end

--- a/test/unit/serializer/link_builder_test.rb
+++ b/test/unit/serializer/link_builder_test.rb
@@ -32,16 +32,16 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
     assert_equal MyEngine::Engine,
       JSONAPI::LinkBuilder.new(
         primary_resource_klass: MyEngine::Api::V1::PersonResource
-    ).engine_name
+    ).engine
 
     assert_equal ApiV2Engine::Engine,
       JSONAPI::LinkBuilder.new(
         primary_resource_klass: ApiV2Engine::PersonResource
-    ).engine_name
+    ).engine
 
     assert_nil JSONAPI::LinkBuilder.new(
       primary_resource_klass: Api::V1::PersonResource
-    ).engine_name
+    ).engine
   end
 
   def test_self_link_regular_app
@@ -156,7 +156,7 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
 
     builder       = JSONAPI::LinkBuilder.new(config)
     source        = Api::V1::PersonResource.new(@steve, nil)
-    relationship  = JSONAPI::Relationship::ToMany.new("posts", {})
+    relationship  = JSONAPI::Relationship::ToMany.new("posts", {parent_resource: Api::V1::PersonResource})
     expected_link = "#{ @base_url }/api/v1/people/#{ @steve.id }/relationships/posts"
 
     assert_equal expected_link,
@@ -172,7 +172,7 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
 
     builder       = JSONAPI::LinkBuilder.new(config)
     source        = ApiV2Engine::PersonResource.new(@steve, nil)
-    relationship  = JSONAPI::Relationship::ToMany.new("posts", {})
+    relationship  = JSONAPI::Relationship::ToMany.new("posts", {parent_resource: ApiV2Engine::PersonResource})
     expected_link = "#{ @base_url }/api_v2/people/#{ @steve.id }/relationships/posts"
 
     assert_equal expected_link,
@@ -188,7 +188,7 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
 
     builder       = JSONAPI::LinkBuilder.new(config)
     source        = MyEngine::Api::V1::PersonResource.new(@steve, nil)
-    relationship  = JSONAPI::Relationship::ToMany.new("posts", {})
+    relationship  = JSONAPI::Relationship::ToMany.new("posts", {parent_resource: MyEngine::Api::V1::PersonResource})
     expected_link = "#{ @base_url }/boomshaka/api/v1/people/#{ @steve.id }/relationships/posts"
 
     assert_equal expected_link,
@@ -204,7 +204,7 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
 
     builder       = JSONAPI::LinkBuilder.new(config)
     source        = Api::V1::PersonResource.new(@steve, nil)
-    relationship  = JSONAPI::Relationship::ToMany.new("posts", {})
+    relationship  = JSONAPI::Relationship::ToMany.new("posts", {parent_resource: Api::V1::PersonResource})
     expected_link = "#{ @base_url }/api/v1/people/#{ @steve.id }/posts"
 
     assert_equal expected_link,
@@ -220,7 +220,7 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
 
     builder       = JSONAPI::LinkBuilder.new(config)
     source        = ApiV2Engine::PersonResource.new(@steve, nil)
-    relationship  = JSONAPI::Relationship::ToMany.new("posts", {})
+    relationship  = JSONAPI::Relationship::ToMany.new("posts", {parent_resource: ApiV2Engine::PersonResource})
     expected_link = "#{ @base_url }/api_v2/people/#{ @steve.id }/posts"
 
     assert_equal expected_link,
@@ -236,7 +236,7 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
 
     builder       = JSONAPI::LinkBuilder.new(config)
     source        = MyEngine::Api::V1::PersonResource.new(@steve, nil)
-    relationship  = JSONAPI::Relationship::ToMany.new("posts", {})
+    relationship  = JSONAPI::Relationship::ToMany.new("posts", {parent_resource: MyEngine::Api::V1::PersonResource})
     expected_link = "#{ @base_url }/boomshaka/api/v1/people/#{ @steve.id }/posts"
 
     assert_equal expected_link,
@@ -252,7 +252,7 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
 
     builder       = JSONAPI::LinkBuilder.new(config)
     source        = Api::V1::PersonResource.new(@steve, nil)
-    relationship  = JSONAPI::Relationship::ToMany.new("posts", {})
+    relationship  = JSONAPI::Relationship::ToMany.new("posts", {parent_resource: Api::V1::PersonResource})
     expected_link = "#{ @base_url }/api/v1/people/#{ @steve.id }/posts?page%5Blimit%5D=12&page%5Boffset%5D=0"
     query         = { page: { offset: 0, limit: 12 } }
 
@@ -302,20 +302,6 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
     assert_equal expected_link, builder.query_link(query)
   end
 
-  def test_query_link_for_regular_app_with_optional_scope
-    config = {
-        base_url: @base_url,
-        route_formatter: OptionalRouteFormatter,
-        primary_resource_klass: OptionalNamespace::V1::PersonResource
-    }
-
-    query         = { page: { offset: 0, limit: 12 } }
-    builder       = JSONAPI::LinkBuilder.new(config)
-    expected_link = "#{ @base_url }/optional_namespace/people?page%5Blimit%5D=12&page%5Boffset%5D=0"
-
-    assert_equal expected_link, builder.query_link(query)
-  end
-
   def test_query_link_for_engine
     config = {
       base_url: @base_url,
@@ -354,20 +340,6 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
     query         = { page: { offset: 0, limit: 12 } }
     builder       = JSONAPI::LinkBuilder.new(config)
     expected_link = "#{ @base_url }/boomshaka/dasherized-namespace/v1/people?page%5Blimit%5D=12&page%5Boffset%5D=0"
-
-    assert_equal expected_link, builder.query_link(query)
-  end
-
-  def test_query_link_for_engine_with_optional_scope
-    config = {
-        base_url: @base_url,
-        route_formatter: OptionalRouteFormatter,
-        primary_resource_klass: MyEngine::OptionalNamespace::V1::PersonResource
-    }
-
-    query         = { page: { offset: 0, limit: 12 } }
-    builder       = JSONAPI::LinkBuilder.new(config)
-    expected_link = "#{ @base_url }/boomshaka/optional_namespace/people?page%5Blimit%5D=12&page%5Boffset%5D=0"
 
     assert_equal expected_link, builder.query_link(query)
   end

--- a/test/unit/serializer/serializer_test.rb
+++ b/test/unit/serializer/serializer_test.rb
@@ -100,7 +100,7 @@ class SerializerTest < ActionDispatch::IntegrationTest
     )
   end
 
-  def test_serializer_namespaced_resource
+  def test_serializer_namespaced_resource_with_custom_resource_links
     post_1_identity = JSONAPI::ResourceIdentity.new(Api::V1::PostResource, 1)
     id_tree = JSONAPI::PrimaryResourceIdTree.new
 
@@ -122,7 +122,8 @@ class SerializerTest < ActionDispatch::IntegrationTest
           type: 'posts',
           id: '1',
           links: {
-            self: 'http://example.com/api/v1/posts/1'
+            self: 'http://example.com/api/v1/posts/1?secret=true',
+            raw: 'http://example.com/api/v1/posts/1/raw'
           },
           attributes: {
             title: 'New post',
@@ -302,8 +303,8 @@ class SerializerTest < ActionDispatch::IntegrationTest
              },
              hairCut: {
                links: {
-                 self: '/people/1001/relationships/hairCut',
-                 related: '/people/1001/hairCut'
+                 self: '/people/1001/relationships/hair_cut',
+                 related: '/people/1001/hair_cut'
                }
              },
              vehicles: {
@@ -314,8 +315,8 @@ class SerializerTest < ActionDispatch::IntegrationTest
              },
              expenseEntries: {
                links: {
-                 self: '/people/1001/relationships/expenseEntries',
-                 related: '/people/1001/expenseEntries'
+                 self: '/people/1001/relationships/expense_entries',
+                 related: '/people/1001/expense_entries'
                }
              }
             }
@@ -433,8 +434,8 @@ class SerializerTest < ActionDispatch::IntegrationTest
                         },
                         hair_cut: {
                             links: {
-                                self: '/people/1001/relationships/hairCut',
-                                related: '/people/1001/hairCut'
+                                self: '/people/1001/relationships/hair_cut',
+                                related: '/people/1001/hair_cut'
                             }
                         },
                         vehicles: {
@@ -445,8 +446,8 @@ class SerializerTest < ActionDispatch::IntegrationTest
                         },
                         expense_entries: {
                             links: {
-                                self: '/people/1001/relationships/expenseEntries',
-                                related: '/people/1001/expenseEntries'
+                                self: '/people/1001/relationships/expense_entries',
+                                related: '/people/1001/expense_entries'
                             }
                         }
                     }


### PR DESCRIPTION
Updates the links generation in LinkBuilder to use the routes url helper functions.

Adds `build_default_links` flags for resources and relationships to turn off building the default links.

When a route helper function can not be found the link is not built and a warning is emitted.

Updates the tests to work with this. This is the bulk of the changes.

Adds a `singleton` flag for singleton resources and a configurable way to resolve the singleton ids.

NaiveCache has been removed from the LinksBuilder. I wasn't seeing an appreciable performance difference with the way it was being used, and it may have been harming performance on typical requests where there is not duplication of the generated links. I do think we should be able to add a more long lived caching system that could improve performance.

There could also be a follow-on PR that adds an `except` flag to `jsonapi_relationships` along with a new `jsonapi_relationship` method to make it easier to create non-routable relationships.

### All Submissions:

- [ ] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

Testing this on some real world apps should be done. It should be a drop in replacement. Assuming all resources are routable there should be no changes needed and no warnings emitted.

If there are some relationships or resources that do not have routes these will emit warnings when they are serialized (say from includes). The `build_default_links` option should be used:

```ruby
class EmployeeResource < JSONAPI::Resource
  build_default_links false

  has_many :expense_entries, build_default_links: false
end
```

Singleton resources now need to be declared as singletons with the `singleton` macro. This macro allows the singleton status (true or false) and options to be set. The only current option is a callable for the `singleton_key`.

```ruby
class PreferencesResource < JSONAPI::Resource
 ...

  singleton singleton_key: -> (context) {
    key = context[:current_user].try(:preferences).try(:id)
    raise JSONAPI::Exceptions::RecordNotFound.new(nil) if key.nil?
    key
  }

end
```
It's also possible to override the `singleton_key` method on the resource instead of providing a callable.

Since this PR is on master and most production apps are still running v0.9 you can test with #1247 as well. The core feature should be the same.

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions