### PR TITLE
Remove unnecessary setting of `missed_resource_ids`

### DIFF
--- a/lib/jsonapi/resource_set.rb
+++ b/lib/jsonapi/resource_set.rb
@@ -47,7 +47,6 @@ module JSONAPI
             )
           )
         else
-          missed_resource_ids[resource_klass] ||= {}
           missed_resource_ids[resource_klass] = @resource_klasses[resource_klass].keys
         end
       end


### PR DESCRIPTION
Since we're overwriting on the next line, there's no need to initialize to an empty hash.