### PR TITLE
Fix issue with primary paginator being used for included resources

### DIFF
--- a/lib/jsonapi/active_relation_resource.rb
+++ b/lib/jsonapi/active_relation_resource.rb
@@ -395,7 +395,7 @@ module JSONAPI
                                                        sort_criteria: sort_criteria,
                                                        filters: filters)
 
-        paginator = options[:paginator] if source_rids.count == 1
+        paginator = options[:paginator]
 
         records = apply_request_settings_to_records(records: records_for_source_to_related(options),
                                resource_klass: resource_klass,
@@ -525,7 +525,7 @@ module JSONAPI
                                                        relationships: linkage_relationships,
                                                        filters: filters)
 
-        paginator = options[:paginator] if source_rids.count == 1
+        paginator = options[:paginator]
 
         # Note: We will sort by the source table. Without using unions we can't sort on a polymorphic relationship
         # in any manner that makes sense

--- a/lib/jsonapi/processor.rb
+++ b/lib/jsonapi/processor.rb
@@ -392,7 +392,7 @@ module JSONAPI
       primary_resource_id_tree = PrimaryResourceIdTree.new
       primary_resource_id_tree.add_resource_fragments(fragments, include_related)
 
-      load_included(resource_klass, primary_resource_id_tree, include_related, options.except(:filters, :sort_criteria))
+      load_included(resource_klass, primary_resource_id_tree, include_related, options)
 
       primary_resource_id_tree
     end
@@ -406,7 +406,7 @@ module JSONAPI
       primary_resource_id_tree = PrimaryResourceIdTree.new
       primary_resource_id_tree.add_resource_fragments(fragments, include_related)
 
-      load_included(resource_klass, primary_resource_id_tree, include_related, options.except(:filters, :sort_criteria))
+      load_included(resource_klass, primary_resource_id_tree, include_related, options)
 
       primary_resource_id_tree
     end
@@ -422,7 +422,7 @@ module JSONAPI
       primary_resource_id_tree = PrimaryResourceIdTree.new
       primary_resource_id_tree.add_resource_fragments(fragments, include_related)
 
-      load_included(resource_klass, primary_resource_id_tree, include_related, options.except(:filters, :sort_criteria))
+      load_included(resource_klass, primary_resource_id_tree, include_related, options)
 
       primary_resource_id_tree
     end
@@ -434,7 +434,7 @@ module JSONAPI
         relationship = resource_klass._relationship(key)
         relationship_name = relationship.name.to_sym
 
-        find_related_resource_options = options.dup
+        find_related_resource_options = options.except(:filters, :sort_criteria, :paginator)
         find_related_resource_options[:sort_criteria] = relationship.resource_klass.default_sort
         find_related_resource_options[:cache] = resource_klass.caching?
 

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -4752,3 +4752,34 @@ class RobotsControllerTest < ActionController::TestCase
     assert_equal 'version is not a valid sort criteria for robots', json_response['errors'].first['detail']
   end
 end
+
+class Api::V6::AuthorDetailsControllerTest < ActionController::TestCase
+  def after_teardown
+    Api::V6::AuthorDetailResource.paginator :none # TODO: ???
+  end
+
+  def test_that_the_last_two_author_details_belong_to_an_author
+    Api::V6::AuthorDetailResource.paginator :offset
+
+    total_count = AuthorDetail.count
+    assert_operator total_count, :>=, 2
+
+    assert_cacheable_get :index, params: {sort: :id, include: :author, page: {limit: 10, offset: total_count - 2}}
+    assert_response :success
+    assert_equal 2, json_response['data'].size
+    assert_not_nil json_response['data'][0]['relationships']['author']['data']
+    assert_not_nil json_response['data'][1]['relationships']['author']['data']
+  end
+
+  def test_that_the_last_author_detail_includes_its_author_even_if_returned_as_the_single_entry_on_a_page_with_nonzero_offset
+    Api::V6::AuthorDetailResource.paginator :offset
+
+    total_count = AuthorDetail.count
+    assert_operator total_count, :>=, 2
+
+    assert_cacheable_get :index, params: {sort: :id, include: :author, page: {limit: 10, offset: total_count - 1}}
+    assert_response :success
+    assert_equal 1, json_response['data'].size
+    assert_not_nil json_response['data'][0]['relationships']['author']['data']
+  end
+end


### PR DESCRIPTION
Fixes #1312

### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [X] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions