### PR TITLE
rails 6.1 supporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
   - "RAILS_VERSION=5.1.7"
   - "RAILS_VERSION=5.2.3"
   - "RAILS_VERSION=6.0.0"
+  - "RAILS_VERSION=6.1.0"
 rvm:
   - 2.3.8
   - 2.4.7
@@ -22,5 +23,9 @@ matrix:
       env: "RAILS_VERSION=6.0.0"
     - rvm: 2.4.7
       env: "RAILS_VERSION=6.0.0"
+    - rvm: 2.3.8
+      env: "RAILS_VERSION=6.1.0"
+    - rvm: 2.4.7
+      env: "RAILS_VERSION=6.1.0"
 before_install:
   - gem install bundler --version 1.17.3

--- a/lib/jsonapi/resource_controller_metal.rb
+++ b/lib/jsonapi/resource_controller_metal.rb
@@ -5,10 +5,10 @@ module JSONAPI
       ActionController::Rendering,
       ActionController::Renderers::All,
       ActionController::StrongParameters,
-      ActionController::ForceSSL,
+      Gem::Requirement.new('< 6.1').satisfied_by?(ActionPack.gem_version) ? ActionController::ForceSSL : nil,
       ActionController::Instrumentation,
       JSONAPI::ActsAsResourceController
-    ].freeze
+    ].compact.freeze
 
     MODULES.each do |mod|
       include mod

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -370,7 +370,7 @@ class Post < ActiveRecord::Base
   belongs_to :writer, class_name: 'Person', foreign_key: 'author_id'
   has_many :comments
   has_and_belongs_to_many :tags, join_table: :posts_tags
-  has_many :special_post_tags, source: :tag
+  has_many :special_post_tags
   has_many :special_tags, through: :special_post_tags, source: :tag
   belongs_to :section
   has_one :parent_post, class_name: 'Post', foreign_key: 'parent_post_id'

--- a/test/integration/requests/request_test.rb
+++ b/test/integration/requests/request_test.rb
@@ -1430,7 +1430,7 @@ class RequestTest < ActionDispatch::IntegrationTest
                        }
 
     $test_user = Person.find(1)
-    assert_equal 2, JSONAPI.configuration.resource_cache.instance_variable_get(:@key_access).length
+    assert_equal 2, JSONAPI.configuration.resource_cache.instance_variable_get(:@data).length
 
     get "/api/v9/people/#{$test_user.id}?include=preferences"
     assert_jsonapi_response 200
@@ -1477,7 +1477,7 @@ class RequestTest < ActionDispatch::IntegrationTest
                          ]
                        }
 
-    assert_equal 4, JSONAPI.configuration.resource_cache.instance_variable_get(:@key_access).length
+    assert_equal 4, JSONAPI.configuration.resource_cache.instance_variable_get(:@data).length
 
   ensure
     JSONAPI.configuration = original_config
@@ -1522,7 +1522,7 @@ class RequestTest < ActionDispatch::IntegrationTest
                          }
                        }
 
-    assert_equal 1, JSONAPI.configuration.resource_cache.instance_variable_get(:@key_access).length
+    assert_equal 1, JSONAPI.configuration.resource_cache.instance_variable_get(:@data).length
 
     $test_user = Person.find(1)
 
@@ -1550,7 +1550,7 @@ class RequestTest < ActionDispatch::IntegrationTest
                          }
                        }
 
-    assert_equal 2, JSONAPI.configuration.resource_cache.instance_variable_get(:@key_access).length
+    assert_equal 2, JSONAPI.configuration.resource_cache.instance_variable_get(:@data).length
 
   ensure
     JSONAPI.configuration = original_config

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -13,7 +13,7 @@ class PostWithBadAfterSave < ActiveRecord::Base
   after_save :do_some_after_save_stuff
 
   def do_some_after_save_stuff
-    errors[:base] << 'Boom! Error added in after_save callback.'
+    errors.add(:base, 'Boom! Error added in after_save callback.')
     raise ActiveRecord::RecordInvalid.new(self)
   end
 end
@@ -23,7 +23,7 @@ class PostWithCustomValidationContext < ActiveRecord::Base
   validate :api_specific_check, on: :json_api_create
 
   def api_specific_check
-    errors[:base] << 'Record is invalid'
+    errors.add(:base, 'Record is invalid')
   end
 end
 


### PR DESCRIPTION
closes #1343

related rails commits:
https://github.com/rails/rails/commit/b0cc7d985eac088079469e9b9df7330132e050c2
https://github.com/rails/rails/commit/b30a23f53b52e59d31358f7b80385ee5c2ba3afe

### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [x] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [x] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [x] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions