### PR TITLE
Lookup polymorphic type from the column before fetching the record

### DIFF
--- a/lib/jsonapi/relationship.rb
+++ b/lib/jsonapi/relationship.rb
@@ -55,8 +55,14 @@ module JSONAPI
 
     def type_for_source(source)
       if polymorphic?
-        resource = source.public_send(name)
-        resource.class._type if resource
+        # try polymorphic type column before asking it from the resource record
+        if source._model.respond_to?(polymorphic_type)
+          model_type = source._model.send(polymorphic_type)
+          source.class.resource_for(model_type)._type if model_type
+        else
+          resource = source.public_send(name)
+          resource.class._type if resource
+        end
       else
         type
       end


### PR DESCRIPTION
Currently, `Relationship#type_for_source` looks up associated record's type by:

1. Fetching its associated record.
2. Calling `.class._type` on that record.

This approach is inefficient because usually, a polymorphic record (the `source`) has `_type` and `_id` columns. And the `_type` column's value will be the polymorphic relationship record's type.

So this PR makes `type_for_source` check the type value from column before fetching the associated record.



### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [x] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions