### PR TITLE
require ruby 2.3 as minimum version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: ruby
 sudo: false
+before_install:
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'
 env:
   - "RAILS_VERSION=4.2.11"
   - "RAILS_VERSION=5.0.7.1"

--- a/jsonapi-resources.gemspec
+++ b/jsonapi-resources.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.1'
+  spec.required_ruby_version = '>= 2.3'
 
   spec.add_development_dependency 'bundler', '~> 1.5'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
In https://github.com/cerebris/jsonapi-resources/pull/1188, support for ruby2.1 and 2.2 in the CI was removed. 

When trying to use this gem with ruby 2.1, I am getting the following error:

```
jsonapi-resources-0.9.10/lib/jsonapi/resource_serializer.rb:100: syntax error, unexpected ':', expecting => (SyntaxError)
      rel_hash = { 'data': data }
```

This PR updates the required ruby version so that jsonapi-resources can't be installed on ruby versions that is does not support.


### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions