### PR TITLE
Have Resource#inherited call through to Class#inherited

### DIFF
--- a/lib/jsonapi/basic_resource.rb
+++ b/lib/jsonapi/basic_resource.rb
@@ -419,6 +419,7 @@ module JSONAPI
 
     class << self
       def inherited(subclass)
+        super
         subclass.abstract(false)
         subclass.immutable(false)
         subclass.caching(_caching)

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -173,6 +173,10 @@ class ResourceTest < ActiveSupport::TestCase
     refute PersonResource._abstract
   end
 
+  def test_inherited_calls_superclass
+    assert_equal(BaseResource.subclasses, [PersonResource, SpecialBaseResource])
+  end
+
   def test_nil_model_class
     # ToDo:Figure out why this test does not work on Rails 4.0
     # :nocov:


### PR DESCRIPTION
The Resource class does not call through to Class#inherited. As a result the various ActiveSupport functions for interrogating a resource's subclasses (Resource.subclasses, Resource.descendents and the like) return empty result sets. This is because Resources override the inherited function but do not call through to their superclass. This PR adds the super call to enable this.

Fixes #1337


### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [x] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [x] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [x] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [x] I've added/updated tests for this change.

### Bug fixes and Changes to Core Features:

- [x] I've included an explanation of what the changes do and why I'd like you to include them.
- [x] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions