### PR TITLE
Rails 6 support fo 0.9.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
   - "RAILS_VERSION=5.0.7.2"
   - "RAILS_VERSION=5.1.7"
   - "RAILS_VERSION=5.2.3"
-#  - "RAILS_VERSION=6.0.0.beta1"
+  - "RAILS_VERSION=6.0.0"
 #  - "RAILS_VERSION=master"
 rvm:
   - 2.3.8
@@ -19,5 +19,9 @@ matrix:
   exclude:
     - rvm: 2.6.4
       env: "RAILS_VERSION=4.2.11"
+    - rvm: 2.3.8
+      env: "RAILS_VERSION=6.0.0"
+    - rvm: 2.4.7
+      env: "RAILS_VERSION=6.0.0"
 before_install:
   - gem install bundler --version 1.17.3

--- a/Gemfile
+++ b/Gemfile
@@ -2,22 +2,26 @@ source 'https://rubygems.org'
 
 gemspec
 
-platforms :ruby do
-  gem 'sqlite3', '1.3.10'
-end
-
 platforms :jruby do
   gem 'activerecord-jdbcsqlite3-adapter'
 end
 
 version = ENV['RAILS_VERSION'] || 'default'
 
+platforms :ruby do
+  if version.start_with?('4.2', '5.0')
+    gem 'sqlite3', '~> 1.3.13'
+  else
+    gem 'sqlite3', '~> 1.4'
+  end
+end
+
 case version
 when 'master'
   gem 'railties', { git: 'https://github.com/rails/rails.git' }
   gem 'arel', { git: 'https://github.com/rails/arel.git' }
 when 'default'
-  gem 'railties', '>= 5.0'
+  gem 'railties', '>= 6.0'
 else
   gem 'railties', "~> #{version}"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -470,7 +470,8 @@ class ActionDispatch::IntegrationTest
   fixtures :all
 
   def assert_jsonapi_response(expected_status, msg = nil)
-    assert_equal JSONAPI::MEDIA_TYPE, response.content_type
+    media_type = Rails::VERSION::MAJOR >= 6 ? response.media_type : response.content_type
+    assert_equal JSONAPI::MEDIA_TYPE, media_type
     if status != expected_status && status >= 400
       pp json_response rescue nil
     end


### PR DESCRIPTION
This backports Rails 6 compatibility to the 0.9.x branch. 

Because of other dependencies we can't use 0.10 yet, but would like to upgrade to Rails 6.


### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions