### PR TITLE
Revert "Use `destroy` instead of `delete` to ensure callbacks are called - master

### DIFF
--- a/lib/jsonapi/basic_resource.rb
+++ b/lib/jsonapi/basic_resource.rb
@@ -365,7 +365,7 @@ module JSONAPI
 
         @reload_needed = true
       else
-        @model.public_send(relationship.relation_name(context: @context)).destroy(key)
+        @model.public_send(relationship.relation_name(context: @context)).delete(key)
       end
 
       :completed

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -1396,6 +1396,25 @@ class PostsControllerTest < ActionController::TestCase
     assert_equal ruby.id, post_object.section_id
   end
 
+  def test_remove_relationship_to_many_belongs_to
+    set_content_type_header!
+    c = Comment.find(3)
+    p = Post.find(2)
+    total_comment_count = Comment.count
+    post_comment_count = p.comments.count
+
+    put :destroy_relationship, params: {post_id: "#{p.id}", relationship: 'comments', data: [{type: 'comments', id: "#{c.id}"}]}
+
+    assert_response :no_content
+    p = Post.find(2)
+    c = Comment.find(3)
+
+    assert_equal post_comment_count - 1, p.comments.length
+    assert_equal total_comment_count, Comment.count
+
+    assert_nil c.post_id
+  end
+
   def test_update_relationship_to_many_join_table_single
     set_content_type_header!
     put :update_relationship, params: {post_id: 3, relationship: 'tags', data: []}


### PR DESCRIPTION
Cherry picked changes from #1261.

Resolves #1260 on the master branch

### All Submissions:

- [ ] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions