### PR TITLE
Use `records` for joined resource Classes

### DIFF
--- a/lib/jsonapi/active_relation/join_manager.rb
+++ b/lib/jsonapi/active_relation/join_manager.rb
@@ -147,9 +147,15 @@ module JSONAPI
             related_resource_klass = join_details[:related_resource_klass]
             join_type = relationship_details[:join_type]
 
+            join_options = {
+              relationship: relationship,
+              relationship_details: relationship_details,
+              related_resource_klass: related_resource_klass,
+            }
+
             if relationship == :root
               unless source_relationship
-                add_join_details('', {alias: resource_klass._table_name, join_type: :root})
+                add_join_details('', {alias: resource_klass._table_name, join_type: :root, join_options: join_options})
               end
               next
             end
@@ -163,7 +169,7 @@ module JSONAPI
                 options: options)
             }
 
-            details = {alias: self.class.alias_from_arel_node(join_node), join_type: join_type}
+            details = {alias: self.class.alias_from_arel_node(join_node), join_type: join_type, join_options: join_options}
 
             if relationship == source_relationship
               if relationship.polymorphic? && relationship.belongs_to?

--- a/lib/jsonapi/active_relation_resource.rb
+++ b/lib/jsonapi/active_relation_resource.rb
@@ -338,6 +338,11 @@ module JSONAPI
             records = records.joins_left(relation_name)
           end
         end
+
+        if relationship.merge_resource_records
+          records = records.merge(self.records(options))
+        end
+
         records
       end
 

--- a/lib/jsonapi/relationship.rb
+++ b/lib/jsonapi/relationship.rb
@@ -3,7 +3,7 @@ module JSONAPI
     attr_reader :acts_as_set, :foreign_key, :options, :name,
                 :class_name, :polymorphic, :always_include_optional_linkage_data,
                 :parent_resource, :eager_load_on_include, :custom_methods,
-                :inverse_relationship, :allow_include
+                :inverse_relationship, :allow_include, :merge_resource_records
 
     attr_writer :allow_include
 
@@ -22,7 +22,7 @@ module JSONAPI
         ActiveSupport::Deprecation.warn('Use polymorphic_types instead of polymorphic_relations')
         @polymorphic_types ||= options[:polymorphic_relations]
       end
-
+      @merge_resource_records = options.fetch(:merge_resource_records, options[:relation_name].nil?) == true
       @always_include_optional_linkage_data = options.fetch(:always_include_optional_linkage_data, false) == true
       @eager_load_on_include = options.fetch(:eager_load_on_include, true) == true
       @allow_include = options[:allow_include]

--- a/test/integration/book_authorization_test.rb
+++ b/test/integration/book_authorization_test.rb
@@ -1,0 +1,38 @@
+require File.expand_path('../../test_helper', __FILE__)
+
+class BookAuthorizationTest < ActionDispatch::IntegrationTest
+  def setup
+    DatabaseCleaner.start
+    JSONAPI.configuration.json_key_format = :underscored_key
+    JSONAPI.configuration.route_format = :underscored_route
+    Api::V2::BookResource.paginator :offset
+  end
+
+  def test_restricted_records_primary
+    Api::V2::BookResource.paginator :none
+
+    # Not a book admin
+    $test_user = Person.find(1001)
+    assert_cacheable_jsonapi_get '/api/v2/books?filter[title]=Book%206'
+    assert_equal 12, json_response['data'].size
+
+    # book_admin
+    $test_user = Person.find(1005)
+    assert_cacheable_jsonapi_get '/api/v2/books?filter[title]=Book%206'
+    assert_equal 111, json_response['data'].size
+  end
+
+  def test_restricted_records_related
+    Api::V2::BookResource.paginator :none
+
+    # Not a book admin
+    $test_user = Person.find(1001)
+    assert_cacheable_jsonapi_get '/api/v2/authors/1002/books'
+    assert_equal 1, json_response['data'].size
+
+    # book_admin
+    $test_user = Person.find(1005)
+    assert_cacheable_jsonapi_get '/api/v2/authors/1002/books'
+    assert_equal 2, json_response['data'].size
+  end
+end

--- a/test/unit/resource/relationship_test.rb
+++ b/test/unit/resource/relationship_test.rb
@@ -18,6 +18,30 @@ class CallableBlogPostsResource < JSONAPI::Resource
   end
 end
 
+class TestRelationshipOptionsPostsResource < JSONAPI::Resource
+  model_name 'Post'
+  has_one :author, allow_include: :is_admin, merge_resource_records: false
+end
+
+class RelationshipTest < ActiveSupport::TestCase
+  def test_merge_resource_records_enabled_by_default
+    relationship = JSONAPI::Relationship::ToOne.new(:author)
+    assert relationship.merge_resource_records
+  end
+
+  def test_merge_resource_records_is_disabled_by_deafult_with_relation_name
+    relationship = JSONAPI::Relationship::ToOne.new(:author,
+                                                    relation_name: "foo" )
+    refute relationship.merge_resource_records
+  end
+
+  def test_merge_resource_records_can_be_disabled
+    relationship = JSONAPI::Relationship::ToOne.new(:author,
+                                                    merge_resource_records: false )
+    refute relationship.merge_resource_records
+  end
+end
+
 class HasOneRelationshipTest < ActiveSupport::TestCase
 
   def test_polymorphic_type


### PR DESCRIPTION
resolves #1308 

In addition this PR also adds some details about the relationship to the `join_details` as each join is setup and tracked. This is useful if you need to override the `apply_joins` method and need a window into the details as each join was setup. This was originally intended for the some experiments with the `jsonapi-authorization` gem, but I believe it could prove useful in any case where a better window into the join process is needed.

### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [x] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [x] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [x] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [x] I've added/updated tests for this change.

### New Feature Submissions:

- [x] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [x] My submission includes new tests.
- [x] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [x] I've included an explanation of what the changes do and why I'd like you to include them.
- [x] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions