### PR TITLE
Allow processors to override global top_level_meta settings

### DIFF
--- a/lib/jsonapi/processor.rb
+++ b/lib/jsonapi/processor.rb
@@ -65,13 +65,13 @@ module JSONAPI
       resource_set.populate!(serializer, context, find_options)
 
       page_options = result_options
-      if (JSONAPI.configuration.top_level_meta_include_record_count || (paginator && paginator.class.requires_record_count))
+      if (top_level_meta_include_record_count || (paginator && paginator.class.requires_record_count))
         page_options[:record_count] = resource_klass.count(verified_filters,
                                                            context: context,
                                                            include_directives: include_directives)
       end
 
-      if (JSONAPI.configuration.top_level_meta_include_page_count && paginator && page_options[:record_count])
+      if (top_level_meta_include_page_count && paginator && page_options[:record_count])
         page_options[:page_count] = paginator ? paginator.calculate_page_count(page_options[:record_count]) : 1
       end
 
@@ -197,9 +197,9 @@ module JSONAPI
       resource_set.populate!(serializer, context, find_options)
 
       opts = result_options
-      if ((JSONAPI.configuration.top_level_meta_include_record_count) ||
+      if ((top_level_meta_include_record_count) ||
           (paginator && paginator.class.requires_record_count) ||
-          (JSONAPI.configuration.top_level_meta_include_page_count))
+          (top_level_meta_include_page_count))
 
         opts[:record_count] = source_resource.class.count_related(
             source_resource.identity,
@@ -207,7 +207,7 @@ module JSONAPI
             find_options)
       end
 
-      if (JSONAPI.configuration.top_level_meta_include_page_count && opts[:record_count])
+      if (top_level_meta_include_page_count && opts[:record_count])
         opts[:page_count] = paginator.calculate_page_count(opts[:record_count])
       end
 
@@ -380,6 +380,14 @@ module JSONAPI
       resource_id_tree = find_resource_id_tree_from_resource_relationship(resource, relationship_name, options, include_related)
 
       JSONAPI::ResourceSet.new(resource_id_tree)
+    end
+
+    def top_level_meta_include_record_count
+      JSONAPI.configuration.top_level_meta_include_record_count
+    end
+
+    def top_level_meta_include_page_count
+      JSONAPI.configuration.top_level_meta_include_page_count
     end
 
     private


### PR DESCRIPTION
This set of changes allow a custom processor to override the defaults for `top_level_meta_include_record_count` and `top_level_meta_include_page_count`.  The use case for this is to allow a custom paginator that does not require record_counts while still using default top_level_meta_include_* for most resource types.

### All Submissions:

- [ ] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [x] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions