### PR TITLE
Consider config.relative_url_root in ActsAsResourceController.base_url

### DIFF
--- a/lib/jsonapi/acts_as_resource_controller.rb
+++ b/lib/jsonapi/acts_as_resource_controller.rb
@@ -152,7 +152,7 @@ module JSONAPI
     end
 
     def base_url
-      @base_url ||= request.protocol + request.host_with_port
+      @base_url ||= "#{request.protocol}#{request.host_with_port}#{Rails.application.config.relative_url_root}"
     end
 
     def resource_klass_name

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -10,6 +10,12 @@ class PostsControllerTest < ActionController::TestCase
     JSONAPI.configuration.always_include_to_one_linkage_data = false
   end
 
+  def test_links_include_relative_root
+    Rails.application.config.relative_url_root = '/subdir'
+    assert_cacheable_get :index
+    assert json_response['data'][0]['links']['self'].include?('/subdir')
+  end
+
   def test_index
     assert_cacheable_get :index
     assert_response :success

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -14,6 +14,7 @@ class PostsControllerTest < ActionController::TestCase
     Rails.application.config.relative_url_root = '/subdir'
     assert_cacheable_get :index
     assert json_response['data'][0]['links']['self'].include?('/subdir')
+    Rails.application.config.relative_url_root = nil
   end
 
   def test_index


### PR DESCRIPTION
When Rails is deployed to a subdirectory per [the official guide instructions](https://guides.rubyonrails.org/configuring.html#deploy-to-a-subdirectory-relative-url-root), JSON:API should take this into account.

Implementation detail: Switched from string concatenation (`+`) to string interpolation because `Rails.application.config.relative_url_root` might be `nil`, which would cause an error as @hlogmans [already stated](https://github.com/cerebris/jsonapi-resources/issues/473#issuecomment-153719383).

Tested with:
- Setting `RAILS_RELATIVE_URL_ROOT=/subdirectory`
- Adding `config.relative_url_root = '/subdirectory'` in application.rb or <environment>.rb

Fixes #473



### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [x] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [x] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [x] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [x] I've added/updated tests for this change.

### Bug fixes and Changes to Core Features:

- [x] I've included an explanation of what the changes do and why I'd like you to include them.
- [x] I've provided test(s) that fails without the change.

### Test Plan:
Unit test: `bundle exec ruby -I test test/controllers/controller_test.rb -n test_links_include_relative_root`

Manual testing:
1. Add `config.relative_url_root = '/subdirectory'` to `config/application.rb`
2. Run Rails server
3. Fetch any resource URL
Expected result: Link objects contain `/subdirectory`

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions