### PR TITLE
Warn on performance issues: non-normalized result set

### DIFF
--- a/lib/jsonapi/active_relation_resource.rb
+++ b/lib/jsonapi/active_relation_resource.rb
@@ -181,6 +181,10 @@ module JSONAPI
           end
         end
 
+        if JSONAPI.configuration.warn_on_performance_issues && (rows.length > fragments.length)
+          warn "Performance issue detected: `#{self.name.to_s}.records` returned non-normalized results in `#{self.name.to_s}.find_fragments`."
+        end
+
         fragments
       end
 

--- a/lib/jsonapi/configuration.rb
+++ b/lib/jsonapi/configuration.rb
@@ -10,6 +10,7 @@ module JSONAPI
                 :raise_if_parameters_not_allowed,
                 :warn_on_route_setup_issues,
                 :warn_on_missing_routes,
+                :warn_on_performance_issues,
                 :default_allow_include_to_one,
                 :default_allow_include_to_many,
                 :allow_sort,
@@ -60,6 +61,7 @@ module JSONAPI
 
       self.warn_on_route_setup_issues = true
       self.warn_on_missing_routes = true
+      self.warn_on_performance_issues = true
 
       # :none, :offset, :paged, or a custom paginator name
       self.default_paginator = :none
@@ -271,6 +273,8 @@ module JSONAPI
     attr_writer :warn_on_route_setup_issues
 
     attr_writer :warn_on_missing_routes
+
+    attr_writer :warn_on_performance_issues
 
     attr_writer :use_relationship_reflection
 

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -3625,6 +3625,29 @@ class Api::V2::BookCommentsControllerTest < ActionController::TestCase
   end
 end
 
+class Api::V4::PostsControllerTest < ActionController::TestCase
+  def test_warn_on_joined_to_many
+    original_config = JSONAPI.configuration.dup
+
+    JSONAPI.configuration.warn_on_performance_issues = true
+    _out, err = capture_subprocess_io do
+      get :index, params: {fields: {posts: 'id,title'}}
+      assert_response :success
+    end
+    assert_equal(err, "Performance issue detected: `Api::V4::PostResource.records` returned non-normalized results in `Api::V4::PostResource.find_fragments`.\n")
+
+    JSONAPI.configuration.warn_on_performance_issues = false
+    _out, err = capture_subprocess_io do
+      get :index, params: {fields: {posts: 'id,title'}}
+      assert_response :success
+    end
+    assert_empty err
+
+  ensure
+    JSONAPI.configuration = original_config
+  end
+end
+
 class Api::V4::BooksControllerTest < ActionController::TestCase
   def setup
     JSONAPI.configuration.json_key_format = :camelized_key

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -1989,7 +1989,15 @@ end
 
 module Api
   module V4
-    class PostResource < PostResource; end
+    class PostResource < PostResource
+      class << self
+        def records(options = {})
+          # Sets up a performance issue for testing
+          super(options).joins(:comments)
+        end
+      end
+    end
+
     class PersonResource < PersonResource; end
     class ExpenseEntryResource < ExpenseEntryResource; end
     class IsoCurrencyResource < IsoCurrencyResource


### PR DESCRIPTION
With the removal of the `distinct` call in #1225 it's now possible for a user who overrides `records` and joins in a has_many relationship to experience extremely slow responses due to non-normalized data. Using `distinct` was hiding this database access faux pas.

This PR adds detection based on the assumption that every row in the result set should translate into a unique resource fragment. If the counts do not match a warning is given in the logs. This warning can be controlled with a new configuration option, `warn_on_performance_issues`.

It's planned that future performance issue checks will be controlled with the same configuration setting.

### All Submissions:

- [X] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions