### PR TITLE
Fix bug report templates

### DIFF
--- a/lib/bug_report_templates/rails_5_latest.rb
+++ b/lib/bug_report_templates/rails_5_latest.rb
@@ -13,7 +13,6 @@ gemfile(true) do
 
   gem 'activerecord-jdbcsqlite3-adapter',
       git: 'https://github.com/jruby/activerecord-jdbc-adapter',
-      branch: 'rails-5',
       platform: :jruby
 
   gem 'jsonapi-resources', require: false

--- a/lib/bug_report_templates/rails_5_master.rb
+++ b/lib/bug_report_templates/rails_5_master.rb
@@ -14,7 +14,6 @@ gemfile(true, ui: ENV['SILENT'] ? Bundler::UI::Silent.new : Bundler::UI::Shell.n
 
   gem 'activerecord-jdbcsqlite3-adapter',
       git: 'https://github.com/jruby/activerecord-jdbc-adapter',
-      branch: 'rails-5',
       platform: :jruby
 
   if ENV['JSONAPI_RESOURCES_PATH']


### PR DESCRIPTION
https://github.com/jruby/activerecord-jdbc-adapter no longer has a rails-5 branch

Closes #1382.

### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [x] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [x] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [x] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [x] I've added/updated tests for this change.

### Bug fixes and Changes to Core Features:

- [x] I've included an explanation of what the changes do and why I'd like you to include them.
- [x] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions