### PR TITLE
Fix JSONAPI::PathSegment::Relationship#eql?

### DIFF
--- a/lib/jsonapi/path_segment.rb
+++ b/lib/jsonapi/path_segment.rb
@@ -30,7 +30,7 @@ module JSONAPI
       end
 
       def eql?(other)
-        relationship == other.relationship && resource_klass == other.resource_klass
+        other.is_a?(self.class) && relationship == other.relationship && resource_klass == other.resource_klass
       end
 
       def hash
@@ -59,7 +59,7 @@ module JSONAPI
       end
 
       def eql?(other)
-        field_name == other.field_name && resource_klass == other.resource_klass
+        other.is_a?(self.class) && field_name == other.field_name && resource_klass == other.resource_klass
       end
 
       def delegated_field_name


### PR DESCRIPTION
Relationship objects are used as key in `@join_details` in [JoinManager](https://github.com/cerebris/jsonapi-resources/blob/7a2de3076fa30312ef8d4ed76bee02156e1455d0/lib/jsonapi/active_relation/join_manager.rb#L123) . This hash contains two types of objects: String and Relationship. In case of hash collisions in `@join_details` the method `Relationship#eql?` is called. It currently fails when comparing with a string key.

Fixes #1333

### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [x] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [x] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [x] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### Bug fixes and Changes to Core Features:

- [x] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

There's no reliable way to test for hash collisions. It would be possible to specifically test for `Relationship#eql?("")` . Shall I add such a test?

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions