### PR TITLE
URI.unescape is obsolete

### DIFF
--- a/lib/jsonapi/request_parser.rb
+++ b/lib/jsonapi/request_parser.rb
@@ -314,7 +314,7 @@ module JSONAPI
 
       sorts = []
       begin
-        raw = URI.unescape(sort_criteria)
+        raw = URI::DEFAULT_PARSER.unescape(sort_criteria)
         sorts += CSV.parse_line(raw)
       rescue CSV::MalformedCSVError
         fail JSONAPI::Exceptions::InvalidSortCriteria.new(format_key(@resource_klass._type), raw)


### PR DESCRIPTION
It's throwing warnings on Ruby 2.7.2

Closes https://github.com/cerebris/jsonapi-resources/issues/1339



### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [x] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [x] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### Bug fixes and Changes to Core Features:

- [x] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions