### PR TITLE
Fix issues with resource definition order and initializers.

### DIFF
--- a/lib/jsonapi/basic_resource.rb
+++ b/lib/jsonapi/basic_resource.rb
@@ -422,11 +422,13 @@ module JSONAPI
         subclass.abstract(false)
         subclass.immutable(false)
         subclass.caching(_caching)
+        subclass.cache_field(_cache_field) if @_cache_field
         subclass.singleton(singleton?, (_singleton_options.dup || {}))
         subclass.exclude_links(_exclude_links)
-        subclass.paginator(_paginator)
+        subclass.paginator(@_paginator)
         subclass._attributes = (_attributes || {}).dup
         subclass.polymorphic(false)
+        subclass.key_type(@_resource_key_type)
 
         subclass._model_hints = (_model_hints || {}).dup
 
@@ -755,7 +757,7 @@ module JSONAPI
       end
 
       def resource_key_type
-        @_resource_key_type ||= JSONAPI.configuration.resource_key_type
+        @_resource_key_type || JSONAPI.configuration.resource_key_type
       end
 
       # override to all resolution of masked ids to actual ids. Because singleton routes do not specify the id this
@@ -878,7 +880,7 @@ module JSONAPI
       end
 
       def _cache_field
-        @_cache_field ||= JSONAPI.configuration.default_resource_cache_field
+        @_cache_field || JSONAPI.configuration.default_resource_cache_field
       end
 
       def _table_name
@@ -898,7 +900,7 @@ module JSONAPI
       end
 
       def _paginator
-        @_paginator ||= JSONAPI.configuration.default_paginator
+        @_paginator || JSONAPI.configuration.default_paginator
       end
 
       def paginator(paginator)


### PR DESCRIPTION
Resources initialized before configuration initializer inherit the
default configuration options, not the intended configuration.

This was affecting the paginator. In addition the _cache_field and
key_type are updated for consistency when resources are defined from a
base resource.

### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [x] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions