### PR TITLE
Remove `data` from cached resource fragments

### DIFF
--- a/lib/jsonapi/cached_response_fragment.rb
+++ b/lib/jsonapi/cached_response_fragment.rb
@@ -52,7 +52,7 @@ module JSONAPI
 
       # Relationships left uncompiled because we'll often want to insert included ids on retrieval
       # Remove the data since that should not be cached
-      @relationships = relationships&.transform_values! {|v| v.delete_if {|k, _v| k == 'data'} }
+      @relationships = relationships&.transform_values {|v| v.delete_if {|k, _v| k == 'data'} }
       @links_json = CompiledJson.of(links_json)
       @attributes_json = CompiledJson.of(attributes_json)
       @meta_json = CompiledJson.of(meta_json)

--- a/lib/jsonapi/cached_response_fragment.rb
+++ b/lib/jsonapi/cached_response_fragment.rb
@@ -51,8 +51,8 @@ module JSONAPI
       @fetchable_fields = Set.new(fetchable_fields)
 
       # Relationships left uncompiled because we'll often want to insert included ids on retrieval
-      @relationships = relationships
-
+      # Remove the data since that should not be cached
+      @relationships = relationships&.transform_values! {|v| v.delete_if {|k, _v| k == 'data'} }
       @links_json = CompiledJson.of(links_json)
       @attributes_json = CompiledJson.of(attributes_json)
       @meta_json = CompiledJson.of(meta_json)

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -304,6 +304,22 @@ class PostsControllerTest < ActionController::TestCase
     JSONAPI.configuration.allow_filter = true
   end
 
+  def test_cached_result_does_not_include_relationship_data
+    JSONAPI.configuration.resource_cache = ActiveSupport::Cache::MemoryStore.new
+    JSONAPI.configuration.default_caching = true
+
+    get :show, params: {id: '1', include: 'author'}
+    assert_response :success
+    assert json_response['data']['relationships']['author']['data']
+
+    get :show, params: {id: '1'}
+    assert_response :success
+    refute json_response['data']['relationships']['author']['data']
+  ensure
+    JSONAPI.configuration.resource_cache = nil
+    JSONAPI.configuration.default_caching = false
+  end
+
   def test_index_include_one_level_query_count
     assert_query_count(4) do
       assert_cacheable_get :index, params: {include: 'author'}


### PR DESCRIPTION
Cached resources were returning relationship `data` elements if when the resource was first accessed the relationship included `data` element. This removes the `data` element from the cached resource fragment.

### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [x] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [x] I've added/updated tests for this change.

### Bug fixes and Changes to Core Features:

- [x] I've included an explanation of what the changes do and why I'd like you to include them.
- [x] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [x] Maintains compliance with JSON:API
- [x] Adequate test coverage exists to prevent regressions