### PR TITLE
Fix for Postgres SQL generation error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,31 @@
 language: ruby
 sudo: false
+services:
+  - postgresql
 env:
-  - "RAILS_VERSION=4.2.11"
-  - "RAILS_VERSION=5.0.7.2"
-  - "RAILS_VERSION=5.1.7"
-  - "RAILS_VERSION=5.2.3"
-  - "RAILS_VERSION=6.0.0"
-#  - "RAILS_VERSION=master"
+  - RAILS_VERSION=6.0.0 DATABASE_URL=postgres://postgres@localhost/jr_test
+  - RAILS_VERSION=6.0.0
+  - RAILS_VERSION=5.2.3 DATABASE_URL=postgres://postgres@localhost/jr_test
+  - RAILS_VERSION=5.2.3
+  - RAILS_VERSION=5.1.7
+  - RAILS_VERSION=5.0.7.2
+  - RAILS_VERSION=4.2.11
 rvm:
-  - 2.3.8
-  - 2.4.7
-  - 2.5.6
-  - 2.6.4
+  - 2.4.9
+  - 2.5.7
+  - 2.6.5
 matrix:
-  allow_failures:
-    - env: "RAILS_VERSION=master"
   exclude:
-    - rvm: 2.6.4
+    - rvm: 2.6.5
       env: "RAILS_VERSION=4.2.11"
-    - rvm: 2.3.8
+    - rvm: 2.4.9
       env: "RAILS_VERSION=6.0.0"
-    - rvm: 2.4.7
-      env: "RAILS_VERSION=6.0.0"
+    - rvm: 2.4.9
+      env: "RAILS_VERSION=6.0.0 DATABASE_URL=postgres://postgres@localhost/jr_test"
+    - rvm: 2.4.9
+      env: "RAILS_VERSION=5.2.3 DATABASE_URL=postgres://postgres@localhost/jr_test"
 before_install:
   - gem install bundler --version 1.17.3
+before_script:
+  - sh -c "if [ '$DATABASE_URL' = 'postgres://postgres@localhost/jr_test' ]; then psql -c 'DROP DATABASE IF EXISTS jr_test;' -U postgres; fi"
+  - sh -c "if [ '$DATABASE_URL' = 'postgres://postgres@localhost/jr_test' ]; then psql -c 'CREATE DATABASE jr_test;' -U postgres; fi"

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,8 @@ end
 version = ENV['RAILS_VERSION'] || 'default'
 
 platforms :ruby do
+  gem 'pg'
+
   if version.start_with?('4.2', '5.0')
     gem 'sqlite3', '~> 1.3.13'
   else

--- a/test/config/database.yml
+++ b/test/config/database.yml
@@ -1,6 +1,0 @@
-test:
-  adapter: sqlite3
-  database: test_db
-#  database: ":memory:"
-  pool: 5
-  timeout: 5000

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -1650,7 +1650,7 @@ class CraterResource < JSONAPI::Resource
 
   filter :description, apply: -> (records, value, options) {
     fail "context not set" unless options[:context][:current_user] != nil && options[:context][:current_user] == $test_user
-    records.where(concat_table_field(options[:join_manager].source_join_details[:alias], :description) => value)
+    records.where(concat_table_field(options.dig(:_relation_helper_options, :join_manager).source_join_details[:alias], :description) => value)
   }
 
   def self.verify_key(key, context = nil)
@@ -1694,7 +1694,7 @@ class PictureResource < JSONAPI::Resource
   has_one :file_properties, inverse_relationship: :fileable, :foreign_key_on => :related, polymorphic: true
 
   filter 'imageable.name', perform_joins: true, apply: -> (records, value, options) {
-    join_manager = options[:join_manager]
+    join_manager = options.dig(:_relation_helper_options, :join_manager)
     relationship = _relationship(:imageable)
     or_parts = relationship.resource_types.collect do |type|
       table_alias = join_manager.join_details_by_polymorphic_relationship(relationship, type)[:alias]
@@ -2038,7 +2038,7 @@ module Api
       relationship :author_detail, to: :one, foreign_key_on: :related
 
       filter :name, apply: lambda { |records, value, options|
-        table_alias = options[:join_manager].source_join_details[:alias]
+        table_alias = options.dig(:_relation_helper_options, :join_manager).source_join_details[:alias]
         t = Arel::Table.new(:people, as: table_alias)
         records.where(t[:name].matches("%#{value[0]}%"))
       }

--- a/test/fixtures/posts.yml
+++ b/test/fixtures/posts.yml
@@ -85,7 +85,7 @@ post_14:
 
 post_15:
   id: 15
-  title: AAAA First Post
+  title: A 1ST Post
   body: First!!!!!!!!!
   author_id: 1003
 

--- a/test/integration/requests/request_test.rb
+++ b/test/integration/requests/request_test.rb
@@ -1438,13 +1438,16 @@ class RequestTest < ActionDispatch::IntegrationTest
   end
 
   def test_sort_included_attribute
+    # Postgres sorts nulls last, whereas sqlite and mysql sort nulls first
+    pg = ENV['DATABASE_URL'].starts_with?('postgres')
+
     get '/api/v6/authors?sort=author_detail.author_stuff', headers: { 'Accept' => JSONAPI::MEDIA_TYPE }
     assert_jsonapi_response 200
-    assert_equal '1000', json_response['data'][0]['id']
+    assert_equal pg ? '1001' : '1000', json_response['data'][0]['id']
 
     get '/api/v6/authors?sort=-author_detail.author_stuff', headers: { 'Accept' => JSONAPI::MEDIA_TYPE }
     assert_jsonapi_response 200
-    assert_equal '1002', json_response['data'][0]['id']
+    assert_equal pg ? '1000' : '1002', json_response['data'][0]['id']
   end
 
   def test_include_parameter_quoted

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,6 +21,8 @@ if ENV['COVERAGE']
   end
 end
 
+ENV['DATABASE_URL'] ||= "sqlite3:test_db"
+
 require 'active_record/railtie'
 require 'rails/test_help'
 require 'minitest/mock'
@@ -67,6 +69,9 @@ class TestApp < Rails::Application
     end
   end
 end
+
+DatabaseCleaner.allow_remote_database_url = true
+DatabaseCleaner.strategy = :transaction
 
 module MyEngine
   class Engine < ::Rails::Engine
@@ -476,8 +481,6 @@ end
 ApiV2Engine::Engine.routes.draw do
   jsonapi_resources :people
 end
-
-DatabaseCleaner.strategy = :transaction
 
 # Ensure backward compatibility with Minitest 4
 Minitest::Test = MiniTest::Unit::TestCase unless defined?(Minitest::Test)


### PR DESCRIPTION
This fixes an issue reported in Gitter where the generated SQL isn't compatible with Postgres. 

`ERROR: for SELECT DISTINCT, ORDER BY expressions must appear in select list`

This fix tracks the fields used for sorting and ensures they are in the SQL used to pluck the results. The sort fields are tracking in an option and can therefore be set in a sort's apply callable. The join_manager was also moved into the options in order to allow correct tracking of joins.

I still need to update the documentation for this. I'll try to update this PR with some examples soon.

Most of the code changes are related to the tests and getting Travis testing with postgres. As of now you need to manually create the database (rake won't work) and set the `DATABASE_URL` environment variable to test locally against postgres. For example:

```bash
DATABASE_URL=postgresql://postgres@localhost/jr_test bundle exec rake test
```

Eventually I'll see if I can load the default rails rake tasks so a `db:create` can work, but that will be another PR.

### All Submissions:

- [ ] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions