### PR TITLE
Ensure eql? comparison object is the type expected

### DIFF
--- a/lib/jsonapi/path_segment.rb
+++ b/lib/jsonapi/path_segment.rb
@@ -30,7 +30,7 @@ module JSONAPI
       end
 
       def eql?(other)
-        relationship == other.relationship && resource_klass == other.resource_klass
+        other.is_a?(JSONAPI::PathSegment::Relationship) && relationship == other.relationship && resource_klass == other.resource_klass
       end
 
       def hash
@@ -59,7 +59,7 @@ module JSONAPI
       end
 
       def eql?(other)
-        field_name == other.field_name && resource_klass == other.resource_klass
+        other.is_a?(JSONAPI::PathSegment::Field) && field_name == other.field_name && resource_klass == other.resource_klass
       end
 
       def delegated_field_name


### PR DESCRIPTION
This fixes a bug exposed by flappy tests on ruby 2.7.2 and 3.0. I still need to resolve the root cause of why strings are being passed in sometimes.


### All Submissions:

- [ ] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions