### PR TITLE
Return a 404 response when no record is found

### DIFF
--- a/lib/jsonapi/processor.rb
+++ b/lib/jsonapi/processor.rb
@@ -101,6 +101,7 @@ module JSONAPI
                                        include_directives,
                                        find_options)
 
+      fail JSONAPI::Exceptions::RecordNotFound.new(id) if resource_set.resource_klasses.empty?
       resource_set.populate!(serializer, context, find_options)
 
       return JSONAPI::ResourceSetOperationResult.new(:ok, resource_set, result_options)

--- a/test/integration/requests/request_test.rb
+++ b/test/integration/requests/request_test.rb
@@ -25,6 +25,11 @@ class RequestTest < ActionDispatch::IntegrationTest
     assert_cacheable_jsonapi_get '/api/v2/books?include=book_comments,book_comments.author'
   end
 
+  def test_get_not_found
+    get "/people/2000"
+    assert_jsonapi_response 404
+  end
+
   def test_post_sessions
     session_id = SecureRandom.uuid
 


### PR DESCRIPTION
The JSON API specification says:
> A server MUST respond with `404 Not Found` when processing a request to fetch a single resource that does not exist

At the moment JSON API Resources returns a 200, with an empty data
object.



### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [x] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [x] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [x] I've included an explanation of what the changes do and why I'd like you to include them.
- [x] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [x] Maintains compliance with JSON:API
- [x] Adequate test coverage exists to prevent regressions