### PR TITLE
Fully support Rails 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
   - "RAILS_VERSION=5.0.7.1"
   - "RAILS_VERSION=5.1.6.1"
   - "RAILS_VERSION=5.2.2"
-#  - "RAILS_VERSION=6.0.0.beta1"
+  - "RAILS_VERSION=6.0.0"
 #  - "RAILS_VERSION=master"
 rvm:
   - 2.3.8
@@ -15,7 +15,10 @@ rvm:
 matrix:
   allow_failures:
     - env: "RAILS_VERSION=master"
-    - env: "RAILS_VERSION=6.0.0.beta1"
   exclude:
     - rvm: 2.6.1
       env: "RAILS_VERSION=4.2.11"
+    - rmv: 2.3.8
+      env: "RAILS_VERSION=6.0.0"
+    - rmv: 2.4.5
+      env: "RAILS_VERSION=6.0.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
   exclude:
     - rvm: 2.6.1
       env: "RAILS_VERSION=4.2.11"
-    - rmv: 2.3.8
+    - rvm: 2.3.8
       env: "RAILS_VERSION=6.0.0"
-    - rmv: 2.4.5
+    - rvm: 2.4.5
       env: "RAILS_VERSION=6.0.0"

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 platforms :ruby do
-  gem 'sqlite3', '1.3.13'
+  gem 'sqlite3', '~> 1.4'
 end
 
 platforms :jruby do

--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,6 @@ source 'https://rubygems.org'
 
 gemspec
 
-platforms :ruby do
-  gem 'sqlite3', '~> 1.4'
-end
-
 platforms :jruby do
   gem 'activerecord-jdbcsqlite3-adapter'
 end
@@ -17,7 +13,17 @@ when 'master'
   gem 'railties', { git: 'https://github.com/rails/rails.git' }
   gem 'arel', { git: 'https://github.com/rails/arel.git' }
 when 'default'
-  gem 'railties', '>= 5.0'
+  gem 'railties', '>= 6.0'
+when '6.0.0'
+  platforms :ruby do
+    gem 'sqlite3', '~> 1.4'
+  end
+
+  gem 'railties', "~> #{version}"
 else
+  platforms :ruby do
+    gem 'sqlite3', '1.3.13'
+  end
+
   gem 'railties', "~> #{version}"
 end

--- a/lib/jsonapi-resources.rb
+++ b/lib/jsonapi-resources.rb
@@ -7,7 +7,6 @@ require 'jsonapi/resource'
 require 'jsonapi/cached_response_fragment'
 require 'jsonapi/response_document'
 require 'jsonapi/acts_as_resource_controller'
-require 'jsonapi/resource_controller'
 require 'jsonapi/resource_controller_metal'
 require 'jsonapi/resources/version'
 require 'jsonapi/configuration'
@@ -35,3 +34,11 @@ require 'jsonapi/resource_id_tree'
 require 'jsonapi/resource_set'
 require 'jsonapi/path'
 require 'jsonapi/path_segment'
+
+if ActiveSupport.respond_to?(:on_load)
+  ActiveSupport.on_load(:action_controller_base) do
+    require 'jsonapi/resource_controller'
+  end
+else
+  require 'jsonapi/resource_controller'
+end

--- a/lib/jsonapi-resources.rb
+++ b/lib/jsonapi-resources.rb
@@ -7,6 +7,13 @@ require 'jsonapi/resource'
 require 'jsonapi/cached_response_fragment'
 require 'jsonapi/response_document'
 require 'jsonapi/acts_as_resource_controller'
+if ActiveSupport.respond_to?(:on_load)
+  ActiveSupport.on_load(:action_controller_base) do
+    require 'jsonapi/resource_controller'
+  end
+else
+  require 'jsonapi/resource_controller'
+end
 require 'jsonapi/resource_controller_metal'
 require 'jsonapi/resources/version'
 require 'jsonapi/configuration'
@@ -35,10 +42,4 @@ require 'jsonapi/resource_set'
 require 'jsonapi/path'
 require 'jsonapi/path_segment'
 
-if ActiveSupport.respond_to?(:on_load)
-  ActiveSupport.on_load(:action_controller_base) do
-    require 'jsonapi/resource_controller'
-  end
-else
-  require 'jsonapi/resource_controller'
-end
+

--- a/lib/jsonapi/active_relation/adapters/join_left_active_record_adapter.rb
+++ b/lib/jsonapi/active_relation/adapters/join_left_active_record_adapter.rb
@@ -8,7 +8,7 @@ module JSONAPI
         # example Post.joins(:comments).joins_left(comments: :author) will join the comments table twice,
         # once inner and once left in 5.2, but only as inner in earlier versions.
         def joins_left(*columns)
-          if Rails::VERSION::MAJOR >= 5 && ActiveRecord::VERSION::MINOR >= 2
+          if Rails::VERSION::MAJOR >= 6 || (Rails::VERSION::MAJOR >= 5 && ActiveRecord::VERSION::MINOR >= 2)
             left_joins(columns)
           else
             join_dependency = ActiveRecord::Associations::JoinDependency.new(self, columns, [])

--- a/test/unit/active_relation_resource_finder/join_manager_test.rb
+++ b/test/unit/active_relation_resource_finder/join_manager_test.rb
@@ -79,7 +79,7 @@ class JoinTreeTest < ActiveSupport::TestCase
     records = Api::V10::PostResource.records({})
     records = join_manager.join(records, {})
 
-    if Rails::VERSION::MAJOR >= 5 && Rails::VERSION::MINOR >= 2
+    if Rails::VERSION::MAJOR >= 6 || (Rails::VERSION::MAJOR >= 5 && ActiveRecord::VERSION::MINOR >= 2)
       assert_equal 'SELECT "posts".* FROM "posts" INNER JOIN "comments" ON "comments"."post_id" = "posts"."id" WHERE "comments"."approved" = 1', records.to_sql
     else
       assert_equal 'SELECT "posts".* FROM "posts" INNER JOIN "comments" ON "comments"."post_id" = "posts"."id" WHERE "comments"."approved" = \'t\'', records.to_sql
@@ -99,7 +99,7 @@ class JoinTreeTest < ActiveSupport::TestCase
     records = Api::V10::PostResource.records({})
     records = join_manager.join(records, {})
 
-    if Rails::VERSION::MAJOR >= 5 && Rails::VERSION::MINOR >= 2
+    if Rails::VERSION::MAJOR >= 6 || (Rails::VERSION::MAJOR >= 5 && ActiveRecord::VERSION::MINOR >= 2)
       assert_equal 'SELECT "posts".* FROM "posts" LEFT OUTER JOIN "comments" ON "comments"."post_id" = "posts"."id" LEFT OUTER JOIN "people" ON "people"."id" = "posts"."author_id" LEFT OUTER JOIN "people" "authors_comments" ON "authors_comments"."id" = "comments"."author_id" LEFT OUTER JOIN "comments_tags" ON "comments_tags"."comment_id" = "comments"."id" LEFT OUTER JOIN "tags" ON "tags"."id" = "comments_tags"."tag_id" WHERE "comments"."approved" = 1 AND "author"."special" = 1', records.to_sql
     else
       assert_equal 'SELECT "posts".* FROM "posts" LEFT OUTER JOIN "comments" ON "comments"."post_id" = "posts"."id" LEFT OUTER JOIN "people" ON "people"."id" = "posts"."author_id" LEFT OUTER JOIN "people" "authors_comments" ON "authors_comments"."id" = "comments"."author_id" LEFT OUTER JOIN "comments_tags" ON "comments_tags"."comment_id" = "comments"."id" LEFT OUTER JOIN "tags" ON "tags"."id" = "comments_tags"."tag_id" WHERE "comments"."approved" = \'t\' AND "author"."special" = \'t\'', records.to_sql
@@ -123,7 +123,7 @@ class JoinTreeTest < ActiveSupport::TestCase
     records = join_manager.join(records, {})
 
     # Note sql is in different order, but aliases should still be right
-    if Rails::VERSION::MAJOR >= 5 && Rails::VERSION::MINOR >= 2
+    if Rails::VERSION::MAJOR >= 6 || (Rails::VERSION::MAJOR >= 5 && ActiveRecord::VERSION::MINOR >= 2)
       assert_equal 'SELECT "posts".* FROM "posts" LEFT OUTER JOIN "people" ON "people"."id" = "posts"."author_id" LEFT OUTER JOIN "comments" ON "comments"."post_id" = "posts"."id" LEFT OUTER JOIN "people" "authors_comments" ON "authors_comments"."id" = "comments"."author_id" LEFT OUTER JOIN "comments_tags" ON "comments_tags"."comment_id" = "comments"."id" LEFT OUTER JOIN "tags" ON "tags"."id" = "comments_tags"."tag_id" WHERE "comments"."approved" = 1 AND "author"."special" = 1', records.to_sql
     else
       assert_equal 'SELECT "posts".* FROM "posts" LEFT OUTER JOIN "people" ON "people"."id" = "posts"."author_id" LEFT OUTER JOIN "comments" ON "comments"."post_id" = "posts"."id" LEFT OUTER JOIN "people" "authors_comments" ON "authors_comments"."id" = "comments"."author_id" LEFT OUTER JOIN "comments_tags" ON "comments_tags"."comment_id" = "comments"."id" LEFT OUTER JOIN "tags" ON "tags"."id" = "comments_tags"."tag_id" WHERE "comments"."approved" = \'t\' AND "author"."special" = \'t\'', records.to_sql
@@ -163,7 +163,7 @@ class JoinTreeTest < ActiveSupport::TestCase
     records = Api::V10::PostResource.records({})
     records = join_manager.join(records, {})
 
-    if Rails::VERSION::MAJOR >= 5 && Rails::VERSION::MINOR >= 2
+    if Rails::VERSION::MAJOR >= 6 || (Rails::VERSION::MAJOR >= 5 && ActiveRecord::VERSION::MINOR >= 2)
       assert_equal 'SELECT "posts".* FROM "posts" LEFT OUTER JOIN "comments" ON "comments"."post_id" = "posts"."id" LEFT OUTER JOIN "people" ON "people"."id" = "posts"."author_id" LEFT OUTER JOIN "people" "authors_comments" ON "authors_comments"."id" = "comments"."author_id" LEFT OUTER JOIN "comments_tags" ON "comments_tags"."comment_id" = "comments"."id" LEFT OUTER JOIN "tags" ON "tags"."id" = "comments_tags"."tag_id" WHERE "comments"."approved" = 1 AND "author"."special" = 1', records.to_sql
     else
       assert_equal 'SELECT "posts".* FROM "posts" LEFT OUTER JOIN "comments" ON "comments"."post_id" = "posts"."id" LEFT OUTER JOIN "people" ON "people"."id" = "posts"."author_id" LEFT OUTER JOIN "people" "authors_comments" ON "authors_comments"."id" = "comments"."author_id" LEFT OUTER JOIN "comments_tags" ON "comments_tags"."comment_id" = "comments"."id" LEFT OUTER JOIN "tags" ON "tags"."id" = "comments_tags"."tag_id" WHERE "comments"."approved" = \'t\' AND "author"."special" = \'t\'', records.to_sql
@@ -184,7 +184,7 @@ class JoinTreeTest < ActiveSupport::TestCase
     records = Api::V10::PostResource.records({})
     records = join_manager.join(records, {})
 
-    if Rails::VERSION::MAJOR >= 5 && Rails::VERSION::MINOR >= 2
+    if Rails::VERSION::MAJOR >= 6 || (Rails::VERSION::MAJOR >= 5 && ActiveRecord::VERSION::MINOR >= 2)
       assert_equal 'SELECT "posts".* FROM "posts" INNER JOIN "comments" ON "comments"."post_id" = "posts"."id" LEFT OUTER JOIN "people" ON "people"."id" = "comments"."author_id" LEFT OUTER JOIN "comments_tags" ON "comments_tags"."comment_id" = "comments"."id" LEFT OUTER JOIN "tags" ON "tags"."id" = "comments_tags"."tag_id" LEFT OUTER JOIN "comments" "comments_people" ON "comments_people"."author_id" = "people"."id" WHERE "comments"."approved" = 1 AND "author"."special" = 1', records.to_sql
     else
       assert_equal 'SELECT "posts".* FROM "posts" INNER JOIN "comments" ON "comments"."post_id" = "posts"."id" LEFT OUTER JOIN "people" ON "people"."id" = "comments"."author_id" LEFT OUTER JOIN "comments_tags" ON "comments_tags"."comment_id" = "comments"."id" LEFT OUTER JOIN "tags" ON "tags"."id" = "comments_tags"."tag_id" LEFT OUTER JOIN "comments" "comments_people" ON "comments_people"."author_id" = "people"."id" WHERE "comments"."approved" = \'t\' AND "author"."special" = \'t\'', records.to_sql


### PR DESCRIPTION
Removes the deprecation warning for autoloading constants with Rails 6.

The message appears, because we are referencing `ActionController::Base` before it was loaded.

fixes #1280
fixes #1275 

Should add full Rails 6 support

### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [x] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [x] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### Bug fixes and Changes to Core Features:

- [x] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions