### PR TITLE
Fix missing Location header in 0.9.x

### DIFF
--- a/lib/jsonapi/acts_as_resource_controller.rb
+++ b/lib/jsonapi/acts_as_resource_controller.rb
@@ -234,7 +234,7 @@ module JSONAPI
         render_options[:body] = JSON.generate(content)
       end
 
-      render_options[:location] = content[:data]["links"][:self] if (
+      render_options[:location] = content[:data]["links"]["self"] if (
         response_doc.status == :created && content[:data].class != Array && content[:data]["links"]
       )
 

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -591,6 +591,7 @@ class PostsControllerTest < ActionController::TestCase
     assert_equal 'JR is Great', json_response['data']['attributes']['title']
     assert_equal 'JSONAPIResources is the greatest thing since unsliced bread.', json_response['data']['attributes']['body']
     assert_equal "http://test.host/posts/#{json_response['data']['id']}", json_response['data']['links']['self']
+    assert_equal json_response['data']['links']['self'], response.location
   end
 
   def test_create_simple_id_not_allowed


### PR DESCRIPTION
See issue: https://github.com/cerebris/jsonapi-resources/issues/1361

### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [x] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [x] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [x] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [x] I've added/updated tests for this change.

### Bug fixes and Changes to Core Features:

- [x] I've included an explanation of what the changes do and why I'd like you to include them.
- [x] I've provided test(s) that fails without the change.

When upgrading from jsonapi-resources `v0.9.0` to `v0.9.12` we've noticed a regression with the `Location` header being set when creating resources.

On further investigation, it appears this change introduced string keys for referencing self links, but did not update the setting of the location header accordingly: https://github.com/cerebris/jsonapi-resources/commit/010f024758a41460ebe51f13b35e0b3136a95e79

This change both adds a failing test (copied from the [original location header PR](https://github.com/cerebris/jsonapi-resources/commit/933750c1aba43f6db2a0cc2a782be5caa902c359)) and fixes the regression.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions