### PR TITLE
Simplify Include Directives Hash

### DIFF
--- a/lib/jsonapi/active_relation_resource.rb
+++ b/lib/jsonapi/active_relation_resource.rb
@@ -92,7 +92,7 @@ module JSONAPI
       def find_fragments(filters, options = {})
         include_directives = options[:include_directives] ? options[:include_directives].include_directives : {}
         resource_klass = self
-        linkage_relationships = to_one_relationships_for_linkage(include_directives[:include_related])
+        linkage_relationships = to_one_relationships_for_linkage(include_directives)
 
         sort_criteria = options.fetch(:sort_criteria) { [] }
 
@@ -381,7 +381,7 @@ module JSONAPI
 
         include_directives = options[:include_directives] ? options[:include_directives].include_directives : {}
         resource_klass = relationship.resource_klass
-        linkage_relationships = resource_klass.to_one_relationships_for_linkage(include_directives[:include_related])
+        linkage_relationships = resource_klass.to_one_relationships_for_linkage(include_directives)
 
         sort_criteria = []
         options[:sort_criteria].try(:each) do |sort|
@@ -514,7 +514,7 @@ module JSONAPI
 
         resource_types.each do |resource_type|
           related_resource_klass = resource_klass_for(resource_type)
-          relationships = related_resource_klass.to_one_relationships_for_linkage(include_directives[:include_related])
+          relationships = related_resource_klass.to_one_relationships_for_linkage(include_directives)
           relationships.each do |r|
             linkage_relationships << "##{resource_type}.#{r}"
           end

--- a/lib/jsonapi/include_directives.rb
+++ b/lib/jsonapi/include_directives.rb
@@ -5,21 +5,15 @@ module JSONAPI
     # will transform into =>
     # {
     #   posts: {
-    #     include_related: {
-    #       comments:{
-    #         include_related: {
-    #           tags: {
-    #             include_related: {}
-    #           }
-    #         }
-    #       }
+    #     comments: {
+    #       tags: {}
     #     }
     #   }
     # }
 
     def initialize(resource_klass, includes_array)
       @resource_klass = resource_klass
-      @include_directives_hash = { include_related: {} }
+      @include_directives_hash = {}
       includes_array.each do |include|
         parse_include(include)
       end
@@ -42,8 +36,8 @@ module JSONAPI
       path.segments.each do |segment|
         relationship_name = segment.relationship.name.to_sym
 
-        current[:include_related][relationship_name] ||= { include_related: {} }
-        current = current[:include_related][relationship_name]
+        current[relationship_name] ||= {}
+        current = current[relationship_name]
       end
 
     rescue JSONAPI::Exceptions::InvalidRelationship => _e

--- a/lib/jsonapi/processor.rb
+++ b/lib/jsonapi/processor.rb
@@ -367,7 +367,7 @@ module JSONAPI
     end
 
     def find_resource_set(resource_klass, include_directives, options)
-      include_related = include_directives.include_directives[:include_related] if include_directives
+      include_related = include_directives.include_directives if include_directives
 
       resource_id_tree = find_resource_id_tree(resource_klass, options, include_related)
 
@@ -375,7 +375,7 @@ module JSONAPI
     end
 
     def find_related_resource_set(resource, relationship_name, include_directives, options)
-      include_related = include_directives.include_directives[:include_related] if include_directives
+      include_related = include_directives.include_directives if include_directives
 
       resource_id_tree = find_resource_id_tree_from_resource_relationship(resource, relationship_name, options, include_related)
 
@@ -443,12 +443,12 @@ module JSONAPI
         )
 
         related_resource_id_tree = source_resource_id_tree.fetch_related_resource_id_tree(relationship)
-        related_resource_id_tree.add_resource_fragments(related_fragments, include_related[key][include_related])
+        related_resource_id_tree.add_resource_fragments(related_fragments, include_related[key])
 
         # Now recursively get the related resources for the currently found resources
         load_included(relationship.resource_klass,
                       related_resource_id_tree,
-                      include_related[relationship_name][:include_related],
+                      include_related[relationship_name],
                       options)
       end
     end

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -4329,7 +4329,8 @@ class Api::BoxesControllerTest < ActionController::TestCase
                             "links" => {
                                 "self" => "http://test.host/api/things/40/relationships/things",
                                 "related" => "http://test.host/api/things/40/things"
-                            }
+                            },
+                            "data" => []
                         }
                     }
                 },

--- a/test/unit/processor/default_processor_test.rb
+++ b/test/unit/processor/default_processor_test.rb
@@ -45,7 +45,7 @@ class DefaultProcessorTest < ActionDispatch::IntegrationTest
     }
     p = JSONAPI::Processor.new(PostResource, :find, params)
 
-    $id_tree_has_one_includes = p.send(:find_resource_id_tree, PostResource, find_options, directives[:include_related])
+    $id_tree_has_one_includes = p.send(:find_resource_id_tree, PostResource, find_options, directives)
     $resource_set_has_one_includes = JSONAPI::ResourceSet.new($id_tree_has_one_includes)
     $populated_resource_set_has_one_includes = JSONAPI::ResourceSet.new($id_tree_has_one_includes).populate!($serializer, nil,{})
   end

--- a/test/unit/serializer/include_directives_test.rb
+++ b/test/unit/serializer/include_directives_test.rb
@@ -6,15 +6,7 @@ class IncludeDirectivesTest < ActiveSupport::TestCase
   def test_one_level_one_include
     directives = JSONAPI::IncludeDirectives.new(PersonResource, ['posts']).include_directives
 
-    assert_hash_equals(
-      {
-        include_related: {
-          posts: {
-            include_related: {}
-          }
-        }
-      },
-      directives)
+    assert_hash_equals({ posts: {} }, directives)
   end
 
   def test_one_level_multiple_includes
@@ -22,17 +14,9 @@ class IncludeDirectivesTest < ActiveSupport::TestCase
 
     assert_hash_equals(
       {
-        include_related: {
-          posts: {
-            include_related: {}
-          },
-          comments: {
-            include_related: {}
-          },
-          expense_entries: {
-            include_related: {}
-          }
-        }
+        posts: {},
+        comments: {},
+        expense_entries: {}
       },
       directives)
   end
@@ -42,21 +26,11 @@ class IncludeDirectivesTest < ActiveSupport::TestCase
 
     assert_hash_equals(
       {
-        include_related: {
-          posts: {
-            include_related: {
-              comments: {
-                include_related: {}
-              }
-            }
-          },
-          comments: {
-            include_related: {}
-          },
-          expense_entries: {
-            include_related: {}
-          }
-        }
+        posts: {
+          comments: {}
+        },
+        comments: {},
+        expense_entries: {}
       },
       directives)
   end
@@ -67,14 +41,8 @@ class IncludeDirectivesTest < ActiveSupport::TestCase
 
     assert_hash_equals(
       {
-        include_related: {
-          posts: {
-            include_related: {
-              comments: {
-                include_related: {}
-              }
-            }
-          }
+        posts: {
+          comments: {}
         }
       },
       directives)
@@ -85,14 +53,8 @@ class IncludeDirectivesTest < ActiveSupport::TestCase
 
     assert_hash_equals(
       {
-        include_related: {
-          posts: {
-            include_related: {
-              comments: {
-                include_related: {}
-              }
-            }
-          }
+        posts: {
+          comments: {}
         }
       },
       directives)
@@ -103,17 +65,9 @@ class IncludeDirectivesTest < ActiveSupport::TestCase
 
     assert_hash_equals(
       {
-        include_related: {
-          posts: {
-            include_related: {
-              comments: {
-                include_related: {
-                  tags: {
-                    include_related: {}
-                  }
-                }
-              }
-            }
+        posts: {
+          comments: {
+            tags: {}
           }
         }
       },

--- a/test/unit/serializer/serializer_test.rb
+++ b/test/unit/serializer/serializer_test.rb
@@ -25,7 +25,7 @@ class SerializerTest < ActionDispatch::IntegrationTest
 
     directives = JSONAPI::IncludeDirectives.new(PersonResource, ['']).include_directives
 
-    id_tree.add_resource_fragment(JSONAPI::ResourceFragment.new(post_1_identity), directives[:include_related])
+    id_tree.add_resource_fragment(JSONAPI::ResourceFragment.new(post_1_identity), directives)
     resource_set = JSONAPI::ResourceSet.new(id_tree)
 
     serializer = JSONAPI::ResourceSerializer.new(
@@ -108,7 +108,7 @@ class SerializerTest < ActionDispatch::IntegrationTest
 
     directives = JSONAPI::IncludeDirectives.new(PersonResource, ['']).include_directives
 
-    id_tree.add_resource_fragment(JSONAPI::ResourceFragment.new(post_1_identity), directives[:include_related])
+    id_tree.add_resource_fragment(JSONAPI::ResourceFragment.new(post_1_identity), directives)
     resource_set = JSONAPI::ResourceSet.new(id_tree)
 
     serializer = JSONAPI::ResourceSerializer.new(
@@ -165,7 +165,7 @@ class SerializerTest < ActionDispatch::IntegrationTest
 
     directives = JSONAPI::IncludeDirectives.new(PersonResource, []).include_directives
 
-    id_tree.add_resource_fragment(JSONAPI::ResourceFragment.new(post_1_identity), directives[:include_related])
+    id_tree.add_resource_fragment(JSONAPI::ResourceFragment.new(post_1_identity), directives)
     resource_set = JSONAPI::ResourceSet.new(id_tree)
 
     serializer = JSONAPI::ResourceSerializer.new(
@@ -208,14 +208,14 @@ class SerializerTest < ActionDispatch::IntegrationTest
 
     directives = JSONAPI::IncludeDirectives.new(PostResource, ['author']).include_directives
 
-    id_tree.add_resource_fragment(JSONAPI::ResourceFragment.new(post_1_identity), directives[:include_related])
+    id_tree.add_resource_fragment(JSONAPI::ResourceFragment.new(post_1_identity), directives)
 
     rel_id_tree = id_tree.fetch_related_resource_id_tree(PostResource._relationships[:author])
 
     author_fragment = JSONAPI::ResourceFragment.new(person_1001_identity)
     author_fragment.add_related_from(post_1_identity)
     author_fragment.add_related_identity(:posts, post_1_identity)
-    rel_id_tree.add_resource_fragment(author_fragment, directives[:include_related][:author][:include_related])
+    rel_id_tree.add_resource_fragment(author_fragment, directives[:author])
 
     resource_set = JSONAPI::ResourceSet.new(id_tree)
 
@@ -339,14 +339,14 @@ class SerializerTest < ActionDispatch::IntegrationTest
 
     directives = JSONAPI::IncludeDirectives.new(PostResource, ['author']).include_directives
 
-    id_tree.add_resource_fragment(JSONAPI::ResourceFragment.new(post_1_identity), directives[:include_related])
+    id_tree.add_resource_fragment(JSONAPI::ResourceFragment.new(post_1_identity), directives)
 
     rel_id_tree = id_tree.fetch_related_resource_id_tree(PostResource._relationships[:author])
 
     author_fragment = JSONAPI::ResourceFragment.new(person_1001_identity)
     author_fragment.add_related_from(post_1_identity)
     author_fragment.add_related_identity(:posts, post_1_identity)
-    rel_id_tree.add_resource_fragment(author_fragment, directives[:include_related][:author][:include_related])
+    rel_id_tree.add_resource_fragment(author_fragment, directives[:author])
 
     resource_set = JSONAPI::ResourceSet.new(id_tree)
 
@@ -479,7 +479,7 @@ class SerializerTest < ActionDispatch::IntegrationTest
     fragment.initialize_related(:section)
     fragment.initialize_related(:tags)
 
-    id_tree.add_resource_fragment(fragment, directives[:include_related])
+    id_tree.add_resource_fragment(fragment, directives)
     resource_set = JSONAPI::ResourceSet.new(id_tree)
 
     serializer = JSONAPI::ResourceSerializer.new(PostResource,


### PR DESCRIPTION
This simplifies include directives hashes by removing the `include_related` subhash under each entity. This indirection exists because of an `include` key that used to be in each hash, but [was removed](https://github.com/cerebris/jsonapi-resources/commit/5d1884985d967d5935d2d1082c4d71889a075f30). Since there are never any other keys in the hashes, the `include_related` subhashes are no longer necessary.

In doing this, I also found (and fixed) [a small bug](https://github.com/cerebris/jsonapi-resources/blob/978f590f85fe9e65d5806f206b661fb35332c1bd/lib/jsonapi/processor.rb#L446) where the processor tries to use an include directives hash as a key for its own subhash instead of the symbol `:include_related`.

---

### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [x] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [x] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [x] I've included an explanation of what the changes do and why I'd like you to include them.
- [x] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions