### PR TITLE
Revert "Use `destroy` instead of `delete` to ensure callbacks are cal…

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -372,7 +372,7 @@ module JSONAPI
 
         @reload_needed = true
       else
-        @model.public_send(relationship.relation_name(context: @context)).destroy(key)
+        @model.public_send(relationship.relation_name(context: @context)).delete(key)
       end
 
       :completed


### PR DESCRIPTION
This reverts commit 5f8705a4c0dfafc93aeaf00abcb90311fb6592b5.
Solves #1260 

I think the reverted commit was based on a misunderstanding of how delete vs destroy works for relationships. Calling destroy on an instance of [ActiveRecord::Associations::CollectionProxy](https://api.rubyonrails.org/classes/ActiveRecord/Associations/CollectionProxy.html) will actually not only remove the intended resource from the relationship, it will remove it from the database, no matter what dependency is set on the base model. Delete will remove the resource from the relationship, but will only destroy the resource if the base model has specified dependency: :destroy.

Destroying resources that should have been nullified feels quite dangerous? The JSONAPI specification doesn't mention what behaviour is expected apart from removing the relation, so I doubt needlessly destroying the underlying resource is what is expected.

Relevant docs:
[ActiveRecord::Associations::CollectionProxy#delete](https://api.rubyonrails.org/classes/ActiveRecord/Associations/CollectionProxy.html#method-i-delete)
[ActiveRecord::Associations::CollectionProxy#destroy](https://api.rubyonrails.org/classes/ActiveRecord/Associations/CollectionProxy.html#method-i-destroy)

### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [x] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [x] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions