### PR TITLE
Support global `default_exclude_links` configuration

### DIFF
--- a/lib/jsonapi/configuration.rb
+++ b/lib/jsonapi/configuration.rb
@@ -34,7 +34,7 @@ module JSONAPI
                 :default_resource_cache_field,
                 :resource_cache_digest_function,
                 :resource_cache_usage_report_function,
-                :exclude_links
+                :default_exclude_links
 
     def initialize
       #:underscored_key, :camelized_key, :dasherized_key, or custom
@@ -140,7 +140,7 @@ module JSONAPI
       # Controls whether to generate links like `self`, `related` with all the resources
       # and relationships. Accepts either `:default`, `:none`, or array containing the
       # specific default links to exclude, which may be `:self` and `:related`.
-      self.exclude_links = :none
+      self.default_exclude_links = :none
     end
 
     def cache_formatters=(bool)
@@ -257,7 +257,7 @@ module JSONAPI
 
     attr_writer :resource_cache_usage_report_function
 
-    attr_writer :exclude_links
+    attr_writer :default_exclude_links
   end
 
   class << self

--- a/lib/jsonapi/configuration.rb
+++ b/lib/jsonapi/configuration.rb
@@ -33,7 +33,8 @@ module JSONAPI
                 :resource_cache,
                 :default_resource_cache_field,
                 :resource_cache_digest_function,
-                :resource_cache_usage_report_function
+                :resource_cache_usage_report_function,
+                :exclude_links
 
     def initialize
       #:underscored_key, :camelized_key, :dasherized_key, or custom
@@ -134,6 +135,12 @@ module JSONAPI
       # Optionally provide a callable which JSONAPI will call with information about cache
       # performance. Should accept three arguments: resource name, hits count, misses count.
       self.resource_cache_usage_report_function = nil
+
+      # Global configuration for links exclusion
+      # Controls whether to generate links like `self`, `related` with all the resources
+      # and relationships. Accepts either `:default`, `:none`, or array containing the
+      # specific default links to exclude, which may be `:self` and `:related`.
+      self.exclude_links = :none
     end
 
     def cache_formatters=(bool)
@@ -249,6 +256,8 @@ module JSONAPI
     attr_writer :resource_cache_digest_function
 
     attr_writer :resource_cache_usage_report_function
+
+    attr_writer :exclude_links
   end
 
   class << self

--- a/lib/jsonapi/relationship.rb
+++ b/lib/jsonapi/relationship.rb
@@ -15,7 +15,7 @@ module JSONAPI
       @always_include_linkage_data = options.fetch(:always_include_linkage_data, false) == true
       @eager_load_on_include = options.fetch(:eager_load_on_include, true) == true
 
-      exclude_links(options.fetch(:exclude_links, :none))
+      exclude_links(options.fetch(:exclude_links, JSONAPI.configuration.exclude_links))
     end
 
     alias_method :polymorphic?, :polymorphic

--- a/lib/jsonapi/relationship.rb
+++ b/lib/jsonapi/relationship.rb
@@ -15,7 +15,7 @@ module JSONAPI
       @always_include_linkage_data = options.fetch(:always_include_linkage_data, false) == true
       @eager_load_on_include = options.fetch(:eager_load_on_include, true) == true
 
-      exclude_links(options.fetch(:exclude_links, JSONAPI.configuration.exclude_links))
+      exclude_links(options.fetch(:exclude_links, JSONAPI.configuration.default_exclude_links))
     end
 
     alias_method :polymorphic?, :polymorphic

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -1070,7 +1070,7 @@ module JSONAPI
       end
 
       def _exclude_links
-        @_exclude_links ||= _resolve_exclude_links(JSONAPI.configuration.exclude_links)
+        @_exclude_links ||= _resolve_exclude_links(JSONAPI.configuration.default_exclude_links)
       end
 
       def exclude_link?(link)

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -1066,6 +1066,18 @@ module JSONAPI
       end
 
       def exclude_links(exclude)
+        _resolve_exclude_links(exclude)
+      end
+
+      def _exclude_links
+        @_exclude_links ||= _resolve_exclude_links(JSONAPI.configuration.exclude_links)
+      end
+
+      def exclude_link?(link)
+        _exclude_links.include?(link.to_sym)
+      end
+
+      def _resolve_exclude_links(exclude)
         case exclude
           when :default, "default"
             @_exclude_links = [:self]
@@ -1076,14 +1088,6 @@ module JSONAPI
           else
             fail "Invalid exclude_links"
         end
-      end
-
-      def _exclude_links
-        @_exclude_links ||= []
-      end
-
-      def exclude_link?(link)
-        _exclude_links.include?(link.to_sym)
       end
 
       def caching(val = true)

--- a/test/unit/resource/relationship_test.rb
+++ b/test/unit/resource/relationship_test.rb
@@ -10,13 +10,13 @@ class HasOneRelationshipTest < ActiveSupport::TestCase
   end
 
   def test_global_exclude_links_configuration_on_relationship
-    JSONAPI.configuration.exclude_links = :none
+    JSONAPI.configuration.default_exclude_links = :none
     relationship = JSONAPI::Relationship::ToOne.new "foo"
     assert_equal [], relationship._exclude_links
     refute relationship.exclude_link?(:self)
     refute relationship.exclude_link?("self")
 
-    JSONAPI.configuration.exclude_links = :default
+    JSONAPI.configuration.default_exclude_links = :default
     relationship = JSONAPI::Relationship::ToOne.new "foo"
     assert_equal [:self, :related], relationship._exclude_links
     assert relationship.exclude_link?(:self)
@@ -24,54 +24,71 @@ class HasOneRelationshipTest < ActiveSupport::TestCase
     assert relationship.exclude_link?(:related)
     assert relationship.exclude_link?("related")
 
-    JSONAPI.configuration.exclude_links = "none"
+    JSONAPI.configuration.default_exclude_links = "none"
     relationship = JSONAPI::Relationship::ToOne.new "foo"
     assert_equal [], relationship._exclude_links
     refute relationship.exclude_link?(:self)
     refute relationship.exclude_link?("self")
 
-    JSONAPI.configuration.exclude_links = "default"
+    JSONAPI.configuration.default_exclude_links = "default"
     relationship = JSONAPI::Relationship::ToOne.new "foo"
     assert_equal [:self, :related], relationship._exclude_links
     assert relationship.exclude_link?(:self)
     assert relationship.exclude_link?("self")
 
-    JSONAPI.configuration.exclude_links = :none
+    JSONAPI.configuration.default_exclude_links = :none
     relationship = JSONAPI::Relationship::ToOne.new "foo"
     assert_equal [], relationship._exclude_links
     refute relationship.exclude_link?(:self)
     refute relationship.exclude_link?("self")
 
-    JSONAPI.configuration.exclude_links = [:self]
+    JSONAPI.configuration.default_exclude_links = [:self]
     relationship = JSONAPI::Relationship::ToOne.new "foo"
     assert_equal [:self], relationship._exclude_links
     assert relationship.exclude_link?(:self)
     assert relationship.exclude_link?("self")
 
-    JSONAPI.configuration.exclude_links = :none
+    JSONAPI.configuration.default_exclude_links = :none
     relationship = JSONAPI::Relationship::ToOne.new "foo"
     assert_equal [], relationship._exclude_links
     refute relationship.exclude_link?(:self)
     refute relationship.exclude_link?("self")
 
-    JSONAPI.configuration.exclude_links = ["self", :related]
+    JSONAPI.configuration.default_exclude_links = ["self", :related]
     relationship = JSONAPI::Relationship::ToOne.new "foo"
     assert_equal [:self, :related], relationship._exclude_links
     assert relationship.exclude_link?(:self)
     assert relationship.exclude_link?("self")
 
-    JSONAPI.configuration.exclude_links = []
+    JSONAPI.configuration.default_exclude_links = []
     relationship = JSONAPI::Relationship::ToOne.new "foo"
     assert_equal [], relationship._exclude_links
     refute relationship.exclude_link?(:self)
     refute relationship.exclude_link?("self")
 
     assert_raises do
-      JSONAPI.configuration.exclude_links = :self
+      JSONAPI.configuration.default_exclude_links = :self
       JSONAPI::Relationship::ToOne.new "foo"
     end
+
+    # Test if the relationships will override the the global configuration
+    JSONAPI.configuration.default_exclude_links = :default
+    relationship = JSONAPI::Relationship::ToOne.new "foo", exclude_links: :none
+    assert_equal [], relationship._exclude_links
+    refute relationship.exclude_link?(:self)
+    refute relationship.exclude_link?("self")
+    refute relationship.exclude_link?(:related)
+    refute relationship.exclude_link?("related")
+
+    JSONAPI.configuration.default_exclude_links = :default
+    relationship = JSONAPI::Relationship::ToOne.new "foo", exclude_links: [:self]
+    assert_equal [:self], relationship._exclude_links
+    refute relationship.exclude_link?(:related)
+    refute relationship.exclude_link?("related")
+    assert relationship.exclude_link?(:self)
+    assert relationship.exclude_link?("self")
   ensure
-    JSONAPI.configuration.exclude_links = :none
+    JSONAPI.configuration.default_exclude_links = :none
   end
 
   def test_exclude_links_on_relationship

--- a/test/unit/resource/relationship_test.rb
+++ b/test/unit/resource/relationship_test.rb
@@ -9,6 +9,71 @@ class HasOneRelationshipTest < ActiveSupport::TestCase
     assert_equal(relationship.polymorphic_type, "imageable_type")
   end
 
+  def test_global_exclude_links_configuration_on_relationship
+    JSONAPI.configuration.exclude_links = :none
+    relationship = JSONAPI::Relationship::ToOne.new "foo"
+    assert_equal [], relationship._exclude_links
+    refute relationship.exclude_link?(:self)
+    refute relationship.exclude_link?("self")
+
+    JSONAPI.configuration.exclude_links = :default
+    relationship = JSONAPI::Relationship::ToOne.new "foo"
+    assert_equal [:self, :related], relationship._exclude_links
+    assert relationship.exclude_link?(:self)
+    assert relationship.exclude_link?("self")
+    assert relationship.exclude_link?(:related)
+    assert relationship.exclude_link?("related")
+
+    JSONAPI.configuration.exclude_links = "none"
+    relationship = JSONAPI::Relationship::ToOne.new "foo"
+    assert_equal [], relationship._exclude_links
+    refute relationship.exclude_link?(:self)
+    refute relationship.exclude_link?("self")
+
+    JSONAPI.configuration.exclude_links = "default"
+    relationship = JSONAPI::Relationship::ToOne.new "foo"
+    assert_equal [:self, :related], relationship._exclude_links
+    assert relationship.exclude_link?(:self)
+    assert relationship.exclude_link?("self")
+
+    JSONAPI.configuration.exclude_links = :none
+    relationship = JSONAPI::Relationship::ToOne.new "foo"
+    assert_equal [], relationship._exclude_links
+    refute relationship.exclude_link?(:self)
+    refute relationship.exclude_link?("self")
+
+    JSONAPI.configuration.exclude_links = [:self]
+    relationship = JSONAPI::Relationship::ToOne.new "foo"
+    assert_equal [:self], relationship._exclude_links
+    assert relationship.exclude_link?(:self)
+    assert relationship.exclude_link?("self")
+
+    JSONAPI.configuration.exclude_links = :none
+    relationship = JSONAPI::Relationship::ToOne.new "foo"
+    assert_equal [], relationship._exclude_links
+    refute relationship.exclude_link?(:self)
+    refute relationship.exclude_link?("self")
+
+    JSONAPI.configuration.exclude_links = ["self", :related]
+    relationship = JSONAPI::Relationship::ToOne.new "foo"
+    assert_equal [:self, :related], relationship._exclude_links
+    assert relationship.exclude_link?(:self)
+    assert relationship.exclude_link?("self")
+
+    JSONAPI.configuration.exclude_links = []
+    relationship = JSONAPI::Relationship::ToOne.new "foo"
+    assert_equal [], relationship._exclude_links
+    refute relationship.exclude_link?(:self)
+    refute relationship.exclude_link?("self")
+
+    assert_raises do
+      JSONAPI.configuration.exclude_links = :self
+      JSONAPI::Relationship::ToOne.new "foo"
+    end
+  ensure
+    JSONAPI.configuration.exclude_links = :none
+  end
+
   def test_exclude_links_on_relationship
     relationship = JSONAPI::Relationship::ToOne.new "foo", exclude_links: :none
     assert_equal [], relationship._exclude_links


### PR DESCRIPTION
Add a new global configuration `default_exclude_links`, which allows to exclude links for all the resources and relationships.

Currently if we need to exclude all the links in relationships, we have to specify `exclude_links` in every relationship definition.

The `exclude_links` defined in resource and relationship scope will override the global configuration so nothing breaks.

If you guys think the PR is feasible, I will open another PR for 0.10 later.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [x] My submission includes new tests.
- [x] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Test Plan:

I have no idea about testing how the resource goes with the global configuration, because `exclude_links` method is called when module loaded. Sorry for the inadequate test coverage.

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions