### PR TITLE
Build Links with strings, track route setup on resource and relationships

### DIFF
--- a/lib/jsonapi/acts_as_resource_controller.rb
+++ b/lib/jsonapi/acts_as_resource_controller.rb
@@ -102,7 +102,8 @@ module JSONAPI
                   base_url: base_url,
                   key_formatter: key_formatter,
                   route_formatter: route_formatter,
-                  serialization_options: serialization_options
+                  serialization_options: serialization_options,
+                  controller: self
               )
               op.options[:cache_serializer_output] = !JSONAPI.configuration.resource_cache.nil?
 

--- a/lib/jsonapi/basic_resource.rb
+++ b/lib/jsonapi/basic_resource.rb
@@ -448,6 +448,9 @@ module JSONAPI
         end
 
         check_reserved_resource_name(subclass._type, subclass.name)
+
+        subclass._routed = false
+        subclass._warned_missing_route = false
       end
 
       def rebuild_relationships(relationships)
@@ -494,7 +497,7 @@ module JSONAPI
         end
       end
 
-      attr_accessor :_attributes, :_relationships, :_type, :_model_hints
+      attr_accessor :_attributes, :_relationships, :_type, :_model_hints, :_routed, :_warned_missing_route
       attr_writer :_allowed_filters, :_paginator, :_allowed_sort
 
       def create(context)

--- a/lib/jsonapi/link_builder.rb
+++ b/lib/jsonapi/link_builder.rb
@@ -2,23 +2,24 @@ module JSONAPI
   class LinkBuilder
     attr_reader :base_url,
                 :primary_resource_klass,
+                :route_formatter,
                 :engine,
-                :routes
+                :engine_mount_point,
+                :url_helpers
+
+    @@url_helper_methods = {}
 
     def initialize(config = {})
-      @base_url               = config[:base_url]
+      @base_url = config[:base_url]
       @primary_resource_klass = config[:primary_resource_klass]
-      @engine                 = build_engine
+      @route_formatter = config[:route_formatter]
+      @engine = build_engine
+      @engine_mount_point = @engine ? @engine.routes.find_script_name({}) : ""
 
-      if engine?
-        @routes = @engine.routes
-      else
-        @routes = Rails.application.routes
-      end
-
-      # ToDo: Use NaiveCache for values. For this we need to not return nils and create composite keys which work
-      # as efficient cache lookups. This could be an array of the [source.identifier, relationship] since the
-      # ResourceIdentity will compare equality correctly
+      # url_helpers may be either a controller which has the route helper methods, or the application router's
+      # url helpers module, `Rails.application.routes.url_helpers`. Because the method no longer behaves as a
+      # singleton, and it's expensive to generate the module, the controller is preferred.
+      @url_helpers = config[:url_helpers]
     end
 
     def engine?
@@ -26,50 +27,60 @@ module JSONAPI
     end
 
     def primary_resources_url
-      @primary_resources_url_cached ||= "#{ base_url }#{ primary_resources_path }"
-    rescue NoMethodError
-      warn "primary_resources_url for #{@primary_resource_klass} could not be generated" if JSONAPI.configuration.warn_on_missing_routes
+      if @primary_resource_klass._routed
+        primary_resources_path = resources_path(primary_resource_klass)
+        @primary_resources_url_cached ||= "#{ base_url }#{ engine_mount_point }#{ primary_resources_path }"
+      else
+        if JSONAPI.configuration.warn_on_missing_routes && !@primary_resource_klass._warned_missing_route
+          warn "primary_resources_url for #{@primary_resource_klass} could not be generated"
+          @primary_resource_klass._warned_missing_route = true
+        end
+        nil
+      end
     end
 
     def query_link(query_params)
-      "#{ primary_resources_url }?#{ query_params.to_query }"
+      url = primary_resources_url
+      return url if url.nil?
+      "#{ url }?#{ query_params.to_query }"
     end
 
     def relationships_related_link(source, relationship, query_params = {})
-      if relationship.parent_resource.singleton?
-        url_helper_name = singleton_related_url_helper_name(relationship)
-        url = call_url_helper(url_helper_name)
+      if relationship._routed
+        url = "#{ self_link(source) }/#{ route_for_relationship(relationship) }"
+        url = "#{ url }?#{ query_params.to_query }" if query_params.present?
+        url
       else
-        url_helper_name = related_url_helper_name(relationship)
-        url = call_url_helper(url_helper_name, source.id)
+        if JSONAPI.configuration.warn_on_missing_routes && !relationship._warned_missing_route
+          warn "related_link for #{relationship} could not be generated"
+          relationship._warned_missing_route = true
+        end
+        nil
       end
-
-      url = "#{ base_url }#{ url }"
-      url = "#{ url }?#{ query_params.to_query }" if query_params.present?
-      url
-    rescue NoMethodError
-      warn "related_link for #{relationship} could not be generated" if JSONAPI.configuration.warn_on_missing_routes
     end
 
     def relationships_self_link(source, relationship)
-      if relationship.parent_resource.singleton?
-        url_helper_name = singleton_relationship_self_url_helper_name(relationship)
-        url = call_url_helper(url_helper_name)
+      if relationship._routed
+        "#{ self_link(source) }/relationships/#{ route_for_relationship(relationship) }"
       else
-        url_helper_name = relationship_self_url_helper_name(relationship)
-        url = call_url_helper(url_helper_name, source.id)
+        if JSONAPI.configuration.warn_on_missing_routes && !relationship._warned_missing_route
+          warn "self_link for #{relationship} could not be generated"
+          relationship._warned_missing_route = true
+        end
+        nil
       end
-
-      url = "#{ base_url }#{ url }"
-      url
-    rescue NoMethodError
-      warn "self_link for #{relationship} could not be generated" if JSONAPI.configuration.warn_on_missing_routes
     end
 
     def self_link(source)
-      "#{ base_url }#{ resource_path(source) }"
-    rescue NoMethodError
-      warn "self_link for #{source.class} could not be generated" if JSONAPI.configuration.warn_on_missing_routes
+      if source.class._routed
+        resource_url(source)
+      else
+        if JSONAPI.configuration.warn_on_missing_routes && !source.class._warned_missing_route
+          warn "self_link for #{source.class} could not be generated"
+          source.class._warned_missing_route = true
+        end
+        nil
+      end
     end
 
     private
@@ -81,105 +92,55 @@ module JSONAPI
         unless scopes.empty?
           "#{ scopes.first.to_s.camelize }::Engine".safe_constantize
         end
-      # :nocov:
+
+          # :nocov:
       rescue LoadError => _e
         nil
-      # :nocov:
+        # :nocov:
       end
     end
 
-    def call_url_helper(method, *args)
-      routes.url_helpers.public_send(method, args)
-    rescue NoMethodError => e
-      raise e
+    def format_route(route)
+      route_formatter.format(route)
     end
 
-    def path_from_resource_class(klass)
-      url_helper_name = resources_url_helper_name_from_class(klass)
-      call_url_helper(url_helper_name)
-    end
+    def formatted_module_path_from_class(klass)
+      scopes = if @engine
+                 module_scopes_from_class(klass)[1..-1]
+               else
+                 module_scopes_from_class(klass)
+               end
 
-    def resource_path(source)
-      url_helper_name = resource_url_helper_name_from_source(source)
-      if source.class.singleton?
-        call_url_helper(url_helper_name)
+      unless scopes.empty?
+        "/#{ scopes.map {|scope| format_route(scope.to_s.underscore)}.compact.join('/') }/"
       else
-        call_url_helper(url_helper_name, source.id)
+        "/"
       end
-    end
-
-    def primary_resources_path
-      path_from_resource_class(primary_resource_klass)
-    end
-
-    def url_helper_name_from_parts(parts)
-      (parts << "path").reject(&:blank?).join("_")
-    end
-
-    def resources_path_parts_from_class(klass)
-      if engine?
-        scopes = module_scopes_from_class(klass)[1..-1]
-      else
-        scopes = module_scopes_from_class(klass)
-      end
-
-      base_path_name = scopes.map { |scope| scope.underscore }.join("_")
-      end_path_name  = klass._type.to_s
-      [base_path_name, end_path_name]
-    end
-
-    def resources_url_helper_name_from_class(klass)
-      url_helper_name_from_parts(resources_path_parts_from_class(klass))
-    end
-
-    def resource_path_parts_from_class(klass)
-      if engine?
-        scopes = module_scopes_from_class(klass)[1..-1]
-      else
-        scopes = module_scopes_from_class(klass)
-      end
-
-      base_path_name = scopes.map { |scope| scope.underscore }.join("_")
-      end_path_name  = klass._type.to_s.singularize
-      [base_path_name, end_path_name]
-    end
-
-    def resource_url_helper_name_from_source(source)
-       url_helper_name_from_parts(resource_path_parts_from_class(source.class))
-    end
-
-    def related_url_helper_name(relationship)
-      relationship_parts = resource_path_parts_from_class(relationship.parent_resource)
-      relationship_parts << "related"
-      relationship_parts << relationship.name
-      url_helper_name_from_parts(relationship_parts)
-    end
-
-    def singleton_related_url_helper_name(relationship)
-      relationship_parts = []
-      relationship_parts << "related"
-      relationship_parts << relationship.name
-      relationship_parts += resource_path_parts_from_class(relationship.parent_resource)
-      url_helper_name_from_parts(relationship_parts)
-    end
-
-    def relationship_self_url_helper_name(relationship)
-      relationship_parts = resource_path_parts_from_class(relationship.parent_resource)
-      relationship_parts << "relationships"
-      relationship_parts << relationship.name
-      url_helper_name_from_parts(relationship_parts)
-    end
-
-    def singleton_relationship_self_url_helper_name(relationship)
-      relationship_parts = []
-      relationship_parts << "relationships"
-      relationship_parts << relationship.name
-      relationship_parts += resource_path_parts_from_class(relationship.parent_resource)
-      url_helper_name_from_parts(relationship_parts)
     end
 
     def module_scopes_from_class(klass)
       klass.name.to_s.split("::")[0...-1]
+    end
+
+    def resources_path(source_klass)
+      formatted_module_path_from_class(source_klass) + format_route(source_klass._type.to_s)
+    end
+
+    def resource_path(source)
+      url = "#{resources_path(source.class)}"
+
+      unless source.class.singleton?
+        url = "#{url}/#{source.id}"
+      end
+      url
+    end
+
+    def resource_url(source)
+      "#{ base_url }#{ engine_mount_point }#{ resource_path(source) }"
+    end
+
+    def route_for_relationship(relationship)
+      format_route(relationship.name)
     end
   end
 end

--- a/lib/jsonapi/relationship.rb
+++ b/lib/jsonapi/relationship.rb
@@ -7,6 +7,8 @@ module JSONAPI
 
     attr_writer :allow_include
 
+    attr_accessor :_routed, :_warned_missing_route
+
     def initialize(name, options = {})
       @name = name.to_s
       @options = options
@@ -26,6 +28,9 @@ module JSONAPI
       @allow_include = options[:allow_include]
       @class_name = nil
       @inverse_relationship = nil
+
+      @_routed = false
+      @_warned_missing_route = false
 
       exclude_links(options.fetch(:exclude_links, :none))
 

--- a/lib/jsonapi/resource_controller_metal.rb
+++ b/lib/jsonapi/resource_controller_metal.rb
@@ -10,6 +10,9 @@ module JSONAPI
       JSONAPI::ActsAsResourceController
     ].freeze
 
+    # Note, the url_helpers are not loaded. This will prevent links from being generated for resources, and warnings
+    # will be emitted. Link support can be added by including `Rails.application.routes.url_helpers`, and links
+    # can be disabled, and warning suppressed, for a resource with `exclude_links :default`
     MODULES.each do |mod|
       include mod
     end

--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -381,6 +381,8 @@ module JSONAPI
       LinkBuilder.new(
         base_url: options.fetch(:base_url, ''),
         primary_resource_klass: primary_resource_klass,
+        route_formatter: options.fetch(:route_formatter, JSONAPI.configuration.route_formatter),
+        url_helpers: options.fetch(:url_helpers, options[:controller]),
       )
     end
   end

--- a/lib/jsonapi/routing_ext.rb
+++ b/lib/jsonapi/routing_ext.rb
@@ -20,6 +20,8 @@ module ActionDispatch
           @resource_type = resources.first
           res = JSONAPI::Resource.resource_klass_for(resource_type_with_module_prefix(@resource_type))
 
+          res._routed = true
+
           unless res.singleton?
             warn "Singleton routes created for non singleton resource #{res}. Links may not be generated correctly."
           end
@@ -83,6 +85,8 @@ module ActionDispatch
         def jsonapi_resources(*resources, &_block)
           @resource_type = resources.first
           res = JSONAPI::Resource.resource_klass_for(resource_type_with_module_prefix(@resource_type))
+
+          res._routed = true
 
           if res.singleton?
             warn "Singleton resource #{res} should use `jsonapi_resource` instead."
@@ -220,6 +224,8 @@ module ActionDispatch
           relationship_name = relationship.first
           relationship = source._relationships[relationship_name]
 
+          relationship._routed = true
+
           formatted_relationship_name = format_route(relationship.name)
 
           if relationship.polymorphic?
@@ -241,6 +247,8 @@ module ActionDispatch
 
           relationship_name = relationship.first
           relationship = source._relationships[relationship_name]
+
+          relationship._routed = true
 
           formatted_relationship_name = format_route(relationship.name)
           related_resource = JSONAPI::Resource.resource_klass_for(resource_type_with_module_prefix(relationship.class_name.underscore))

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -901,6 +901,7 @@ class SessionsController < ActionController::Base
 end
 
 class AuthorsController < JSONAPI::ResourceControllerMetal
+  include Rails.application.routes.url_helpers
 end
 
 class PeopleController < JSONAPI::ResourceController
@@ -1991,7 +1992,9 @@ module Api
     class PostResource < PostResource; end
     class PersonResource < PersonResource; end
     class ExpenseEntryResource < ExpenseEntryResource; end
-    class IsoCurrencyResource < IsoCurrencyResource; end
+    class IsoCurrencyResource < IsoCurrencyResource
+      has_many :expense_entries, exclude_links: :default
+    end
 
     class AuthorResource < Api::V2::AuthorResource; end
 
@@ -2389,6 +2392,7 @@ end
 
 module ApiV2Engine
   class PostResource < PostResource
+    has_one :person
   end
 
   class PersonResource < JSONAPI::Resource

--- a/test/integration/requests/request_test.rb
+++ b/test/integration/requests/request_test.rb
@@ -5,7 +5,6 @@ class RequestTest < ActionDispatch::IntegrationTest
     DatabaseCleaner.start
     JSONAPI.configuration.json_key_format = :underscored_key
     JSONAPI.configuration.route_format = :underscored_route
-    JSONAPI.configuration.warn_on_missing_routes = false
     Api::V2::BookResource.paginator :offset
     $test_user = Person.find(1001)
   end
@@ -16,7 +15,6 @@ class RequestTest < ActionDispatch::IntegrationTest
 
   def after_teardown
     JSONAPI.configuration.route_format = :underscored_route
-    JSONAPI.configuration.warn_on_missing_routes = true
   end
 
   def test_get
@@ -190,6 +188,7 @@ class RequestTest < ActionDispatch::IntegrationTest
   def test_get_camelized_route_and_links
     original_config = JSONAPI.configuration.dup
     JSONAPI.configuration.json_key_format = :camelized_key
+    JSONAPI.configuration.route_format = :camelized_route
     assert_cacheable_jsonapi_get '/api/v4/expenseEntries/1/relationships/isoCurrency'
     assert_hash_equals({'links' => {
                          'self' => 'http://www.example.com/api/v4/expenseEntries/1/relationships/isoCurrency',

--- a/test/unit/processor/default_processor_test.rb
+++ b/test/unit/processor/default_processor_test.rb
@@ -12,7 +12,9 @@ class DefaultProcessorTest < ActionDispatch::IntegrationTest
     PostResource.caching true
     PersonResource.caching true
 
-    $serializer = JSONAPI::ResourceSerializer.new(PostResource, base_url: 'http://example.com')
+    $serializer = JSONAPI::ResourceSerializer.new(PostResource,
+                                                  base_url: 'http://example.com',
+                                                  url_helpers: TestApp.routes.url_helpers)
 
     # no includes
     filters = { id: [10, 12] }

--- a/test/unit/serializer/link_builder_test.rb
+++ b/test/unit/serializer/link_builder_test.rb
@@ -2,6 +2,20 @@ require File.expand_path('../../../test_helper', __FILE__)
 require 'jsonapi-resources'
 require 'json'
 
+module Api
+  module Secret
+    class PostResource < JSONAPI::Resource
+      attribute :title
+      attribute :body
+
+      has_one :author, class_name: 'Person'
+    end
+
+    class PersonResource < JSONAPI::Resource
+    end
+  end
+end
+
 class LinkBuilderTest < ActionDispatch::IntegrationTest
   def setup
     # the route format is being set directly in test_helper and is being set differently depending on
@@ -11,7 +25,9 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
 
     @base_url        = "http://example.com"
     @route_formatter = JSONAPI.configuration.route_formatter
-    @steve           = Person.create(name: "Steve Rogers", date_joined: "1941-03-01")
+    @steve           = Person.create(name: "Steve Rogers", date_joined: "1941-03-01", id: 777)
+    @steves_prefs    = Preferences.create(advanced_mode: true, id: 444, person_id: 777)
+    @great_post      = Post.create(title: "Greatest Post", id: 555)
   end
 
   def test_engine_boolean
@@ -30,14 +46,14 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
 
   def test_engine_name
     assert_equal MyEngine::Engine,
-      JSONAPI::LinkBuilder.new(
-        primary_resource_klass: MyEngine::Api::V1::PersonResource
-    ).engine
+                 JSONAPI::LinkBuilder.new(
+                   primary_resource_klass: MyEngine::Api::V1::PersonResource
+                 ).engine
 
     assert_equal ApiV2Engine::Engine,
-      JSONAPI::LinkBuilder.new(
-        primary_resource_klass: ApiV2Engine::PersonResource
-    ).engine
+                 JSONAPI::LinkBuilder.new(
+                   primary_resource_klass: ApiV2Engine::PersonResource
+                 ).engine
 
     assert_nil JSONAPI::LinkBuilder.new(
       primary_resource_klass: Api::V1::PersonResource
@@ -51,6 +67,7 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
       base_url: @base_url,
       route_formatter: @route_formatter,
       primary_resource_klass: primary_resource_klass,
+      url_helpers: TestApp.routes.url_helpers,
     }
 
     builder = JSONAPI::LinkBuilder.new(config)
@@ -60,13 +77,200 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
     assert_equal expected_link, builder.self_link(source)
   end
 
-  def test_self_link_with_engine_app
-    primary_resource_klass = ApiV2Engine::PersonResource
+  def test_self_link_regular_app_not_routed
+    primary_resource_klass = Api::Secret::PostResource
 
     config = {
       base_url: @base_url,
       route_formatter: @route_formatter,
       primary_resource_klass: primary_resource_klass,
+      url_helpers: TestApp.routes.url_helpers,
+    }
+
+    builder = JSONAPI::LinkBuilder.new(config)
+    source  = primary_resource_klass.new(@great_post, nil)
+
+
+    # Should not warn if warn_on_missing_routes is false
+    JSONAPI.configuration.warn_on_missing_routes = false
+    primary_resource_klass._warned_missing_route = false
+
+    _out, err = capture_subprocess_io do
+      link = builder.self_link(source)
+      assert_nil link
+    end
+    assert_empty(err)
+
+    # Test warn_on_missing_routes
+    JSONAPI.configuration.warn_on_missing_routes = true
+    primary_resource_klass._warned_missing_route = false
+
+    _out, err = capture_subprocess_io do
+      link = builder.self_link(source)
+      assert_nil link
+    end
+    assert_equal(err, "self_link for Api::Secret::PostResource could not be generated\n")
+
+    # should only warn once
+    builder = JSONAPI::LinkBuilder.new(config)
+    _out, err = capture_subprocess_io do
+      link = builder.self_link(source)
+      assert_nil link
+    end
+    assert_empty(err)
+
+  ensure
+    JSONAPI.configuration.warn_on_missing_routes = true
+  end
+
+  def test_primary_resources_url_not_routed
+    primary_resource_klass = Api::Secret::PostResource
+
+    config = {
+      base_url: @base_url,
+      route_formatter: @route_formatter,
+      primary_resource_klass: primary_resource_klass,
+      url_helpers: TestApp.routes.url_helpers,
+    }
+
+    builder = JSONAPI::LinkBuilder.new(config)
+
+    # Should not warn if warn_on_missing_routes is false
+    JSONAPI.configuration.warn_on_missing_routes = false
+    primary_resource_klass._warned_missing_route = false
+
+    _out, err = capture_subprocess_io do
+      link = builder.primary_resources_url
+      assert_nil link
+    end
+    assert_empty(err)
+
+    # Test warn_on_missing_routes
+    JSONAPI.configuration.warn_on_missing_routes = true
+    primary_resource_klass._warned_missing_route = false
+    _out, err = capture_subprocess_io do
+      link = builder.primary_resources_url
+      assert_nil link
+    end
+    assert_equal(err, "primary_resources_url for Api::Secret::PostResource could not be generated\n")
+
+    # should only warn once
+    builder = JSONAPI::LinkBuilder.new(config)
+    _out, err = capture_subprocess_io do
+      link = builder.primary_resources_url
+      assert_nil link
+    end
+    assert_empty(err)
+
+  ensure
+    JSONAPI.configuration.warn_on_missing_routes = true
+  end
+
+  def test_relationships_self_link_not_routed
+    primary_resource_klass = Api::Secret::PostResource
+
+    config = {
+      base_url: @base_url,
+      route_formatter: @route_formatter,
+      primary_resource_klass: primary_resource_klass,
+      url_helpers: TestApp.routes.url_helpers,
+    }
+
+    builder       = JSONAPI::LinkBuilder.new(config)
+
+    source        = primary_resource_klass.new(@great_post, nil)
+
+    relationship  = Api::Secret::PostResource._relationships[:author]
+
+    # Should not warn if warn_on_missing_routes is false
+    JSONAPI.configuration.warn_on_missing_routes = false
+    relationship._warned_missing_route = false
+
+    _out, err = capture_subprocess_io do
+      link = builder.relationships_self_link(source, relationship)
+      assert_nil link
+    end
+    assert_empty(err)
+
+    # Test warn_on_missing_routes
+    JSONAPI.configuration.warn_on_missing_routes = true
+    relationship._warned_missing_route = false
+
+    _out, err = capture_subprocess_io do
+      link = builder.relationships_self_link(source, relationship)
+      assert_nil link
+    end
+    assert_equal(err, "self_link for Api::Secret::PostResource.author(BelongsToOne) could not be generated\n")
+
+    # should only warn once
+    builder = JSONAPI::LinkBuilder.new(config)
+    _out, err = capture_subprocess_io do
+      link = builder.relationships_self_link(source, relationship)
+      assert_nil link
+    end
+    assert_empty(err)
+
+  ensure
+    JSONAPI.configuration.warn_on_missing_routes = true
+  end
+
+  def test_relationships_related_link_not_routed
+    primary_resource_klass = Api::Secret::PostResource
+
+    config = {
+      base_url: @base_url,
+      route_formatter: @route_formatter,
+      primary_resource_klass: primary_resource_klass,
+      url_helpers: TestApp.routes.url_helpers,
+    }
+
+    builder       = JSONAPI::LinkBuilder.new(config)
+
+    source        = primary_resource_klass.new(@great_post, nil)
+
+    relationship  = Api::Secret::PostResource._relationships[:author]
+
+    # Should not warn if warn_on_missing_routes is false
+    JSONAPI.configuration.warn_on_missing_routes = false
+    relationship._warned_missing_route = false
+
+    _out, err = capture_subprocess_io do
+      link = builder.relationships_related_link(source, relationship)
+      assert_nil link
+    end
+    assert_empty(err)
+
+    # Test warn_on_missing_routes
+    JSONAPI.configuration.warn_on_missing_routes = true
+    relationship._warned_missing_route = false
+
+    _out, err = capture_subprocess_io do
+      link = builder.relationships_related_link(source, relationship)
+      assert_nil link
+    end
+    assert_equal(err, "related_link for Api::Secret::PostResource.author(BelongsToOne) could not be generated\n")
+
+    # should only warn once
+    builder = JSONAPI::LinkBuilder.new(config)
+    _out, err = capture_subprocess_io do
+      link = builder.relationships_related_link(source, relationship)
+      assert_nil link
+    end
+    assert_empty(err)
+
+  ensure
+    JSONAPI.configuration.warn_on_missing_routes = true
+  end
+
+  def test_self_link_with_engine_app
+    primary_resource_klass = ApiV2Engine::PersonResource
+    primary_resource_klass._warned_missing_route = false
+
+    config = {
+      base_url: "#{ @base_url }",
+      route_formatter: @route_formatter,
+      primary_resource_klass: primary_resource_klass,
+      url_helpers: ApiV2Engine::Engine.routes.url_helpers,
     }
 
     builder = JSONAPI::LinkBuilder.new(config)
@@ -83,6 +287,7 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
       base_url: @base_url,
       route_formatter: @route_formatter,
       primary_resource_klass: primary_resource_klass,
+      url_helpers: MyEngine::Engine.routes.url_helpers,
     }
 
     builder = JSONAPI::LinkBuilder.new(config)
@@ -99,6 +304,7 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
       base_url: @base_url,
       route_formatter: @route_formatter,
       primary_resource_klass: primary_resource_klass,
+      url_helpers: MyEngine::Engine.routes.url_helpers,
     }
 
     builder = JSONAPI::LinkBuilder.new(config)
@@ -113,6 +319,7 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
       base_url: @base_url,
       route_formatter: @route_formatter,
       primary_resource_klass: Api::V1::PersonResource,
+      url_helpers: TestApp.routes.url_helpers,
     }
 
     builder = JSONAPI::LinkBuilder.new(config)
@@ -125,7 +332,8 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
     config = {
       base_url: @base_url,
       route_formatter: @route_formatter,
-      primary_resource_klass: ApiV2Engine::PersonResource
+      primary_resource_klass: ApiV2Engine::PersonResource,
+      url_helpers: ApiV2Engine::Engine.routes.url_helpers,
     }
 
     builder = JSONAPI::LinkBuilder.new(config)
@@ -138,7 +346,8 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
     config = {
       base_url: @base_url,
       route_formatter: @route_formatter,
-      primary_resource_klass: MyEngine::Api::V1::PersonResource
+      primary_resource_klass: MyEngine::Api::V1::PersonResource,
+      url_helpers: MyEngine::Engine.routes.url_helpers,
     }
 
     builder = JSONAPI::LinkBuilder.new(config)
@@ -151,108 +360,149 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
     config = {
       base_url: @base_url,
       route_formatter: @route_formatter,
-      primary_resource_klass: Api::V1::PersonResource
+      primary_resource_klass: Api::V1::PersonResource,
+      url_helpers: TestApp.routes.url_helpers,
     }
 
     builder       = JSONAPI::LinkBuilder.new(config)
     source        = Api::V1::PersonResource.new(@steve, nil)
-    relationship  = JSONAPI::Relationship::ToMany.new("posts", {parent_resource: Api::V1::PersonResource})
+    relationship  = Api::V1::PersonResource._relationships[:posts]
     expected_link = "#{ @base_url }/api/v1/people/#{ @steve.id }/relationships/posts"
 
     assert_equal expected_link,
-      builder.relationships_self_link(source, relationship)
+                 builder.relationships_self_link(source, relationship)
+  end
+
+  def test_relationships_self_link_for_regular_app_singleton
+    config = {
+      base_url: @base_url,
+      route_formatter: @route_formatter,
+      primary_resource_klass: Api::V1::PersonResource,
+      url_helpers: TestApp.routes.url_helpers,
+    }
+
+    builder       = JSONAPI::LinkBuilder.new(config)
+    source        = Api::V1::PreferencesResource.new(@steves_prefs, nil)
+    relationship  = Api::V1::PreferencesResource._relationships[:author]
+    expected_link = "#{ @base_url }/api/v1/preferences/relationships/author"
+
+    assert_equal expected_link,
+                 builder.relationships_self_link(source, relationship)
+  end
+
+  def test_relationships_related_link_for_regular_app_singleton
+    config = {
+      base_url: @base_url,
+      route_formatter: @route_formatter,
+      primary_resource_klass: Api::V1::PersonResource,
+      url_helpers: TestApp.routes.url_helpers,
+    }
+
+    builder       = JSONAPI::LinkBuilder.new(config)
+    source        = Api::V1::PreferencesResource.new(@steves_prefs, nil)
+    relationship  = Api::V1::PreferencesResource._relationships[:author]
+    expected_link = "#{ @base_url }/api/v1/preferences/author"
+
+    assert_equal expected_link,
+                 builder.relationships_related_link(source, relationship)
   end
 
   def test_relationships_self_link_for_engine
     config = {
       base_url: @base_url,
       route_formatter: @route_formatter,
-      primary_resource_klass: ApiV2Engine::PersonResource
+      primary_resource_klass: ApiV2Engine::PersonResource,
+      url_helpers: ApiV2Engine::Engine.routes.url_helpers,
     }
 
     builder       = JSONAPI::LinkBuilder.new(config)
     source        = ApiV2Engine::PersonResource.new(@steve, nil)
-    relationship  = JSONAPI::Relationship::ToMany.new("posts", {parent_resource: ApiV2Engine::PersonResource})
+    relationship  = ApiV2Engine::PersonResource._relationships[:posts]
     expected_link = "#{ @base_url }/api_v2/people/#{ @steve.id }/relationships/posts"
 
     assert_equal expected_link,
-      builder.relationships_self_link(source, relationship)
+                 builder.relationships_self_link(source, relationship)
   end
 
   def test_relationships_self_link_for_namespaced_engine
     config = {
       base_url: @base_url,
       route_formatter: @route_formatter,
-      primary_resource_klass: MyEngine::Api::V1::PersonResource
+      primary_resource_klass: MyEngine::Api::V1::PersonResource,
+      url_helpers: MyEngine::Engine.routes.url_helpers,
     }
 
     builder       = JSONAPI::LinkBuilder.new(config)
     source        = MyEngine::Api::V1::PersonResource.new(@steve, nil)
-    relationship  = JSONAPI::Relationship::ToMany.new("posts", {parent_resource: MyEngine::Api::V1::PersonResource})
+    relationship  = MyEngine::Api::V1::PersonResource._relationships[:posts]
     expected_link = "#{ @base_url }/boomshaka/api/v1/people/#{ @steve.id }/relationships/posts"
 
     assert_equal expected_link,
-      builder.relationships_self_link(source, relationship)
+                 builder.relationships_self_link(source, relationship)
   end
 
   def test_relationships_related_link_for_regular_app
     config = {
       base_url: @base_url,
       route_formatter: @route_formatter,
-      primary_resource_klass: Api::V1::PersonResource
+      primary_resource_klass: Api::V1::PersonResource,
+      url_helpers: TestApp.routes.url_helpers,
     }
 
     builder       = JSONAPI::LinkBuilder.new(config)
     source        = Api::V1::PersonResource.new(@steve, nil)
-    relationship  = JSONAPI::Relationship::ToMany.new("posts", {parent_resource: Api::V1::PersonResource})
+    relationship  = Api::V1::PersonResource._relationships[:posts]
     expected_link = "#{ @base_url }/api/v1/people/#{ @steve.id }/posts"
 
     assert_equal expected_link,
-      builder.relationships_related_link(source, relationship)
+                 builder.relationships_related_link(source, relationship)
   end
 
   def test_relationships_related_link_for_engine
     config = {
       base_url: @base_url,
       route_formatter: @route_formatter,
-      primary_resource_klass: ApiV2Engine::PersonResource
+      primary_resource_klass: ApiV2Engine::PersonResource,
+      url_helpers: ApiV2Engine::Engine.routes.url_helpers,
     }
 
     builder       = JSONAPI::LinkBuilder.new(config)
     source        = ApiV2Engine::PersonResource.new(@steve, nil)
-    relationship  = JSONAPI::Relationship::ToMany.new("posts", {parent_resource: ApiV2Engine::PersonResource})
+    relationship  = ApiV2Engine::PersonResource._relationships[:posts]
     expected_link = "#{ @base_url }/api_v2/people/#{ @steve.id }/posts"
 
     assert_equal expected_link,
-      builder.relationships_related_link(source, relationship)
+                 builder.relationships_related_link(source, relationship)
   end
 
   def test_relationships_related_link_for_namespaced_engine
     config = {
       base_url: @base_url,
       route_formatter: @route_formatter,
-      primary_resource_klass: MyEngine::Api::V1::PersonResource
+      primary_resource_klass: MyEngine::Api::V1::PersonResource,
+      url_helpers: MyEngine::Engine.routes.url_helpers,
     }
 
     builder       = JSONAPI::LinkBuilder.new(config)
     source        = MyEngine::Api::V1::PersonResource.new(@steve, nil)
-    relationship  = JSONAPI::Relationship::ToMany.new("posts", {parent_resource: MyEngine::Api::V1::PersonResource})
+    relationship  = MyEngine::Api::V1::PersonResource._relationships[:posts]
     expected_link = "#{ @base_url }/boomshaka/api/v1/people/#{ @steve.id }/posts"
 
     assert_equal expected_link,
-      builder.relationships_related_link(source, relationship)
+                 builder.relationships_related_link(source, relationship)
   end
 
   def test_relationships_related_link_with_query_params
     config = {
       base_url: @base_url,
       route_formatter: @route_formatter,
-      primary_resource_klass: Api::V1::PersonResource
+      primary_resource_klass: Api::V1::PersonResource,
+      url_helpers: TestApp.routes.url_helpers,
     }
 
     builder       = JSONAPI::LinkBuilder.new(config)
     source        = Api::V1::PersonResource.new(@steve, nil)
-    relationship  = JSONAPI::Relationship::ToMany.new("posts", {parent_resource: Api::V1::PersonResource})
+    relationship  = Api::V1::PersonResource._relationships[:posts]
     expected_link = "#{ @base_url }/api/v1/people/#{ @steve.id }/posts?page%5Blimit%5D=12&page%5Boffset%5D=0"
     query         = { page: { offset: 0, limit: 12 } }
 
@@ -264,7 +514,8 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
     config = {
       base_url: @base_url,
       route_formatter: @route_formatter,
-      primary_resource_klass: Api::V1::PersonResource
+      primary_resource_klass: Api::V1::PersonResource,
+      url_helpers: TestApp.routes.url_helpers,
     }
 
     query         = { page: { offset: 0, limit: 12 } }
@@ -278,7 +529,8 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
     config = {
       base_url: @base_url,
       route_formatter: @route_formatter,
-      primary_resource_klass: AdminApi::V1::PersonResource
+      primary_resource_klass: AdminApi::V1::PersonResource,
+      url_helpers: TestApp.routes.url_helpers,
     }
 
     query         = { page: { offset: 0, limit: 12 } }
@@ -290,9 +542,10 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
 
   def test_query_link_for_regular_app_with_dasherized_scope
     config = {
-        base_url: @base_url,
-        route_formatter: DasherizedRouteFormatter,
-        primary_resource_klass: DasherizedNamespace::V1::PersonResource
+      base_url: @base_url,
+      route_formatter: DasherizedRouteFormatter,
+      primary_resource_klass: DasherizedNamespace::V1::PersonResource,
+      url_helpers: TestApp.routes.url_helpers,
     }
 
     query         = { page: { offset: 0, limit: 12 } }
@@ -306,7 +559,8 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
     config = {
       base_url: @base_url,
       route_formatter: @route_formatter,
-      primary_resource_klass: ApiV2Engine::PersonResource
+      primary_resource_klass: ApiV2Engine::PersonResource,
+      url_helpers: ApiV2Engine::Engine.routes.url_helpers,
     }
 
     query         = { page: { offset: 0, limit: 12 } }
@@ -320,7 +574,8 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
     config = {
       base_url: @base_url,
       route_formatter: @route_formatter,
-      primary_resource_klass: MyEngine::Api::V1::PersonResource
+      primary_resource_klass: MyEngine::Api::V1::PersonResource,
+      url_helpers: MyEngine::Engine.routes.url_helpers,
     }
 
     query         = { page: { offset: 0, limit: 12 } }
@@ -332,9 +587,10 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
 
   def test_query_link_for_engine_with_dasherized_scope
     config = {
-        base_url: @base_url,
-        route_formatter: DasherizedRouteFormatter,
-        primary_resource_klass: MyEngine::DasherizedNamespace::V1::PersonResource
+      base_url: @base_url,
+      route_formatter: DasherizedRouteFormatter,
+      primary_resource_klass: MyEngine::DasherizedNamespace::V1::PersonResource,
+      url_helpers: MyEngine::Engine.routes.url_helpers,
     }
 
     query         = { page: { offset: 0, limit: 12 } }
@@ -348,7 +604,8 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
     config = {
       base_url: @base_url,
       route_formatter: @route_formatter,
-      primary_resource_klass: MyEngine::AdminApi::V1::PersonResource
+      primary_resource_klass: MyEngine::AdminApi::V1::PersonResource,
+      url_helpers: MyEngine::Engine.routes.url_helpers,
     }
 
     query         = { page: { offset: 0, limit: 12 } }

--- a/test/unit/serializer/serializer_test.rb
+++ b/test/unit/serializer/serializer_test.rb
@@ -30,7 +30,8 @@ class SerializerTest < ActionDispatch::IntegrationTest
 
     serializer = JSONAPI::ResourceSerializer.new(
         PostResource,
-        base_url: 'http://example.com')
+        base_url: 'http://example.com',
+        url_helpers: TestApp.routes.url_helpers)
 
     resource_set.populate!(serializer, {}, {})
     serialized = serializer.serialize_resource_set_to_hash_single(resource_set)
@@ -87,7 +88,8 @@ class SerializerTest < ActionDispatch::IntegrationTest
 
     serializer = JSONAPI::ResourceSerializer.new(
         Api::V1::PostResource,
-        base_url: 'http://example.com')
+        base_url: 'http://example.com',
+        url_helpers: TestApp.routes.url_helpers)
 
     resource_set.populate!(serializer, {}, {})
     serialized = serializer.serialize_resource_set_to_hash_single(resource_set)
@@ -111,7 +113,8 @@ class SerializerTest < ActionDispatch::IntegrationTest
 
     serializer = JSONAPI::ResourceSerializer.new(
         Api::V1::PostResource,
-        base_url: 'http://example.com')
+        base_url: 'http://example.com',
+        url_helpers: TestApp.routes.url_helpers)
 
     resource_set.populate!(serializer, {}, {})
     serialized = serializer.serialize_resource_set_to_hash_single(resource_set)
@@ -167,7 +170,8 @@ class SerializerTest < ActionDispatch::IntegrationTest
 
     serializer = JSONAPI::ResourceSerializer.new(
         PostResource,
-        fields: {posts: [:id, :title, :author]})
+        fields: {posts: [:id, :title, :author]},
+        url_helpers: TestApp.routes.url_helpers)
 
     resource_set.populate!(serializer, {}, {})
     serialized = serializer.serialize_resource_set_to_hash_single(resource_set)
@@ -215,7 +219,8 @@ class SerializerTest < ActionDispatch::IntegrationTest
 
     resource_set = JSONAPI::ResourceSet.new(id_tree)
 
-    serializer = JSONAPI::ResourceSerializer.new(PostResource)
+    serializer = JSONAPI::ResourceSerializer.new(PostResource,
+                                                 url_helpers: TestApp.routes.url_helpers)
 
     resource_set.populate!(serializer, {}, {})
     serialized = serializer.serialize_resource_set_to_hash_single(resource_set)
@@ -303,8 +308,8 @@ class SerializerTest < ActionDispatch::IntegrationTest
              },
              hairCut: {
                links: {
-                 self: '/people/1001/relationships/hair_cut',
-                 related: '/people/1001/hair_cut'
+                 self: '/people/1001/relationships/hairCut',
+                 related: '/people/1001/hairCut'
                }
              },
              vehicles: {
@@ -315,8 +320,8 @@ class SerializerTest < ActionDispatch::IntegrationTest
              },
              expenseEntries: {
                links: {
-                 self: '/people/1001/relationships/expense_entries',
-                 related: '/people/1001/expense_entries'
+                 self: '/people/1001/relationships/expenseEntries',
+                 related: '/people/1001/expenseEntries'
                }
              }
             }
@@ -346,7 +351,8 @@ class SerializerTest < ActionDispatch::IntegrationTest
     resource_set = JSONAPI::ResourceSet.new(id_tree)
 
     serializer = JSONAPI::ResourceSerializer.new(PostResource,
-                                                 key_formatter: UnderscoredKeyFormatter,)
+                                                 key_formatter: UnderscoredKeyFormatter,
+                                                 url_helpers: TestApp.routes.url_helpers)
 
     resource_set.populate!(serializer, {}, {})
     serialized = serializer.serialize_resource_set_to_hash_single(resource_set)
@@ -434,8 +440,8 @@ class SerializerTest < ActionDispatch::IntegrationTest
                         },
                         hair_cut: {
                             links: {
-                                self: '/people/1001/relationships/hair_cut',
-                                related: '/people/1001/hair_cut'
+                                self: '/people/1001/relationships/hairCut',
+                                related: '/people/1001/hairCut'
                             }
                         },
                         vehicles: {
@@ -446,8 +452,8 @@ class SerializerTest < ActionDispatch::IntegrationTest
                         },
                         expense_entries: {
                             links: {
-                                self: '/people/1001/relationships/expense_entries',
-                                related: '/people/1001/expense_entries'
+                                self: '/people/1001/relationships/expenseEntries',
+                                related: '/people/1001/expenseEntries'
                             }
                         }
                     }
@@ -476,7 +482,8 @@ class SerializerTest < ActionDispatch::IntegrationTest
     id_tree.add_resource_fragment(fragment, directives[:include_related])
     resource_set = JSONAPI::ResourceSet.new(id_tree)
 
-    serializer = JSONAPI::ResourceSerializer.new(PostResource)
+    serializer = JSONAPI::ResourceSerializer.new(PostResource,
+                                                 url_helpers: TestApp.routes.url_helpers)
 
     resource_set.populate!(serializer, {}, {})
     serialized = serializer.serialize_resource_set_to_hash_single(resource_set)


### PR DESCRIPTION
Revert building links with 'url_helpers' for performance reasons

Now tracking whether routes have been setup for resources and relationships in the respective objects. This allows for the efficiency of string based link generation as well as warning when a route has not been setup. This should restore the performance we lost with the `url_helpers`.

Also reworked way the LinkBuilder handles Engines.

This is the same basic changes as #1262 

Closes #1259 

### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [x] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [x] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [x] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [x] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions