### PR TITLE
Performance

### DIFF
--- a/lib/jsonapi/basic_resource.rb
+++ b/lib/jsonapi/basic_resource.rb
@@ -455,6 +455,7 @@ module JSONAPI
         subclass._warned_missing_route = false
 
         subclass._clear_cached_attribute_options
+        subclass._clear_fields_cache
       end
 
       def rebuild_relationships(relationships)
@@ -530,6 +531,7 @@ module JSONAPI
 
       def attribute(attribute_name, options = {})
         _clear_cached_attribute_options
+        _clear_fields_cache
 
         attr = attribute_name.to_sym
 
@@ -697,7 +699,7 @@ module JSONAPI
       end
 
       def fields
-        _relationships.keys | _attributes.keys
+        @_fields_cache ||= _relationships.keys | _attributes.keys
       end
 
       def resources_for(records, context)
@@ -1067,6 +1069,8 @@ module JSONAPI
       end
 
       def _add_relationship(klass, *attrs)
+        _clear_fields_cache
+
         options = attrs.extract_options!
         options[:parent_resource] = self
 
@@ -1113,6 +1117,10 @@ module JSONAPI
 
       def _clear_cached_attribute_options
         @_cached_attribute_options = {}
+      end
+
+      def _clear_fields_cache
+        @_fields_cache = nil
       end
 
       private

--- a/lib/jsonapi/basic_resource.rb
+++ b/lib/jsonapi/basic_resource.rb
@@ -453,6 +453,8 @@ module JSONAPI
 
         subclass._routed = false
         subclass._warned_missing_route = false
+
+        subclass._clear_cached_attribute_options
       end
 
       def rebuild_relationships(relationships)
@@ -527,6 +529,8 @@ module JSONAPI
       end
 
       def attribute(attribute_name, options = {})
+        _clear_cached_attribute_options
+
         attr = attribute_name.to_sym
 
         check_reserved_attribute_name(attr)
@@ -826,7 +830,7 @@ module JSONAPI
 
       # quasi private class methods
       def _attribute_options(attr)
-        default_attribute_options.merge(@_attributes[attr])
+        @_cached_attribute_options[attr] ||= default_attribute_options.merge(@_attributes[attr])
       end
 
       def _attribute_delegated_name(attr)
@@ -1105,6 +1109,10 @@ module JSONAPI
 
       def register_relationship(name, relationship_object)
         @_relationships[name] = relationship_object
+      end
+
+      def _clear_cached_attribute_options
+        @_cached_attribute_options = {}
       end
 
       private

--- a/lib/jsonapi/link_builder.rb
+++ b/lib/jsonapi/link_builder.rb
@@ -123,7 +123,8 @@ module JSONAPI
     end
 
     def resources_path(source_klass)
-      formatted_module_path_from_class(source_klass) + format_route(source_klass._type.to_s)
+      @_resources_path ||= {}
+      @_resources_path[source_klass] ||= formatted_module_path_from_class(source_klass) + format_route(source_klass._type.to_s)
     end
 
     def resource_path(source)

--- a/lib/jsonapi/link_builder.rb
+++ b/lib/jsonapi/link_builder.rb
@@ -127,12 +127,11 @@ module JSONAPI
     end
 
     def resource_path(source)
-      url = "#{resources_path(source.class)}"
-
-      unless source.class.singleton?
-        url = "#{url}/#{source.id}"
+      if source.class.singleton?
+        resources_path(source.class)
+      else
+        "#{resources_path(source.class)}/#{source.id}"
       end
-      url
     end
 
     def resource_url(source)

--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -230,7 +230,7 @@ module JSONAPI
     end
 
     def custom_generation_options
-      {
+      @_custom_generation_options ||= {
         serializer: self,
         serialization_options: @serialization_options
       }


### PR DESCRIPTION
A set of tweaks to reduce memory allocation in the worst spots. In general I've been trying to avoid premature optimizations, but I think in this case they are clear enough, and have enough benefit, to make it worth the minor added complexity.

Results from using the Peeps app with rack-mini-profiler:
```ruby
gem 'rack-mini-profiler'
gem 'memory_profiler'
```
`http://localhost:3000/contacts?include=phone-numbers&pp=profile-memory`

Without:

```
Total allocated: 7562865 bytes (83291 objects)
Total retained:  543442 bytes (3826 objects)

allocated memory by gem
-----------------------------------
   2889655  jsonapi-resources/lib
   2001415  activesupport-5.2.3
    647682  activerecord-5.2.3
    561114  activemodel-5.2.3
    551528  set
    526434  json
    112432  bootsnap-1.4.4
     74306  sqlite3-1.4.1
     48232  tzinfo-1.2.5
     33544  arel-9.0.0
     29805  actionpack-5.2.3
     29399  digest
     23319  csv
      8973  rack-2.0.7
      6932  actionview-5.2.3
      4136  logger
      4104  concurrent-ruby-1.1.5
      3720  ipaddr
      2872  web-console-3.7.0
      1754  railties-5.2.3
       677  securerandom
       360  uri
       320  monitor
        72  mutex_m
        40  i18n-1.6.0
        40  rack-mini-profiler-1.0.2
```

And with this PR:

```
Total allocated: 6481135 bytes (71271 objects)
Total retained:  545970 bytes (3837 objects)

allocated memory by gem
-----------------------------------
   2001077  activesupport-5.2.3
   1808263  jsonapi-resources/lib
    647682  activerecord-5.2.3
    561114  activemodel-5.2.3
    551528  set
    526434  json
    112432  bootsnap-1.4.4
     74306  sqlite3-1.4.1
     48232  tzinfo-1.2.5
     33544  arel-9.0.0
     29805  actionpack-5.2.3
     29399  digest
     23319  csv
      8973  rack-2.0.7
      6932  actionview-5.2.3
      4136  logger
      4104  concurrent-ruby-1.1.5
      3720  ipaddr
      2872  web-console-3.7.0
      1754  railties-5.2.3
       677  securerandom
       360  uri
       320  monitor
        72  mutex_m
        40  i18n-1.6.0
        40  rack-mini-profiler-1.0.2

```

Timings run against a fresh development instance with no warm up show about a 6-7% improvement as well. The request is returning 50 primary and 100 related resources.

### All Submissions:

- [ ] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions