### PR TITLE
Fix ruby 2.7 warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ rvm:
   - 2.4.7
   - 2.5.6
   - 2.6.4
+  - 2.7.2
 matrix:
   allow_failures:
     - env: "RAILS_VERSION=master"

--- a/lib/jsonapi/request_parser.rb
+++ b/lib/jsonapi/request_parser.rb
@@ -1,5 +1,6 @@
 require 'jsonapi/operation'
 require 'jsonapi/paginator'
+require 'cgi'
 
 module JSONAPI
   class RequestParser
@@ -314,7 +315,7 @@ module JSONAPI
 
       sorts = []
       begin
-        raw = URI.unescape(sort_criteria)
+        raw = CGI.unescape(sort_criteria)
         sorts += CSV.parse_line(raw)
       rescue CSV::MalformedCSVError
         fail JSONAPI::Exceptions::InvalidSortCriteria.new(format_key(@resource_klass._type), raw)


### PR DESCRIPTION

### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions