### PR TITLE
Use controller for route helpers in LinkBuilder

### DIFF
--- a/lib/jsonapi/acts_as_resource_controller.rb
+++ b/lib/jsonapi/acts_as_resource_controller.rb
@@ -125,7 +125,8 @@ module JSONAPI
         base_url: base_url,
         key_formatter: key_formatter,
         route_formatter: route_formatter,
-        serialization_options: serialization_options
+        serialization_options: serialization_options,
+        controller: self
       )
       @resource_serializer
     end

--- a/lib/jsonapi/link_builder.rb
+++ b/lib/jsonapi/link_builder.rb
@@ -3,18 +3,17 @@ module JSONAPI
     attr_reader :base_url,
                 :primary_resource_klass,
                 :engine,
-                :routes
+                :url_helpers
 
     def initialize(config = {})
       @base_url               = config[:base_url]
       @primary_resource_klass = config[:primary_resource_klass]
       @engine                 = build_engine
 
-      if engine?
-        @routes = @engine.routes
-      else
-        @routes = Rails.application.routes
-      end
+      # url_helpers may be either a controller which has the route helper methods, or the application router's
+      # url helpers module, `Rails.application.routes.url_helpers`. Because the method no longer behaves as a
+      # singleton, and it's expensive to generate the module, the controller is preferred.
+      @url_helpers            = config[:url_helpers]
 
       # ToDo: Use NaiveCache for values. For this we need to not return nils and create composite keys which work
       # as efficient cache lookups. This could be an array of the [source.identifier, relationship] since the
@@ -89,7 +88,9 @@ module JSONAPI
     end
 
     def call_url_helper(method, *args)
-      routes.url_helpers.public_send(method, args)
+      fail NoMethodError.new(method) if url_helpers.nil?
+
+      url_helpers.send(method, args)
     rescue NoMethodError => e
       raise e
     end

--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -539,6 +539,7 @@ module JSONAPI
       LinkBuilder.new(
         base_url: options.fetch(:base_url, ''),
         primary_resource_klass: primary_resource_klass,
+        url_helpers: options[:url_helpers] || options[:controller]
       )
     end
   end

--- a/test/unit/serializer/link_builder_test.rb
+++ b/test/unit/serializer/link_builder_test.rb
@@ -51,6 +51,7 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
       base_url: @base_url,
       route_formatter: @route_formatter,
       primary_resource_klass: primary_resource_klass,
+      url_helpers: TestApp.routes.url_helpers,
     }
 
     builder = JSONAPI::LinkBuilder.new(config)
@@ -67,6 +68,7 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
       base_url: @base_url,
       route_formatter: @route_formatter,
       primary_resource_klass: primary_resource_klass,
+      url_helpers: ApiV2Engine::Engine.routes.url_helpers,
     }
 
     builder = JSONAPI::LinkBuilder.new(config)
@@ -83,6 +85,7 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
       base_url: @base_url,
       route_formatter: @route_formatter,
       primary_resource_klass: primary_resource_klass,
+      url_helpers: MyEngine::Engine.routes.url_helpers,
     }
 
     builder = JSONAPI::LinkBuilder.new(config)
@@ -99,6 +102,7 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
       base_url: @base_url,
       route_formatter: @route_formatter,
       primary_resource_klass: primary_resource_klass,
+      url_helpers: MyEngine::Engine.routes.url_helpers,
     }
 
     builder = JSONAPI::LinkBuilder.new(config)
@@ -113,6 +117,7 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
       base_url: @base_url,
       route_formatter: @route_formatter,
       primary_resource_klass: Api::V1::PersonResource,
+      url_helpers: TestApp.routes.url_helpers,
     }
 
     builder = JSONAPI::LinkBuilder.new(config)
@@ -125,7 +130,8 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
     config = {
       base_url: @base_url,
       route_formatter: @route_formatter,
-      primary_resource_klass: ApiV2Engine::PersonResource
+      primary_resource_klass: ApiV2Engine::PersonResource,
+      url_helpers: ApiV2Engine::Engine.routes.url_helpers,
     }
 
     builder = JSONAPI::LinkBuilder.new(config)
@@ -138,7 +144,8 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
     config = {
       base_url: @base_url,
       route_formatter: @route_formatter,
-      primary_resource_klass: MyEngine::Api::V1::PersonResource
+      primary_resource_klass: MyEngine::Api::V1::PersonResource,
+      url_helpers: MyEngine::Engine.routes.url_helpers,
     }
 
     builder = JSONAPI::LinkBuilder.new(config)
@@ -151,7 +158,8 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
     config = {
       base_url: @base_url,
       route_formatter: @route_formatter,
-      primary_resource_klass: Api::V1::PersonResource
+      primary_resource_klass: Api::V1::PersonResource,
+      url_helpers: TestApp.routes.url_helpers,
     }
 
     builder       = JSONAPI::LinkBuilder.new(config)
@@ -167,7 +175,8 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
     config = {
       base_url: @base_url,
       route_formatter: @route_formatter,
-      primary_resource_klass: ApiV2Engine::PersonResource
+      primary_resource_klass: ApiV2Engine::PersonResource,
+      url_helpers: ApiV2Engine::Engine.routes.url_helpers,
     }
 
     builder       = JSONAPI::LinkBuilder.new(config)
@@ -183,7 +192,8 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
     config = {
       base_url: @base_url,
       route_formatter: @route_formatter,
-      primary_resource_klass: MyEngine::Api::V1::PersonResource
+      primary_resource_klass: MyEngine::Api::V1::PersonResource,
+      url_helpers: MyEngine::Engine.routes.url_helpers,
     }
 
     builder       = JSONAPI::LinkBuilder.new(config)
@@ -199,7 +209,8 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
     config = {
       base_url: @base_url,
       route_formatter: @route_formatter,
-      primary_resource_klass: Api::V1::PersonResource
+      primary_resource_klass: Api::V1::PersonResource,
+      url_helpers: TestApp.routes.url_helpers,
     }
 
     builder       = JSONAPI::LinkBuilder.new(config)
@@ -215,7 +226,8 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
     config = {
       base_url: @base_url,
       route_formatter: @route_formatter,
-      primary_resource_klass: ApiV2Engine::PersonResource
+      primary_resource_klass: ApiV2Engine::PersonResource,
+      url_helpers: ApiV2Engine::Engine.routes.url_helpers,
     }
 
     builder       = JSONAPI::LinkBuilder.new(config)
@@ -231,7 +243,8 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
     config = {
       base_url: @base_url,
       route_formatter: @route_formatter,
-      primary_resource_klass: MyEngine::Api::V1::PersonResource
+      primary_resource_klass: MyEngine::Api::V1::PersonResource,
+      url_helpers: MyEngine::Engine.routes.url_helpers,
     }
 
     builder       = JSONAPI::LinkBuilder.new(config)
@@ -247,7 +260,8 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
     config = {
       base_url: @base_url,
       route_formatter: @route_formatter,
-      primary_resource_klass: Api::V1::PersonResource
+      primary_resource_klass: Api::V1::PersonResource,
+      url_helpers: TestApp.routes.url_helpers,
     }
 
     builder       = JSONAPI::LinkBuilder.new(config)
@@ -264,7 +278,8 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
     config = {
       base_url: @base_url,
       route_formatter: @route_formatter,
-      primary_resource_klass: Api::V1::PersonResource
+      primary_resource_klass: Api::V1::PersonResource,
+      url_helpers: TestApp.routes.url_helpers,
     }
 
     query         = { page: { offset: 0, limit: 12 } }
@@ -278,7 +293,8 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
     config = {
       base_url: @base_url,
       route_formatter: @route_formatter,
-      primary_resource_klass: AdminApi::V1::PersonResource
+      primary_resource_klass: AdminApi::V1::PersonResource,
+      url_helpers: TestApp.routes.url_helpers,
     }
 
     query         = { page: { offset: 0, limit: 12 } }
@@ -292,7 +308,8 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
     config = {
       base_url: @base_url,
       route_formatter: DasherizedRouteFormatter,
-      primary_resource_klass: DasherizedNamespace::V1::PersonResource
+      primary_resource_klass: DasherizedNamespace::V1::PersonResource,
+      url_helpers: TestApp.routes.url_helpers,
     }
 
     query         = { page: { offset: 0, limit: 12 } }
@@ -306,7 +323,8 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
     config = {
       base_url: @base_url,
       route_formatter: @route_formatter,
-      primary_resource_klass: ApiV2Engine::PersonResource
+      primary_resource_klass: ApiV2Engine::PersonResource,
+      url_helpers: ApiV2Engine::Engine.routes.url_helpers,
     }
 
     query         = { page: { offset: 0, limit: 12 } }
@@ -320,7 +338,8 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
     config = {
       base_url: @base_url,
       route_formatter: @route_formatter,
-      primary_resource_klass: MyEngine::Api::V1::PersonResource
+      primary_resource_klass: MyEngine::Api::V1::PersonResource,
+      url_helpers: MyEngine::Engine.routes.url_helpers,
     }
 
     query         = { page: { offset: 0, limit: 12 } }
@@ -334,7 +353,8 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
     config = {
       base_url: @base_url,
       route_formatter: DasherizedRouteFormatter,
-      primary_resource_klass: MyEngine::DasherizedNamespace::V1::PersonResource
+      primary_resource_klass: MyEngine::DasherizedNamespace::V1::PersonResource,
+      url_helpers: MyEngine::Engine.routes.url_helpers,
     }
 
     query         = { page: { offset: 0, limit: 12 } }
@@ -348,7 +368,8 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
     config = {
       base_url: @base_url,
       route_formatter: @route_formatter,
-      primary_resource_klass: MyEngine::AdminApi::V1::PersonResource
+      primary_resource_klass: MyEngine::AdminApi::V1::PersonResource,
+      url_helpers: MyEngine::Engine.routes.url_helpers,
     }
 
     query         = { page: { offset: 0, limit: 12 } }

--- a/test/unit/serializer/polymorphic_serializer_test.rb
+++ b/test/unit/serializer/polymorphic_serializer_test.rb
@@ -26,10 +26,11 @@ class PolymorphismTest < ActionDispatch::IntegrationTest
   end
 
   def test_sti_polymorphic_to_many_serialization
-    serialized_data = JSONAPI::ResourceSerializer.new(
-      PersonResource,
-      include: %w(vehicles)
-    ).serialize_to_hash(PersonResource.new(@person, nil))
+    serializer = JSONAPI::ResourceSerializer.new(PersonResource,
+                                                      include: %w(vehicles),
+                                                      url_helpers: TestApp.routes.url_helpers)
+
+    serialized_data = serializer.serialize_to_hash(PersonResource.new(@person, nil))
 
     assert_hash_equals(
       {
@@ -132,10 +133,9 @@ class PolymorphismTest < ActionDispatch::IntegrationTest
 
   def test_sti_polymorphic_to_many_serialization_with_custom_polymorphic_records
     person_resource = PersonResource.new(@person, nil)
-    serializer = JSONAPI::ResourceSerializer.new(
-      PersonResource,
-      include: %w(vehicles)
-    )
+    serializer = JSONAPI::ResourceSerializer.new(PersonResource,
+                                                 include: %w(vehicles),
+                                                 url_helpers: TestApp.routes.url_helpers)
 
     def person_resource.records_for_vehicles(opts = {})
       @model.vehicles.none
@@ -198,10 +198,11 @@ class PolymorphismTest < ActionDispatch::IntegrationTest
 
 
   def test_polymorphic_belongs_to_serialization
-    serialized_data = JSONAPI::ResourceSerializer.new(
-      PictureResource,
-      include: %w(imageable)
-    ).serialize_to_hash(@pictures.map { |p| PictureResource.new p, nil })
+    serializer = JSONAPI::ResourceSerializer.new(PictureResource,
+                                                 include: %w(imageable),
+                                                 url_helpers: TestApp.routes.url_helpers)
+
+    serialized_data = serializer.serialize_to_hash(@pictures.map {|p| PictureResource.new p, nil})
 
     assert_hash_equals(
       {
@@ -319,10 +320,12 @@ class PolymorphismTest < ActionDispatch::IntegrationTest
   end
 
   def test_polymorphic_has_one_serialization
-    serialized_data = JSONAPI::ResourceSerializer.new(
+    serializer = JSONAPI::ResourceSerializer.new(
       QuestionResource,
-      include: %w(respondent)
-    ).serialize_to_hash(@questions.map { |p| QuestionResource.new p, nil })
+      include: %w(respondent),
+      url_helpers: TestApp.routes.url_helpers)
+
+    serialized_data = serializer.serialize_to_hash(@questions.map { |p| QuestionResource.new p, nil })
 
     assert_hash_equals(
       {

--- a/test/unit/serializer/response_document_test.rb
+++ b/test/unit/serializer/response_document_test.rb
@@ -9,12 +9,13 @@ class ResponseDocumentTest < ActionDispatch::IntegrationTest
   end
 
   def create_response_document(operation_results, resource_klass)
-    JSONAPI::ResponseDocument.new(
-      operation_results,
-      JSONAPI::ResourceSerializer.new(resource_klass),
-      {
-        primary_resource_klass: resource_klass
-      }
+    serializer = JSONAPI::ResourceSerializer.new(resource_klass, url_helpers: TestApp.routes.url_helpers)
+
+    JSONAPI::ResponseDocument.new(operation_results,
+                                  serializer,
+                                  {
+                                    primary_resource_klass: resource_klass
+                                  }
     )
   end
 


### PR DESCRIPTION
A performance bug was reported where memory was growing and CPU usage was greater than earlier releases.

I believe this is related to the LinkBuilder repeatedly calling `routes.url_helpers.public_send(method, args)`, which seems generate a new module containing all the route helper methods each time, for each link being built. See https://github.com/rails/rails/issues/23451

Since rails removed the caching of the url_helpers modules for a reason, I don't wish to reintroduce this concept. As an alternative the controller will be passed through to the LinkBuilder and the helper methods will be called on the controller.

For some tests the inefficient call to `routes.url_helpers` will still be used for convenience.

### All Submissions:

- [X] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [X] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [X] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions