### PR TITLE
Add `related` scope to related routes, similar to relationships routes

### DIFF
--- a/lib/jsonapi/link_builder.rb
+++ b/lib/jsonapi/link_builder.rb
@@ -150,12 +150,14 @@ module JSONAPI
 
     def related_url_helper_name(relationship)
       relationship_parts = resource_path_parts_from_class(relationship.parent_resource)
+      relationship_parts << "related"
       relationship_parts << relationship.name
       url_helper_name_from_parts(relationship_parts)
     end
 
     def singleton_related_url_helper_name(relationship)
       relationship_parts = []
+      relationship_parts << "related"
       relationship_parts << relationship.name
       relationship_parts += resource_path_parts_from_class(relationship.parent_resource)
       url_helper_name_from_parts(relationship_parts)

--- a/lib/jsonapi/routing_ext.rb
+++ b/lib/jsonapi/routing_ext.rb
@@ -235,7 +235,7 @@ module ActionDispatch
           match formatted_relationship_name, controller: options[:controller],
                 relationship: relationship.name, source: resource_type_with_module_prefix(source._type),
                 action: 'get_related_resource', via: [:get],
-                as: relationship_name
+                as: "related/#{relationship_name}"
         end
 
         def jsonapi_related_resources(*relationship)
@@ -253,7 +253,7 @@ module ActionDispatch
                 controller: options[:controller],
                 relationship: relationship.name, source: resource_type_with_module_prefix(source._type),
                 action: 'get_related_resources', via: [:get],
-                as: relationship_name
+                as: "related/#{relationship_name}"
         end
 
         protected

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -330,6 +330,14 @@ ActiveRecord::Schema.define do
     t.string :name
     t.belongs_to :painting
   end
+
+  create_table :lists, force: true do |t|
+    t.string :name
+  end
+
+  create_table :list_items, force: true do |t|
+    t.belongs_to :list
+  end
   # special cases
 end
 
@@ -687,6 +695,15 @@ end
 class Collector < ActiveRecord::Base
   belongs_to :painting
 end
+
+class List < ActiveRecord::Base
+  has_many :items, class_name: 'ListItem', inverse_of: :list
+end
+
+class ListItem < ActiveRecord::Base
+  belongs_to :list, inverse_of: :items
+end
+
 ### CONTROLLERS
 class AuthorsController < JSONAPI::ResourceControllerMetal
 end
@@ -992,6 +1009,12 @@ class DoctorsController < JSONAPI::ResourceController
 end
 
 class RespondentController < JSONAPI::ResourceController
+end
+
+class ListsController < JSONAPI::ResourceController
+end
+
+class ListItemsController < JSONAPI::ResourceController
 end
 
 ### RESOURCES
@@ -2079,6 +2102,14 @@ end
 
 class RespondentResource < JSONAPI::Resource
   abstract
+end
+
+class ListResource < JSONAPI::Resource
+  has_many :items, class_name: 'ListItem'
+end
+
+class ListItemResource < JSONAPI::Resource
+  has_one :list
 end
 
 ### PORO Data - don't do this in a production app

--- a/test/integration/routes/routes_test.rb
+++ b/test/integration/routes/routes_test.rb
@@ -191,6 +191,20 @@ class RoutesTest < ActionDispatch::IntegrationTest
                    {controller: 'api/v5/authors', action: 'create_relationship', author_id: '1', relationship: 'posts'})
   end
 
+  def test_routing_list_items_index
+    assert_routing({path: '/list_items', method: :get},
+                   {controller: 'list_items', action: 'index'})
+  end
+
+  def test_routing_list_related_items
+    assert_routing({path: '/lists/1/items', method: :get},
+                   {controller: 'list_items', action: 'get_related_resources', relationship: 'items', list_id: '1', source: 'lists'})
+  end
+
+  def test_list_items_route_helper_name
+    assert_equal(list_items_path, '/list_items')
+  end
+
   #primary_key
   def test_routing_primary_key_jsonapi_resources
     assert_routing({path: '/iso_currencies/USD', method: :get},

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -268,6 +268,9 @@ TestApp.routes.draw do
   jsonapi_resources :employees
   jsonapi_resources :web_pages
 
+  jsonapi_resources :lists
+  jsonapi_resources :list_items
+
   jsonapi_resources :person_with_even_and_odd_posts
 
   namespace :api do


### PR DESCRIPTION
This addresses #1251 by adding a `related` scope prefix to related resource routes, similar to the `relationships` prefix for relationship routes.

Fixes #1251

### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [x] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [x] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [x] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [x] I've added/updated tests for this change.

### Bug fixes and Changes to Core Features:

- [x] I've included an explanation of what the changes do and why I'd like you to include them.
- [x] I've provided test(s) that fails without the change.

### Test Plan:

Ensure that `list_items_path` generates the path to the ListItemResource index, instead of failing to generate the incorrect related resource path.

### Reviewer Checklist:
- [x] Maintains compliance with JSON:API
- [x] Adequate test coverage exists to prevent regressions