### PR TITLE
Fix typo in config_description hash key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,22 @@ language: ruby
 sudo: false
 env:
   - "RAILS_VERSION=4.2.11"
-  - "RAILS_VERSION=5.0.7.1"
-  - "RAILS_VERSION=5.1.6.1"
-  - "RAILS_VERSION=5.2.2"
+  - "RAILS_VERSION=5.0.7.2"
+  - "RAILS_VERSION=5.1.7"
+  - "RAILS_VERSION=5.2.3"
 #  - "RAILS_VERSION=6.0.0.beta1"
 #  - "RAILS_VERSION=master"
 rvm:
   - 2.3.8
-  - 2.4.5
-  - 2.5.3
-  - 2.6.1
+  - 2.4.7
+  - 2.5.6
+  - 2.6.4
 matrix:
   allow_failures:
     - env: "RAILS_VERSION=master"
     - env: "RAILS_VERSION=6.0.0.beta1"
   exclude:
-    - rvm: 2.6.1
+    - rvm: 2.6.4
       env: "RAILS_VERSION=4.2.11"
+before_install:
+  - gem install bundler --version 1.17.3

--- a/jsonapi-resources.gemspec
+++ b/jsonapi-resources.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.1'
 
-  spec.add_development_dependency 'bundler', '~> 1.5'
+  spec.add_development_dependency 'bundler', '~> 1.17.3'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'minitest', '~> 5.10', '!= 5.10.2'
   spec.add_development_dependency 'minitest-spec-rails'

--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -131,7 +131,7 @@ module JSONAPI
     def config_description(resource_klass)
       {
         class_name: self.class.name,
-        seriserialization_options: serialization_options.sort.map(&:as_json),
+        serialization_options: serialization_options.sort.map(&:as_json),
         supplying_attribute_fields: supplying_attribute_fields(resource_klass).sort,
         supplying_relationship_fields: supplying_relationship_fields(resource_klass).sort,
         link_builder_base_url: link_builder.base_url,


### PR DESCRIPTION
Typo “seriserialization_options” → “serialization_options”. I couldn't find any references to this misspelt key in the current codebase, neither any GitHub search result besides forks of jsonapi-resources 😄 So I presume it's safe to correct it.

The only usage of the affected `config_description` method I found ends up using the keys as [part of a cache key](https://github.com/cerebris/jsonapi-resources/blob/d87cd2d2e80ab7660081c32db2303f196860b060/lib/jsonapi/resource_set.rb#L28), which won't be affected either.

closes #1273 

### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [x] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [x] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [x] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### Bug fixes and Changes to Core Features:

- [x] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions