### PR TITLE
Add MySQL to CI workflow

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -10,6 +10,18 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     services:
+      mysql:
+        image: mysql
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd "mysqladmin ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
       postgres:
         image: postgres
         env:
@@ -35,6 +47,7 @@ jobs:
           - 5.2.4.4
           - 5.1.7
         database_url:
+          - mysql2://root:root@127.0.0.1:3306/test
           - postgresql://postgres:password@localhost:5432/test
           - sqlite3:test_db
         exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ version = ENV['RAILS_VERSION'] || 'default'
 
 platforms :ruby do
   gem 'pg'
+  gem 'mysql2'
 
   if version.start_with?('4.2', '5.0')
     gem 'sqlite3', '~> 1.3.13'


### PR DESCRIPTION
This PR adds MySQL to the CI workflow, as mentioned in #1369.

There is currently a MySQL syntax error in the `0.10.x` code that would be detected in CI with MySQL in the testing matrix.

### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [x] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [x] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [x] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions