### PR TITLE
Use records for joined resources for 0.10

### DIFF
--- a/lib/jsonapi/active_relation/join_manager.rb
+++ b/lib/jsonapi/active_relation/join_manager.rb
@@ -147,9 +147,15 @@ module JSONAPI
             related_resource_klass = join_details[:related_resource_klass]
             join_type = relationship_details[:join_type]
 
+            join_options = {
+              relationship: relationship,
+              relationship_details: relationship_details,
+              related_resource_klass: related_resource_klass,
+            }
+
             if relationship == :root
               unless source_relationship
-                add_join_details('', {alias: resource_klass._table_name, join_type: :root})
+                add_join_details('', {alias: resource_klass._table_name, join_type: :root, join_options: join_options})
               end
               next
             end
@@ -163,7 +169,7 @@ module JSONAPI
                 options: options)
             }
 
-            details = {alias: self.class.alias_from_arel_node(join_node), join_type: join_type}
+            details = {alias: self.class.alias_from_arel_node(join_node), join_type: join_type, join_options: join_options}
 
             if relationship == source_relationship
               if relationship.polymorphic? && relationship.belongs_to?

--- a/lib/jsonapi/active_relation_resource.rb
+++ b/lib/jsonapi/active_relation_resource.rb
@@ -324,6 +324,11 @@ module JSONAPI
             records = records.joins_left(relation_name)
           end
         end
+
+        if relationship.merge_resource_records
+          records = records.merge(self.records(options))
+        end
+
         records
       end
 

--- a/lib/jsonapi/active_relation_resource.rb
+++ b/lib/jsonapi/active_relation_resource.rb
@@ -325,7 +325,7 @@ module JSONAPI
           end
         end
 
-        if relationship.merge_resource_records_for_joins
+        if relationship.use_related_resource_records_for_joins
           records = records.merge(self.records(options))
         end
 

--- a/lib/jsonapi/active_relation_resource.rb
+++ b/lib/jsonapi/active_relation_resource.rb
@@ -325,7 +325,7 @@ module JSONAPI
           end
         end
 
-        if relationship.merge_resource_records
+        if relationship.merge_resource_records_for_joins
           records = records.merge(self.records(options))
         end
 

--- a/lib/jsonapi/configuration.rb
+++ b/lib/jsonapi/configuration.rb
@@ -39,7 +39,8 @@ module JSONAPI
                 :default_resource_cache_field,
                 :resource_cache_digest_function,
                 :resource_cache_usage_report_function,
-                :default_exclude_links
+                :default_exclude_links,
+                :merge_resource_records
 
     def initialize
       #:underscored_key, :camelized_key, :dasherized_key, or custom
@@ -158,6 +159,10 @@ module JSONAPI
       # and relationships. Accepts either `:default`, `:none`, or array containing the
       # specific default links to exclude, which may be `:self` and `:related`.
       self.default_exclude_links = :none
+
+      # Merge related resources `records` when performing joins and a relation_name is not specified.
+      # This will bring in permission scopes on the included resources. This can be overridden per relationship.
+      self.merge_resource_records = true
     end
 
     def cache_formatters=(bool)
@@ -299,6 +304,8 @@ module JSONAPI
     attr_writer :resource_cache_usage_report_function
 
     attr_writer :default_exclude_links
+
+    attr_writer :merge_resource_records
   end
 
   class << self

--- a/lib/jsonapi/configuration.rb
+++ b/lib/jsonapi/configuration.rb
@@ -160,9 +160,9 @@ module JSONAPI
       # specific default links to exclude, which may be `:self` and `:related`.
       self.default_exclude_links = :none
 
-      # Use related `records` when performing joins. If a relation_name is specified this option is ignored for the
-      # relationship. This will bring in permission scopes on the included resources.
-      # This can be overridden per relationship.
+      # Use a related resource's records when performing joins. This setting allows included resources to account for
+      # permission scopes. It can be overridden explicitly per relationship. Furthermore, specifying a relation_name on
+      # a relationship will cause this setting to be ignored.
       self.use_related_resource_records_for_joins = true
     end
 

--- a/lib/jsonapi/configuration.rb
+++ b/lib/jsonapi/configuration.rb
@@ -40,7 +40,7 @@ module JSONAPI
                 :resource_cache_digest_function,
                 :resource_cache_usage_report_function,
                 :default_exclude_links,
-                :merge_resource_records_for_joins
+                :use_related_resource_records_for_joins
 
     def initialize
       #:underscored_key, :camelized_key, :dasherized_key, or custom
@@ -160,9 +160,10 @@ module JSONAPI
       # specific default links to exclude, which may be `:self` and `:related`.
       self.default_exclude_links = :none
 
-      # Merge related resources `records` when performing joins and a relation_name is not specified.
-      # This will bring in permission scopes on the included resources. This can be overridden per relationship.
-      self.merge_resource_records_for_joins = true
+      # Use related `records` when performing joins. If a relation_name is specified this option is ignored for the
+      # relationship. This will bring in permission scopes on the included resources.
+      # This can be overridden per relationship.
+      self.use_related_resource_records_for_joins = true
     end
 
     def cache_formatters=(bool)
@@ -305,7 +306,7 @@ module JSONAPI
 
     attr_writer :default_exclude_links
 
-    attr_writer :merge_resource_records_for_joins
+    attr_writer :use_related_resource_records_for_joins
   end
 
   class << self

--- a/lib/jsonapi/configuration.rb
+++ b/lib/jsonapi/configuration.rb
@@ -160,9 +160,9 @@ module JSONAPI
       # specific default links to exclude, which may be `:self` and `:related`.
       self.default_exclude_links = :none
 
-      # Use a related resource's records when performing joins. This setting allows included resources to account for
-      # permission scopes. It can be overridden explicitly per relationship. Furthermore, specifying a relation_name on
-      # a relationship will cause this setting to be ignored.
+      # Use a related resource's `records` when performing joins. This setting allows included resources to account for
+      # permission scopes. It can be overridden explicitly per relationship. Furthermore, specifying a `relation_name`
+      # on a relationship will cause this setting to be ignored.
       self.use_related_resource_records_for_joins = true
     end
 

--- a/lib/jsonapi/configuration.rb
+++ b/lib/jsonapi/configuration.rb
@@ -40,7 +40,7 @@ module JSONAPI
                 :resource_cache_digest_function,
                 :resource_cache_usage_report_function,
                 :default_exclude_links,
-                :merge_resource_records
+                :merge_resource_records_for_joins
 
     def initialize
       #:underscored_key, :camelized_key, :dasherized_key, or custom
@@ -162,7 +162,7 @@ module JSONAPI
 
       # Merge related resources `records` when performing joins and a relation_name is not specified.
       # This will bring in permission scopes on the included resources. This can be overridden per relationship.
-      self.merge_resource_records = true
+      self.merge_resource_records_for_joins = true
     end
 
     def cache_formatters=(bool)
@@ -305,7 +305,7 @@ module JSONAPI
 
     attr_writer :default_exclude_links
 
-    attr_writer :merge_resource_records
+    attr_writer :merge_resource_records_for_joins
   end
 
   class << self

--- a/lib/jsonapi/relationship.rb
+++ b/lib/jsonapi/relationship.rb
@@ -3,7 +3,7 @@ module JSONAPI
     attr_reader :acts_as_set, :foreign_key, :options, :name,
                 :class_name, :polymorphic, :always_include_optional_linkage_data,
                 :parent_resource, :eager_load_on_include, :custom_methods,
-                :inverse_relationship, :allow_include
+                :inverse_relationship, :allow_include, :merge_resource_records
 
     attr_writer :allow_include
 
@@ -22,7 +22,7 @@ module JSONAPI
         ActiveSupport::Deprecation.warn('Use polymorphic_types instead of polymorphic_relations')
         @polymorphic_types ||= options[:polymorphic_relations]
       end
-
+      @merge_resource_records = options.fetch(:merge_resource_records, options[:relation_name].nil?) == true
       @always_include_optional_linkage_data = options.fetch(:always_include_optional_linkage_data, false) == true
       @eager_load_on_include = options.fetch(:eager_load_on_include, false) == true
       @allow_include = options[:allow_include]

--- a/lib/jsonapi/relationship.rb
+++ b/lib/jsonapi/relationship.rb
@@ -3,7 +3,7 @@ module JSONAPI
     attr_reader :acts_as_set, :foreign_key, :options, :name,
                 :class_name, :polymorphic, :always_include_optional_linkage_data,
                 :parent_resource, :eager_load_on_include, :custom_methods,
-                :inverse_relationship, :allow_include, :merge_resource_records
+                :inverse_relationship, :allow_include, :merge_resource_records_for_joins
 
     attr_writer :allow_include
 
@@ -23,8 +23,8 @@ module JSONAPI
         @polymorphic_types ||= options[:polymorphic_relations]
       end
 
-      merge_resource_record_default = options[:relation_name] ? false : JSONAPI.configuration.merge_resource_records
-      @merge_resource_records = options.fetch(:merge_resource_records, merge_resource_record_default) == true
+      merge_resource_record_default = options[:relation_name] ? false : JSONAPI.configuration.merge_resource_records_for_joins
+      @merge_resource_records_for_joins = options.fetch(:merge_resource_records_for_joins, merge_resource_record_default) == true
 
       @always_include_optional_linkage_data = options.fetch(:always_include_optional_linkage_data, false) == true
       @eager_load_on_include = options.fetch(:eager_load_on_include, false) == true

--- a/lib/jsonapi/relationship.rb
+++ b/lib/jsonapi/relationship.rb
@@ -23,8 +23,14 @@ module JSONAPI
         @polymorphic_types ||= options[:polymorphic_relations]
       end
 
-      merge_resource_record_default = options[:relation_name] ? false : JSONAPI.configuration.use_related_resource_records_for_joins
-      @use_related_resource_records_for_joins = options.fetch(:use_related_resource_records_for_joins, merge_resource_record_default) == true
+      use_related_resource_records_for_joins_default = if options[:relation_name]
+                                                         false
+                                                       else
+                                                         JSONAPI.configuration.use_related_resource_records_for_joins
+                                                       end
+      
+      @use_related_resource_records_for_joins = options.fetch(:use_related_resource_records_for_joins,
+                                                              use_related_resource_records_for_joins_default) == true
 
       @always_include_optional_linkage_data = options.fetch(:always_include_optional_linkage_data, false) == true
       @eager_load_on_include = options.fetch(:eager_load_on_include, false) == true

--- a/lib/jsonapi/relationship.rb
+++ b/lib/jsonapi/relationship.rb
@@ -3,7 +3,7 @@ module JSONAPI
     attr_reader :acts_as_set, :foreign_key, :options, :name,
                 :class_name, :polymorphic, :always_include_optional_linkage_data,
                 :parent_resource, :eager_load_on_include, :custom_methods,
-                :inverse_relationship, :allow_include, :merge_resource_records_for_joins
+                :inverse_relationship, :allow_include, :use_related_resource_records_for_joins
 
     attr_writer :allow_include
 
@@ -23,8 +23,8 @@ module JSONAPI
         @polymorphic_types ||= options[:polymorphic_relations]
       end
 
-      merge_resource_record_default = options[:relation_name] ? false : JSONAPI.configuration.merge_resource_records_for_joins
-      @merge_resource_records_for_joins = options.fetch(:merge_resource_records_for_joins, merge_resource_record_default) == true
+      merge_resource_record_default = options[:relation_name] ? false : JSONAPI.configuration.use_related_resource_records_for_joins
+      @use_related_resource_records_for_joins = options.fetch(:use_related_resource_records_for_joins, merge_resource_record_default) == true
 
       @always_include_optional_linkage_data = options.fetch(:always_include_optional_linkage_data, false) == true
       @eager_load_on_include = options.fetch(:eager_load_on_include, false) == true

--- a/lib/jsonapi/relationship.rb
+++ b/lib/jsonapi/relationship.rb
@@ -22,7 +22,10 @@ module JSONAPI
         ActiveSupport::Deprecation.warn('Use polymorphic_types instead of polymorphic_relations')
         @polymorphic_types ||= options[:polymorphic_relations]
       end
-      @merge_resource_records = options.fetch(:merge_resource_records, options[:relation_name].nil?) == true
+
+      merge_resource_record_default = options[:relation_name] ? false : JSONAPI.configuration.merge_resource_records
+      @merge_resource_records = options.fetch(:merge_resource_records, merge_resource_record_default) == true
+
       @always_include_optional_linkage_data = options.fetch(:always_include_optional_linkage_data, false) == true
       @eager_load_on_include = options.fetch(:eager_load_on_include, false) == true
       @allow_include = options[:allow_include]

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -1413,7 +1413,7 @@ class PostResource < JSONAPI::Resource
 
   has_one :author, class_name: 'Person'
   has_one :section
-  has_many :tags, acts_as_set: true, inverse_relationship: :posts, eager_load_on_include: false
+  has_many :tags, acts_as_set: true, inverse_relationship: :posts
   has_many :comments, acts_as_set: false, inverse_relationship: :post
 
   # Not needed - just for testing
@@ -1932,16 +1932,7 @@ module Api
       model_name 'Person'
       attributes :name
 
-      has_many :books, inverse_relationship: :authors, relation_name: -> (options) {
-        book_admin = options[:context][:book_admin] || options[:context][:current_user].try(:book_admin)
-
-        if book_admin
-          :books
-        else
-          :not_banned_books
-        end
-      }
-
+      has_many :books
       has_many :book_comments
     end
 
@@ -1981,6 +1972,9 @@ module Api
               }
 
       filter :banned, apply: :apply_filter_banned
+      filter :title, apply: ->(records, value, options) {
+        records.where('books.title LIKE ?', "#{value[0]}%")
+      }
 
       class << self
         def books
@@ -1992,10 +1986,9 @@ module Api
         end
 
         def records(options = {})
-          context = options[:context]
-          current_user = context ? context[:current_user] : nil
+          current_user = options.dig(:context, :current_user)
 
-          records = _model_class.all
+          records = super
           # Hide the banned books from people who are not book admins
           unless current_user && current_user.book_admin
             records = records.where(not_banned_books)
@@ -2004,8 +1997,7 @@ module Api
         end
 
         def apply_filter_banned(records, value, options)
-          context = options[:context]
-          current_user = context ? context[:current_user] : nil
+          current_user = options.dig(:context, :current_user)
 
           # Only book admins might filter for banned books
           if current_user && current_user.book_admin
@@ -2045,7 +2037,7 @@ module Api
         end
 
         def records(options = {})
-          current_user = options[:context][:current_user]
+          current_user = options.dig(:context, :current_user)
           _model_class.for_user(current_user)
         end
       end
@@ -2100,7 +2092,7 @@ module Api
 
       has_one :author, class_name: 'Person', exclude_links: [:self, "related"]
       has_one :section, exclude_links: [:self, :related]
-      has_many :tags, acts_as_set: true, inverse_relationship: :posts, eager_load_on_include: false, exclude_links: :default
+      has_many :tags, acts_as_set: true, inverse_relationship: :posts, exclude_links: :default
       has_many :comments, acts_as_set: false, inverse_relationship: :post, exclude_links: ["self", :related]
     end
 

--- a/test/integration/book_authorization_test.rb
+++ b/test/integration/book_authorization_test.rb
@@ -1,0 +1,38 @@
+require File.expand_path('../../test_helper', __FILE__)
+
+class BookAuthorizationTest < ActionDispatch::IntegrationTest
+  def setup
+    DatabaseCleaner.start
+    JSONAPI.configuration.json_key_format = :underscored_key
+    JSONAPI.configuration.route_format = :underscored_route
+    Api::V2::BookResource.paginator :offset
+  end
+
+  def test_restricted_records_primary
+    Api::V2::BookResource.paginator :none
+
+    # Not a book admin
+    $test_user = Person.find(1001)
+    assert_cacheable_jsonapi_get '/api/v2/books?filter[title]=Book%206'
+    assert_equal 12, json_response['data'].size
+
+    # book_admin
+    $test_user = Person.find(1005)
+    assert_cacheable_jsonapi_get '/api/v2/books?filter[title]=Book%206'
+    assert_equal 111, json_response['data'].size
+  end
+
+  def test_restricted_records_related
+    Api::V2::BookResource.paginator :none
+
+    # Not a book admin
+    $test_user = Person.find(1001)
+    assert_cacheable_jsonapi_get '/api/v2/authors/1002/books'
+    assert_equal 1, json_response['data'].size
+
+    # book_admin
+    $test_user = Person.find(1005)
+    assert_cacheable_jsonapi_get '/api/v2/authors/1002/books'
+    assert_equal 2, json_response['data'].size
+  end
+end

--- a/test/unit/resource/relationship_test.rb
+++ b/test/unit/resource/relationship_test.rb
@@ -18,6 +18,30 @@ class CallableBlogPostsResource < JSONAPI::Resource
   end
 end
 
+class TestRelationshipOptionsPostsResource < JSONAPI::Resource
+  model_name 'Post'
+  has_one :author, allow_include: :is_admin, merge_resource_records: false
+end
+
+class RelationshipTest < ActiveSupport::TestCase
+  def test_merge_resource_records_enabled_by_default
+    relationship = JSONAPI::Relationship::ToOne.new(:author)
+    assert relationship.merge_resource_records
+  end
+
+  def test_merge_resource_records_is_disabled_by_deafult_with_relation_name
+    relationship = JSONAPI::Relationship::ToOne.new(:author,
+                                                    relation_name: "foo" )
+    refute relationship.merge_resource_records
+  end
+
+  def test_merge_resource_records_can_be_disabled
+    relationship = JSONAPI::Relationship::ToOne.new(:author,
+                                                    merge_resource_records: false )
+    refute relationship.merge_resource_records
+  end
+end
+
 class HasOneRelationshipTest < ActiveSupport::TestCase
 
   def test_polymorphic_type

--- a/test/unit/resource/relationship_test.rb
+++ b/test/unit/resource/relationship_test.rb
@@ -20,36 +20,36 @@ end
 
 class TestRelationshipOptionsPostsResource < JSONAPI::Resource
   model_name 'Post'
-  has_one :author, allow_include: :is_admin, merge_resource_records_for_joins: false
+  has_one :author, allow_include: :is_admin, use_related_resource_records_for_joins: false
 end
 
 class RelationshipTest < ActiveSupport::TestCase
-  def test_merge_resource_records_for_joins_enabled_by_default
-    assert JSONAPI.configuration.merge_resource_records_for_joins == true
+  def test_use_related_resource_records_for_joins_enabled_by_default
+    assert JSONAPI.configuration.use_related_resource_records_for_joins == true
     relationship = JSONAPI::Relationship::ToOne.new(:author)
-    assert relationship.merge_resource_records_for_joins
+    assert relationship.use_related_resource_records_for_joins
   end
 
-  def test_merge_resource_records_for_joins_can_be_disabled_globally
+  def test_use_related_resource_records_for_joins_can_be_disabled_globally
     original_config = JSONAPI.configuration.dup
 
-    JSONAPI.configuration.merge_resource_records_for_joins = false
+    JSONAPI.configuration.use_related_resource_records_for_joins = false
     relationship = JSONAPI::Relationship::ToOne.new(:author)
-    assert relationship.merge_resource_records_for_joins == false
+    assert relationship.use_related_resource_records_for_joins == false
   ensure
     JSONAPI.configuration = original_config
   end
 
-  def test_merge_resource_records_for_joins_is_disabled_by_deafult_with_relation_name
+  def test_use_related_resource_records_for_joins_is_disabled_by_deafult_with_relation_name
     relationship = JSONAPI::Relationship::ToOne.new(:author,
                                                     relation_name: "foo" )
-    refute relationship.merge_resource_records_for_joins
+    refute relationship.use_related_resource_records_for_joins
   end
 
-  def test_merge_resource_records_for_joins_can_be_disabled
+  def test_use_related_resource_records_for_joins_can_be_disabled
     relationship = JSONAPI::Relationship::ToOne.new(:author,
-                                                    merge_resource_records_for_joins: false )
-    refute relationship.merge_resource_records_for_joins
+                                                    use_related_resource_records_for_joins: false )
+    refute relationship.use_related_resource_records_for_joins
   end
 end
 

--- a/test/unit/resource/relationship_test.rb
+++ b/test/unit/resource/relationship_test.rb
@@ -20,36 +20,36 @@ end
 
 class TestRelationshipOptionsPostsResource < JSONAPI::Resource
   model_name 'Post'
-  has_one :author, allow_include: :is_admin, merge_resource_records: false
+  has_one :author, allow_include: :is_admin, merge_resource_records_for_joins: false
 end
 
 class RelationshipTest < ActiveSupport::TestCase
-  def test_merge_resource_records_enabled_by_default
-    assert JSONAPI.configuration.merge_resource_records == true
+  def test_merge_resource_records_for_joins_enabled_by_default
+    assert JSONAPI.configuration.merge_resource_records_for_joins == true
     relationship = JSONAPI::Relationship::ToOne.new(:author)
-    assert relationship.merge_resource_records
+    assert relationship.merge_resource_records_for_joins
   end
 
-  def test_merge_resource_records_can_be_disabled_globally
+  def test_merge_resource_records_for_joins_can_be_disabled_globally
     original_config = JSONAPI.configuration.dup
 
-    JSONAPI.configuration.merge_resource_records = false
+    JSONAPI.configuration.merge_resource_records_for_joins = false
     relationship = JSONAPI::Relationship::ToOne.new(:author)
-    assert relationship.merge_resource_records == false
+    assert relationship.merge_resource_records_for_joins == false
   ensure
     JSONAPI.configuration = original_config
   end
 
-  def test_merge_resource_records_is_disabled_by_deafult_with_relation_name
+  def test_merge_resource_records_for_joins_is_disabled_by_deafult_with_relation_name
     relationship = JSONAPI::Relationship::ToOne.new(:author,
                                                     relation_name: "foo" )
-    refute relationship.merge_resource_records
+    refute relationship.merge_resource_records_for_joins
   end
 
-  def test_merge_resource_records_can_be_disabled
+  def test_merge_resource_records_for_joins_can_be_disabled
     relationship = JSONAPI::Relationship::ToOne.new(:author,
-                                                    merge_resource_records: false )
-    refute relationship.merge_resource_records
+                                                    merge_resource_records_for_joins: false )
+    refute relationship.merge_resource_records_for_joins
   end
 end
 

--- a/test/unit/resource/relationship_test.rb
+++ b/test/unit/resource/relationship_test.rb
@@ -25,8 +25,19 @@ end
 
 class RelationshipTest < ActiveSupport::TestCase
   def test_merge_resource_records_enabled_by_default
+    assert JSONAPI.configuration.merge_resource_records == true
     relationship = JSONAPI::Relationship::ToOne.new(:author)
     assert relationship.merge_resource_records
+  end
+
+  def test_merge_resource_records_can_be_disabled_globally
+    original_config = JSONAPI.configuration.dup
+
+    JSONAPI.configuration.merge_resource_records = false
+    relationship = JSONAPI::Relationship::ToOne.new(:author)
+    assert relationship.merge_resource_records == false
+  ensure
+    JSONAPI.configuration = original_config
   end
 
   def test_merge_resource_records_is_disabled_by_deafult_with_relation_name


### PR DESCRIPTION
See #1307 for more details

### All Submissions:

- [ ] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions