### PR TITLE
Add `resource_key_type` feature

### DIFF
--- a/lib/jsonapi/active_relation/join_manager.rb
+++ b/lib/jsonapi/active_relation/join_manager.rb
@@ -162,6 +162,10 @@ module JSONAPI
                 relationship: relationship,
                 options: options)
             }
+            unless join_node
+              warn "join node for #{related_resource_klass._type} not found"
+              next
+            end
 
             details = {alias: self.class.alias_from_arel_node(join_node), join_type: join_type}
 
@@ -234,7 +238,8 @@ module JSONAPI
             process_all_types = !segment.path_specified_resource_klass?
 
             if process_all_types || related_resource_klass == segment.resource_klass
-              related_resource_tree = process_path_to_tree(path_segments.dup, related_resource_klass, default_join_type, default_polymorphic_join_type)
+              # Prefer using `segment.resource_klass` insead of `related_resource_klass` to avoid inheritance issue
+              related_resource_tree = process_path_to_tree(path_segments.dup, segment.resource_klass, default_join_type, default_polymorphic_join_type)
               node[:resource_klasses][resource_klass][:relationships][segment.relationship].deep_merge!(related_resource_tree)
             end
           end

--- a/lib/jsonapi/basic_resource.rb
+++ b/lib/jsonapi/basic_resource.rb
@@ -287,7 +287,7 @@ module JSONAPI
       if reflect
         existing_rids = self.class.find_related_fragments([identity], relationship_type, options)
 
-        existing = existing_rids.keys.collect { |rid| rid.id }
+        existing = existing_rids.keys.collect { |rid| rid.custom_id || rid.id }
 
         to_delete = existing - (relationship_key_values & existing)
         to_delete.each do |key|

--- a/lib/jsonapi/formatter.rb
+++ b/lib/jsonapi/formatter.rb
@@ -92,6 +92,17 @@ module JSONAPI
 end
 
 class UnderscoredKeyFormatter < JSONAPI::KeyFormatter
+  class << self
+    def format(arg)
+      # take care of modules
+      arg.to_s.split('/').last
+    end
+
+    def unformat(arg, modules: [])
+      # take care of modules
+      modules.push(arg.to_s).join('/')
+    end
+  end
 end
 
 class CamelizedKeyFormatter < JSONAPI::KeyFormatter

--- a/lib/jsonapi/link_builder.rb
+++ b/lib/jsonapi/link_builder.rb
@@ -29,7 +29,7 @@ module JSONAPI
     def primary_resources_url
       if @primary_resource_klass._routed
         primary_resources_path = resources_path(primary_resource_klass)
-        @primary_resources_url_cached ||= "#{ base_url }#{ engine_mount_point }#{ primary_resources_path }"
+        @primary_resources_url_cached ||= "#{ base_url }#{ serialized_engine_mount_point }#{ primary_resources_path }"
       else
         if JSONAPI.configuration.warn_on_missing_routes && !@primary_resource_klass._warned_missing_route
           warn "primary_resources_url for #{@primary_resource_klass} could not be generated"
@@ -136,7 +136,11 @@ module JSONAPI
     end
 
     def resource_url(source)
-      "#{ base_url }#{ engine_mount_point }#{ resource_path(source) }"
+      "#{ base_url }#{ serialized_engine_mount_point }#{ resource_path(source) }"
+    end
+
+    def serialized_engine_mount_point
+       engine_mount_point == "/" ? "" : engine_mount_point
     end
 
     def route_for_relationship(relationship)

--- a/lib/jsonapi/resource_controller_metal.rb
+++ b/lib/jsonapi/resource_controller_metal.rb
@@ -5,7 +5,6 @@ module JSONAPI
       ActionController::Rendering,
       ActionController::Renderers::All,
       ActionController::StrongParameters,
-      ActionController::ForceSSL,
       ActionController::Instrumentation,
       JSONAPI::ActsAsResourceController
     ].freeze

--- a/lib/jsonapi/resource_fragment.rb
+++ b/lib/jsonapi/resource_fragment.rb
@@ -13,13 +13,14 @@ module JSONAPI
   class ResourceFragment
     attr_reader :identity, :attributes, :related_from, :related
 
-    attr_accessor :primary, :cache
+    attr_accessor :primary, :cache, :custom_cache
 
     alias :cache_field :cache #ToDo: Rename one or the other
 
     def initialize(identity)
       @identity = identity
       @cache = nil
+      @custom_cache = nil
       @attributes = {}
       @related = {}
       @primary = false

--- a/lib/jsonapi/resource_identity.rb
+++ b/lib/jsonapi/resource_identity.rb
@@ -11,11 +11,12 @@ module JSONAPI
   # rid = ResourceIdentity.new(PostResource, 12)
   #
   class ResourceIdentity
-    attr_reader :resource_klass, :id
+    attr_reader :resource_klass, :id, :custom_id
 
-    def initialize(resource_klass, id)
+    def initialize(resource_klass, id, custom_id = nil)
       @resource_klass = resource_klass
       @id = id
+      @custom_id = custom_id
     end
 
     def ==(other)
@@ -25,17 +26,17 @@ module JSONAPI
     end
 
     def eql?(other)
-      other.is_a?(ResourceIdentity) && other.resource_klass == @resource_klass && other.id == @id
+      other.is_a?(ResourceIdentity) && other.resource_klass == @resource_klass && other.id == @id && other.custom_id == @custom_id
     end
 
     def hash
-      [@resource_klass, @id].hash
+      [@resource_klass, @id, @custom_id].hash
     end
 
     # Creates a string representation of the identifier.
     def to_s
       # :nocov:
-      "#{resource_klass}:#{id}"
+      [resource_klass, id, custom_id].compact.join(':')
       # :nocov:
     end
   end

--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -331,7 +331,7 @@ module JSONAPI
       linkage = []
 
       rids && rids.each do |details|
-        id = details.id
+        id = details.custom_id || details.id
         type = details.resource_klass.try(:_type)
         if type && id
           linkage.append({'type' => format_key(type), 'id' => @id_formatter.format(id)})
@@ -346,7 +346,7 @@ module JSONAPI
 
       {
           'type' => format_key(rid.resource_klass._type),
-          'id' => @id_formatter.format(rid.id),
+          'id' => @id_formatter.format(rid.custom_id || rid.id),
       }
     end
 

--- a/lib/jsonapi/resource_set.rb
+++ b/lib/jsonapi/resource_set.rb
@@ -153,15 +153,23 @@ module JSONAPI
 
         resource_klass = resource_rid.resource_klass
         id = resource_rid.id
+        custom_id = resource_rid.custom_id
+        
 
         flattened_tree[resource_klass] ||= {}
 
-        flattened_tree[resource_klass][id] ||= {primary: fragment.primary, relationships: {}}
-        flattened_tree[resource_klass][id][:cache_id] ||= fragment.cache
+        if custom_id
+          flattened_tree[resource_klass][custom_id] ||= {primary: fragment.primary, relationships: {}}
+          flattened_tree[resource_klass][custom_id][:cache_id] ||= fragment.custom_cache
+        else
+          flattened_tree[resource_klass][id] ||= {primary: fragment.primary, relationships: {}}
+          flattened_tree[resource_klass][id][:cache_id] ||= fragment.cache
+        end
 
         fragment.related.try(:each_pair) do |relationship_name, related_rids|
-          flattened_tree[resource_klass][id][:relationships][relationship_name] ||= Set.new
-          flattened_tree[resource_klass][id][:relationships][relationship_name].merge(related_rids)
+          final_key = custom_id ? custom_id : id
+          flattened_tree[resource_klass][final_key][:relationships][relationship_name] ||= Set.new
+          flattened_tree[resource_klass][final_key][:relationships][relationship_name].merge(related_rids)
         end
       end
 


### PR DESCRIPTION
Closes #1344

Related to #1343 

### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [x] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [x] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [x] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions