### PR TITLE
Set default processor cass by name, deprecate default_processor_klass

### DIFF
--- a/lib/jsonapi/configuration.rb
+++ b/lib/jsonapi/configuration.rb
@@ -18,7 +18,7 @@ module JSONAPI
                 :default_paginator,
                 :default_page_size,
                 :maximum_page_size,
-                :default_processor_klass,
+                :default_processor_klass_name,
                 :use_text_errors,
                 :top_level_links_include_pagination,
                 :top_level_meta_include_record_count,
@@ -110,7 +110,7 @@ module JSONAPI
 
       # The default Operation Processor to use if one is not defined specifically
       # for a Resource.
-      self.default_processor_klass = JSONAPI::Processor
+      self.default_processor_klass_name = 'JSONAPI::Processor'
 
       # Allows transactions for creating and updating records
       # Set this to false if your backend does not support transactions (e.g. Mongodb)
@@ -225,7 +225,17 @@ module JSONAPI
     end
 
     def default_processor_klass=(default_processor_klass)
+      ActiveSupport::Deprecation.warn('`default_processor_klass` has been replaced by `default_processor_klass_name`.')
       @default_processor_klass = default_processor_klass
+    end
+
+    def default_processor_klass
+      @default_processor_klass ||= default_processor_klass_name.safe_constantize
+    end
+
+    def default_processor_klass_name=(default_processor_klass_name)
+      @default_processor_klass = nil
+      @default_processor_klass_name = default_processor_klass_name
     end
 
     def allow_include=(allow_include)


### PR DESCRIPTION
This fixes Zeitwerk deprecation warnings:

```bash
DEPRECATION WARNING: Initialization autoloaded the constants Api, Api::V1, and Api::V1::BaseProcessor.

Being able to do this is deprecated. Autoloading during initialization is going
to be an error condition in future versions of Rails.

Reloading does not reboot the application, and therefore code executed during
initialization does not run again. So, if you reload Api, for example,
the expected changes won't be reflected in that stale Module object.

These autoloaded constants have been unloaded.

Please, check the "Autoloading and Reloading Constants" guide for solutions.
```

### All Submissions:

- [ ] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions