### PR TITLE
Add `_table_name_for_alias` to replace '.' with '_' when creating an …

### DIFF
--- a/lib/jsonapi/active_relation/join_manager.rb
+++ b/lib/jsonapi/active_relation/join_manager.rb
@@ -149,7 +149,7 @@ module JSONAPI
 
             if relationship == :root
               unless source_relationship
-                add_join_details('', {alias: resource_klass._table_name, join_type: :root})
+                add_join_details('', {alias: resource_klass._table_name_for_alias, join_type: :root})
               end
               next
             end

--- a/lib/jsonapi/active_relation_resource.rb
+++ b/lib/jsonapi/active_relation_resource.rb
@@ -112,7 +112,7 @@ module JSONAPI
                                options: options)
 
         # This alias is going to be resolve down to the model's table name and will not actually be an alias
-        resource_table_alias = resource_klass._table_name
+        resource_table_alias = resource_klass._table_name_for_alias
 
         pluck_fields = [Arel.sql("#{concat_table_field(resource_table_alias, resource_klass._primary_key)} AS #{resource_table_alias}_#{resource_klass._primary_key}")]
 
@@ -543,9 +543,9 @@ module JSONAPI
         related_type = concat_table_field(_table_name, relationship.polymorphic_type)
 
         pluck_fields = [
-            Arel.sql("#{primary_key} AS #{_table_name}_#{_primary_key}"),
-            Arel.sql("#{related_key} AS #{_table_name}_#{relationship.foreign_key}"),
-            Arel.sql("#{related_type} AS #{_table_name}_#{relationship.polymorphic_type}")
+            Arel.sql("#{primary_key} AS #{_table_name_for_alias}_#{_primary_key}"),
+            Arel.sql("#{related_key} AS #{_table_name_for_alias}_#{relationship.foreign_key}"),
+            Arel.sql("#{related_type} AS #{_table_name_for_alias}_#{relationship.polymorphic_type}")
         ]
 
         # Get the additional fields from each relation. There's a limitation that the fields must exist in each relation
@@ -826,7 +826,7 @@ module JSONAPI
           join_details = join_manager.join_details[path.last_relationship]
           table_alias = join_details[:alias]
         else
-          table_alias = self._table_name
+          table_alias = self._table_name_for_alias
         end
 
         concat_table_field(table_alias, field_segment.delegated_field_name)

--- a/lib/jsonapi/basic_resource.rb
+++ b/lib/jsonapi/basic_resource.rb
@@ -893,6 +893,10 @@ module JSONAPI
         @_table_name ||= _model_class.respond_to?(:table_name) ? _model_class.table_name : _model_name.tableize
       end
 
+      def _table_name_for_alias
+        @_table_name ||= _table_name.tr('.', '_')
+      end
+
       def _as_parent_key
         @_as_parent_key ||= "#{_type.to_s.singularize}_id"
       end


### PR DESCRIPTION
…alias to tables in another database

Fixes #1310, #1316

Ideally we'd have tests for this, but setting up the testing framework to handle external databases is not something I have time for at the moment.

### All Submissions:

- [ ] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions