### PR TITLE
Fixes 1378 - Add Ruby 3.1 and Rails 7.0 to the CI matrix

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -32,35 +32,35 @@ jobs:
           - 3.1
           - 3.2
         rails:
-          - 7.0.1
-          - 6.1.3
-          - 6.0.3
-          - 5.2.4
+          - 7.0.4
+          - 6.1.7
+          - 6.0.6
+          - 5.2.8.1
           - 5.1.7
         database_url:
           - postgresql://postgres:password@localhost:5432/test
           - sqlite3:test_db
         exclude:
           - ruby: 3.2
-            rails: 6.0.3
+            rails: 6.0.6
           - ruby: 3.2
-            rails: 5.2.4
+            rails: 5.2.8.1
           - ruby: 3.2
             rails: 5.1.7
           - ruby: 3.1
-            rails: 6.0.3
+            rails: 6.0.6
           - ruby: 3.1
-            rails: 5.2.4
+            rails: 5.2.8.1
           - ruby: 3.1
             rails: 5.1.7
           - ruby: '3.0'
-            rails: 6.0.3
+            rails: 6.0.6
           - ruby: '3.0'
-            rails: 5.2.4
+            rails: 5.2.8.1
           - ruby: '3.0'
             rails: 5.1.7
           - ruby: 2.6
-            rails: 7.0.1
+            rails: 7.0.4
           - database_url: postgresql://postgres:password@localhost:5432/test
             rails: 5.1.7
     env:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -30,6 +30,7 @@ jobs:
           - 2.7
           - '3.0'
           - 3.1
+          - 3.2
         rails:
           - 7.0.1
           - 6.1.3
@@ -40,11 +41,17 @@ jobs:
           - postgresql://postgres:password@localhost:5432/test
           - sqlite3:test_db
         exclude:
-          - ruby: '3.1'
+          - ruby: 3.2
             rails: 6.0.3
-          - ruby: '3.1'
+          - ruby: 3.2
             rails: 5.2.4
-          - ruby: '3.1'
+          - ruby: 3.2
+            rails: 5.1.7
+          - ruby: 3.1
+            rails: 6.0.3
+          - ruby: 3.1
+            rails: 5.2.4
+          - ruby: 3.1
             rails: 5.1.7
           - ruby: '3.0'
             rails: 6.0.3
@@ -61,7 +68,7 @@ jobs:
       DATABASE_URL: ${{ matrix.database_url }}
     name: Ruby ${{ matrix.ruby }} Rails ${{ matrix.rails }} DB ${{ matrix.database_url }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -26,24 +26,34 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - 2.6.6
-          - 2.7.2
-          - 3.0.0
+          - 2.6
+          - 2.7
+          - '3.0'
+          - 3.1
         rails:
-          - 6.1.3.1
-          - 6.0.3.4
-          - 5.2.4.4
+          - 7.0.1
+          - 6.1.3
+          - 6.0.3
+          - 5.2.4
           - 5.1.7
         database_url:
           - postgresql://postgres:password@localhost:5432/test
           - sqlite3:test_db
         exclude:
-          - ruby: 3.0.0
-            rails: 6.0.3.4
-          - ruby: 3.0.0
-            rails: 5.2.4.4
-          - ruby: 3.0.0
+          - ruby: '3.1'
+            rails: 6.0.3
+          - ruby: '3.1'
+            rails: 5.2.4
+          - ruby: '3.1'
             rails: 5.1.7
+          - ruby: '3.0'
+            rails: 6.0.3
+          - ruby: '3.0'
+            rails: 5.2.4
+          - ruby: '3.0'
+            rails: 5.1.7
+          - ruby: 2.6
+            rails: 7.0.1
           - database_url: postgresql://postgres:password@localhost:5432/test
             rails: 5.1.7
     env:

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -62,7 +62,7 @@ class TestApp < Rails::Application
   config.active_support.halt_callback_chains_on_return_false = false
   config.active_record.time_zone_aware_types = [:time, :datetime]
   config.active_record.belongs_to_required_by_default = false
-  unless Rails::VERSION::MAJOR == 5 && Rails::VERSION::MINOR < 2 || Rails::VERSION::MAJOR == 6 && Rails::VERSION::MINOR >= 1
+  if Rails::VERSION::MAJOR == 5 && Rails::VERSION::MINOR == 2
     config.active_record.sqlite3.represent_boolean_as_integer = true
   end
 end

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -174,7 +174,10 @@ class ResourceTest < ActiveSupport::TestCase
   end
 
   def test_inherited_calls_superclass
-    assert_equal(BaseResource.subclasses, [PersonResource, SpecialBaseResource])
+    subclasses = BaseResource.subclasses
+    assert_includes(subclasses, PersonResource)
+    assert_includes(subclasses, SpecialBaseResource)
+    assert_equal(2, subclasses.size)
   end
 
   def test_nil_model_class


### PR DESCRIPTION
This PR adds Ruby 3.1 and Rails 7.0 to the CI matrix.  In addition to the change to the basic GitHub Actions YAML, the following changes were required:

1. In `test/test_helper.rb` restrict setting `config.active_record.sqlite3.represent_boolean_as_integer` to Rails version 5.2.x
2. In `test/unit/resource/resource_test.rb` there's no guarantee on the ordering of classes returned by subclasses, so loosen the spec to pass if the correct subclasses are returned in any order.
3. Updated the CI configuration to pull the latest patch version for each minor version of Ruby and Rails.

### All Submissions:

- [X] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [X] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [X] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [X] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [X] I've added/updated tests for this change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions