### PR TITLE
Rails 6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,22 @@ env:
   - RAILS_VERSION=5.2.4.4 DATABASE_URL=postgres://postgres@localhost/jr_test
   - RAILS_VERSION=5.2.4.4
   - RAILS_VERSION=5.1.7
-  - RAILS_VERSION=5.0.7.2
 rvm:
   - 2.6.6
   - 2.7.2
   - 3.0.0
+matrix:
+  exclude:
+    - rvm: 3.0.0
+      env: 6.0.3.4 DATABASE_URL=postgres://postgres@localhost/jr_test
+    - rvm: 3.0.0
+      env: 6.0.3.4
+    - rvm: 3.0.0
+      env: 5.2.4.4 DATABASE_URL=postgres://postgres@localhost/jr_test
+    - rvm: 3.0.0
+      env: 5.2.4.4
+    - rvm: 3.0.0
+      env: 5.1.7
 before_install:
   - gem install bundler --version 2.2.5
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,15 +17,15 @@ rvm:
 matrix:
   exclude:
     - rvm: 3.0.0
-      env: 6.0.3.4 DATABASE_URL=postgres://postgres@localhost/jr_test
+      env: RAILS_VERSION=6.0.3.4 DATABASE_URL=postgres://postgres@localhost/jr_test
     - rvm: 3.0.0
-      env: 6.0.3.4
+      env: RAILS_VERSION=6.0.3.4
     - rvm: 3.0.0
-      env: 5.2.4.4 DATABASE_URL=postgres://postgres@localhost/jr_test
+      env: RAILS_VERSION=5.2.4.4 DATABASE_URL=postgres://postgres@localhost/jr_test
     - rvm: 3.0.0
-      env: 5.2.4.4
+      env: RAILS_VERSION=5.2.4.4
     - rvm: 3.0.0
-      env: 5.1.7
+      env: RAILS_VERSION=5.1.7
 before_install:
   - gem install bundler --version 2.2.5
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,6 @@ rvm:
   - 2.6.6
   - 2.7.2
   - 3.0.0
-matrix:
-  allow_failures:
-    - rvm: 3.0.0
 before_install:
   - gem install bundler --version 2.2.5
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ rvm:
   - 3.0.0
 matrix:
   allow_failures:
-    - env: "RAILS_VERSION=6.1.1"
-    - env: "RAILS_VERSION=6.1.1 DATABASE_URL=postgres://postgres@localhost/jr_test"
     - rvm: 3.0.0
 before_install:
   - gem install bundler --version 2.2.5

--- a/lib/jsonapi/active_relation_resource.rb
+++ b/lib/jsonapi/active_relation_resource.rb
@@ -756,7 +756,7 @@ module JSONAPI
 
       # Assumes ActiveRecord's counting. Override if you need a different counting method
       def count_records(records)
-        if Rails::VERSION::MAJOR >= 5 && ActiveRecord::VERSION::MINOR >= 1
+        if (Rails::VERSION::MAJOR == 5 && ActiveRecord::VERSION::MINOR >= 1) || Rails::VERSION::MAJOR >= 6
           records.count(:all)
         else
           records.count

--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -409,7 +409,7 @@ module JSONAPI
         sorts = sort_criteria
       elsif sort_criteria.is_a?(String)
         begin
-          raw = URI.unescape(sort_criteria)
+          raw = URI.decode_www_form_component(sort_criteria)
           sorts = CSV.parse_line(raw)
         rescue CSV::MalformedCSVError
           fail JSONAPI::Exceptions::InvalidSortCriteria.new(format_key(resource_klass._type), raw)

--- a/lib/jsonapi/resource_controller_metal.rb
+++ b/lib/jsonapi/resource_controller_metal.rb
@@ -5,10 +5,10 @@ module JSONAPI
       ActionController::Rendering,
       ActionController::Renderers::All,
       ActionController::StrongParameters,
-      ActionController::ForceSSL,
+      Gem::Requirement.new('< 6.1').satisfied_by?(ActionPack.gem_version) ? ActionController::ForceSSL : nil,
       ActionController::Instrumentation,
       JSONAPI::ActsAsResourceController
-    ].freeze
+    ].compact.freeze
 
     # Note, the url_helpers are not loaded. This will prevent links from being generated for resources, and warnings
     # will be emitted. Link support can be added by including `Rails.application.routes.url_helpers`, and links

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -503,7 +503,7 @@ class Post < ActiveRecord::Base
   belongs_to :writer, class_name: 'Person', foreign_key: 'author_id'
   has_many :comments
   has_and_belongs_to_many :tags, join_table: :posts_tags
-  has_many :special_post_tags, source: :tag
+  has_many :special_post_tags
   has_many :special_tags, through: :special_post_tags, source: :tag
   belongs_to :section
   belongs_to :parent_post, class_name: 'Post', foreign_key: 'parent_post_id'

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -745,8 +745,8 @@ class Picture < ActiveRecord::Base
   belongs_to :author, class_name: 'Person', foreign_key: 'author_id'
 
   belongs_to :imageable, polymorphic: true
-  belongs_to :document, -> { where( pictures: { imageable_type: 'Document' } ).eager_load( :pictures ) }, foreign_key: 'imageable_id'
-  belongs_to :product, -> { where( pictures: { imageable_type: 'Product' } ).eager_load( :pictures ) }, foreign_key: 'imageable_id'
+  belongs_to :document, -> { where( pictures: { imageable_type: 'Document' } ) }, foreign_key: 'imageable_id'
+  belongs_to :product, -> { where( pictures: { imageable_type: 'Product' } ) }, foreign_key: 'imageable_id'
 
   has_one :file_properties, as: 'fileable'
 end

--- a/test/integration/requests/request_test.rb
+++ b/test/integration/requests/request_test.rb
@@ -1608,7 +1608,7 @@ class RequestTest < ActionDispatch::IntegrationTest
                        }
 
     $test_user = Person.find(1001)
-    assert_equal 2, JSONAPI.configuration.resource_cache.instance_variable_get(:@key_access).length
+    assert_equal 2, JSONAPI.configuration.resource_cache.instance_variable_get(:@data).length
 
     get "/api/v9/people/#{$test_user.id}?include=preferences"
     assert_jsonapi_response 200
@@ -1655,7 +1655,7 @@ class RequestTest < ActionDispatch::IntegrationTest
                          ]
                        }
 
-    assert_equal 4, JSONAPI.configuration.resource_cache.instance_variable_get(:@key_access).length
+    assert_equal 4, JSONAPI.configuration.resource_cache.instance_variable_get(:@data).length
 
   ensure
     JSONAPI.configuration = original_config
@@ -1700,7 +1700,7 @@ class RequestTest < ActionDispatch::IntegrationTest
                          }
                        }
 
-    assert_equal 1, JSONAPI.configuration.resource_cache.instance_variable_get(:@key_access).length
+    assert_equal 1, JSONAPI.configuration.resource_cache.instance_variable_get(:@data).length
 
     $test_user = Person.find(1001)
 
@@ -1728,7 +1728,7 @@ class RequestTest < ActionDispatch::IntegrationTest
                          }
                        }
 
-    assert_equal 2, JSONAPI.configuration.resource_cache.instance_variable_get(:@key_access).length
+    assert_equal 2, JSONAPI.configuration.resource_cache.instance_variable_get(:@data).length
 
   ensure
     JSONAPI.configuration = original_config

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -88,9 +88,9 @@ end
 # Monkeypatch ActionController::TestCase to delete the RAW_POST_DATA on subsequent calls in the same test.
 if Rails::VERSION::MAJOR >= 5
   module ClearRawPostHeader
-    def process(action, *args)
+    def process(action, **args)
       @request.delete_header 'RAW_POST_DATA'
-      super
+      super action, **args
     end
   end
 
@@ -560,13 +560,13 @@ class ActionDispatch::IntegrationTest
 end
 
 class ActionController::TestCase
-  def assert_cacheable_get(action, *args)
+  def assert_cacheable_get(action, **args)
     assert_nil JSONAPI.configuration.resource_cache
 
     normal_queries = []
     normal_query_callback = lambda {|_, _, _, _, payload| normal_queries.push payload[:sql] }
     ActiveSupport::Notifications.subscribed(normal_query_callback, 'sql.active_record') do
-      get action, *args
+      get action, **args
     end
     non_caching_response = json_response_sans_all_backtraces
     non_caching_status = response.status
@@ -602,7 +602,7 @@ class ActionController::TestCase
               @controller = nil
               setup_controller_request_and_response
               @request.headers.merge!(orig_request_headers.dup)
-              get action, *args
+              get action, **args
             end
           end
         rescue Exception

--- a/test/unit/active_relation_resource_finder/join_manager_test.rb
+++ b/test/unit/active_relation_resource_finder/join_manager_test.rb
@@ -110,7 +110,11 @@ class JoinTreeTest < ActiveSupport::TestCase
     records = Api::V10::PostResource.records({})
     records = join_manager.join(records, {})
 
-    sql = 'SELECT "posts".* FROM "posts" LEFT OUTER JOIN "comments" ON "comments"."post_id" = "posts"."id" LEFT OUTER JOIN "people" ON "people"."id" = "posts"."author_id" LEFT OUTER JOIN "people" "authors_comments" ON "authors_comments"."id" = "comments"."author_id" LEFT OUTER JOIN "comments_tags" ON "comments_tags"."comment_id" = "comments"."id" LEFT OUTER JOIN "tags" ON "tags"."id" = "comments_tags"."tag_id" WHERE "comments"."approved" = ' + db_true +  ' AND "author"."special" = ' + db_true
+    if (Rails::VERSION::MAJOR == 6 && Rails::VERSION::MINOR >= 1) || Rails::VERSION::MAJOR > 6
+      sql = 'SELECT "posts".* FROM "posts" LEFT OUTER JOIN "comments" ON "comments"."post_id" = "posts"."id" LEFT OUTER JOIN "people" author ON author."id" = "posts"."author_id" LEFT OUTER JOIN "people" "authors_comments" ON "authors_comments"."id" = "comments"."author_id" LEFT OUTER JOIN "comments_tags" ON "comments_tags"."comment_id" = "comments"."id" LEFT OUTER JOIN "tags" ON "tags"."id" = "comments_tags"."tag_id" WHERE "comments"."approved" = ' + db_true + ' AND "author"."special" = ' + db_true
+    else
+      sql = 'SELECT "posts".* FROM "posts" LEFT OUTER JOIN "comments" ON "comments"."post_id" = "posts"."id" LEFT OUTER JOIN "people" ON "people"."id" = "posts"."author_id" LEFT OUTER JOIN "people" "authors_comments" ON "authors_comments"."id" = "comments"."author_id" LEFT OUTER JOIN "comments_tags" ON "comments_tags"."comment_id" = "comments"."id" LEFT OUTER JOIN "tags" ON "tags"."id" = "comments_tags"."tag_id" WHERE "comments"."approved" = ' + db_true + ' AND "author"."special" = ' + db_true
+    end
 
     assert_equal sql, records.to_sql
 
@@ -132,7 +136,11 @@ class JoinTreeTest < ActiveSupport::TestCase
     records = join_manager.join(records, {})
 
     # Note sql is in different order, but aliases should still be right
-    sql = 'SELECT "posts".* FROM "posts" LEFT OUTER JOIN "people" ON "people"."id" = "posts"."author_id" LEFT OUTER JOIN "comments" ON "comments"."post_id" = "posts"."id" LEFT OUTER JOIN "people" "authors_comments" ON "authors_comments"."id" = "comments"."author_id" LEFT OUTER JOIN "comments_tags" ON "comments_tags"."comment_id" = "comments"."id" LEFT OUTER JOIN "tags" ON "tags"."id" = "comments_tags"."tag_id" WHERE "comments"."approved" = ' + db_true +  ' AND "author"."special" = ' + db_true
+    if (Rails::VERSION::MAJOR == 6 && Rails::VERSION::MINOR >= 1) || Rails::VERSION::MAJOR > 6
+      sql = 'SELECT "posts".* FROM "posts" LEFT OUTER JOIN "people" author ON author."id" = "posts"."author_id" LEFT OUTER JOIN "comments" ON "comments"."post_id" = "posts"."id" LEFT OUTER JOIN "people" "authors_comments" ON "authors_comments"."id" = "comments"."author_id" LEFT OUTER JOIN "comments_tags" ON "comments_tags"."comment_id" = "comments"."id" LEFT OUTER JOIN "tags" ON "tags"."id" = "comments_tags"."tag_id" WHERE "comments"."approved" = ' + db_true + ' AND "author"."special" = ' + db_true
+    else
+      sql = 'SELECT "posts".* FROM "posts" LEFT OUTER JOIN "people" ON "people"."id" = "posts"."author_id" LEFT OUTER JOIN "comments" ON "comments"."post_id" = "posts"."id" LEFT OUTER JOIN "people" "authors_comments" ON "authors_comments"."id" = "comments"."author_id" LEFT OUTER JOIN "comments_tags" ON "comments_tags"."comment_id" = "comments"."id" LEFT OUTER JOIN "tags" ON "tags"."id" = "comments_tags"."tag_id" WHERE "comments"."approved" = ' + db_true + ' AND "author"."special" = ' + db_true
+    end
 
     assert_equal sql, records.to_sql
 
@@ -171,7 +179,11 @@ class JoinTreeTest < ActiveSupport::TestCase
     records = Api::V10::PostResource.records({})
     records = join_manager.join(records, {})
 
-    sql = 'SELECT "posts".* FROM "posts" LEFT OUTER JOIN "comments" ON "comments"."post_id" = "posts"."id" LEFT OUTER JOIN "people" ON "people"."id" = "posts"."author_id" LEFT OUTER JOIN "people" "authors_comments" ON "authors_comments"."id" = "comments"."author_id" LEFT OUTER JOIN "comments_tags" ON "comments_tags"."comment_id" = "comments"."id" LEFT OUTER JOIN "tags" ON "tags"."id" = "comments_tags"."tag_id" WHERE "comments"."approved" = ' + db_true +  ' AND "author"."special" = ' + db_true
+    if (Rails::VERSION::MAJOR == 6 && Rails::VERSION::MINOR >= 1) || Rails::VERSION::MAJOR > 6
+      sql = 'SELECT "posts".* FROM "posts" LEFT OUTER JOIN "comments" ON "comments"."post_id" = "posts"."id" LEFT OUTER JOIN "people" author ON author."id" = "posts"."author_id" LEFT OUTER JOIN "people" "authors_comments" ON "authors_comments"."id" = "comments"."author_id" LEFT OUTER JOIN "comments_tags" ON "comments_tags"."comment_id" = "comments"."id" LEFT OUTER JOIN "tags" ON "tags"."id" = "comments_tags"."tag_id" WHERE "comments"."approved" = ' + db_true + ' AND "author"."special" = ' + db_true
+    else
+      sql = 'SELECT "posts".* FROM "posts" LEFT OUTER JOIN "comments" ON "comments"."post_id" = "posts"."id" LEFT OUTER JOIN "people" ON "people"."id" = "posts"."author_id" LEFT OUTER JOIN "people" "authors_comments" ON "authors_comments"."id" = "comments"."author_id" LEFT OUTER JOIN "comments_tags" ON "comments_tags"."comment_id" = "comments"."id" LEFT OUTER JOIN "tags" ON "tags"."id" = "comments_tags"."tag_id" WHERE "comments"."approved" = ' + db_true + ' AND "author"."special" = ' + db_true
+    end
 
     assert_equal sql, records.to_sql
 
@@ -190,13 +202,18 @@ class JoinTreeTest < ActiveSupport::TestCase
     records = Api::V10::PostResource.records({})
     records = join_manager.join(records, {})
 
-    sql = 'SELECT "posts".* FROM "posts" INNER JOIN "comments" ON "comments"."post_id" = "posts"."id" LEFT OUTER JOIN "people" ON "people"."id" = "comments"."author_id" LEFT OUTER JOIN "comments_tags" ON "comments_tags"."comment_id" = "comments"."id" LEFT OUTER JOIN "tags" ON "tags"."id" = "comments_tags"."tag_id" LEFT OUTER JOIN "comments" "comments_people" ON "comments_people"."author_id" = "people"."id" WHERE "comments"."approved" = ' + db_true +  ' AND "author"."special" = ' + db_true
+    if (Rails::VERSION::MAJOR == 6 && Rails::VERSION::MINOR >= 1) || Rails::VERSION::MAJOR > 6
+      sql = 'SELECT "posts".* FROM "posts" INNER JOIN "comments" ON "comments"."post_id" = "posts"."id" LEFT OUTER JOIN "people" author ON author."id" = "comments"."author_id" LEFT OUTER JOIN "comments_tags" ON "comments_tags"."comment_id" = "comments"."id" LEFT OUTER JOIN "tags" ON "tags"."id" = "comments_tags"."tag_id" LEFT OUTER JOIN "comments" "comments_people" ON "comments_people"."author_id" = "people"."id" WHERE "comments"."approved" = ' + db_true + ' AND "author"."special" = ' + db_true
+      assert_hash_equals({alias: 'author', join_type: :left}, join_manager.join_details_by_relationship(Api::V10::CommentResource._relationship(:author)))
+    else
+      sql = 'SELECT "posts".* FROM "posts" INNER JOIN "comments" ON "comments"."post_id" = "posts"."id" LEFT OUTER JOIN "people" ON "people"."id" = "comments"."author_id" LEFT OUTER JOIN "comments_tags" ON "comments_tags"."comment_id" = "comments"."id" LEFT OUTER JOIN "tags" ON "tags"."id" = "comments_tags"."tag_id" LEFT OUTER JOIN "comments" "comments_people" ON "comments_people"."author_id" = "people"."id" WHERE "comments"."approved" = ' + db_true + ' AND "author"."special" = ' + db_true
+      assert_hash_equals({alias: 'people', join_type: :left}, join_manager.join_details_by_relationship(Api::V10::CommentResource._relationship(:author)))
+    end
 
     assert_equal sql, records.to_sql
 
     assert_hash_equals({alias: 'comments', join_type: :inner}, join_manager.source_join_details)
     assert_hash_equals({alias: 'comments', join_type: :inner}, join_manager.join_details_by_relationship(Api::V10::PostResource._relationship(:comments)))
-    assert_hash_equals({alias: 'people', join_type: :left}, join_manager.join_details_by_relationship(Api::V10::CommentResource._relationship(:author)))
     assert_hash_equals({alias: 'tags', join_type: :left}, join_manager.join_details_by_relationship(Api::V10::CommentResource._relationship(:tags)))
     assert_hash_equals({alias: 'comments_people', join_type: :left}, join_manager.join_details_by_relationship(Api::V10::PersonResource._relationship(:comments)))
   end

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -13,7 +13,7 @@ class PostWithBadAfterSave < ActiveRecord::Base
   after_save :do_some_after_save_stuff
 
   def do_some_after_save_stuff
-    errors[:base] << 'Boom! Error added in after_save callback.'
+    errors.add(:base, 'Boom! Error added in after_save callback.')
     raise ActiveRecord::RecordInvalid.new(self)
   end
 end
@@ -23,7 +23,7 @@ class PostWithCustomValidationContext < ActiveRecord::Base
   validate :api_specific_check, on: :json_api_create
 
   def api_specific_check
-    errors[:base] << 'Record is invalid'
+    errors.add(:base, 'Record is invalid')
   end
 end
 


### PR DESCRIPTION
Adds support for rails 6.1

Brings in the rails 6.1 work from #1346, fixes a few JoinManager tests to account for new aliasing behavior, and updates the testing matrix. I'd like to rewrite the JoinManger tests, but not for this PR since it will be a lot of time I's rather spend on new features.

### All Submissions:

- [ ] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions