### PR TITLE
Move `requires_record_count` to class instance

### DIFF
--- a/lib/jsonapi/paginator.rb
+++ b/lib/jsonapi/paginator.rb
@@ -13,9 +13,16 @@ module JSONAPI
       # :nocov:
     end
 
+    def requires_record_count
+      # :nocov:
+      self.class.requires_record_count
+      # :nocov:
+    end
+
     class << self
       def requires_record_count
         # :nocov:
+        # @deprecated
         false
         # :nocov:
       end
@@ -36,7 +43,12 @@ class OffsetPaginator < JSONAPI::Paginator
     verify_pagination_params
   end
 
+  # @deprecated
   def self.requires_record_count
+    true
+  end
+
+  def requires_record_count
     true
   end
 
@@ -127,7 +139,12 @@ class PagedPaginator < JSONAPI::Paginator
     verify_pagination_params
   end
 
+  # @deprecated
   def self.requires_record_count
+    true
+  end
+
+  def requires_record_count
     true
   end
 

--- a/lib/jsonapi/processor.rb
+++ b/lib/jsonapi/processor.rb
@@ -65,7 +65,7 @@ module JSONAPI
       resource_set.populate!(serializer, context, find_options)
 
       page_options = result_options
-      if (top_level_meta_include_record_count || (paginator && paginator.class.requires_record_count))
+      if (top_level_meta_include_record_count || (paginator && paginator.requires_record_count))
         page_options[:record_count] = resource_klass.count(verified_filters,
                                                            context: context,
                                                            include_directives: include_directives)
@@ -198,7 +198,7 @@ module JSONAPI
 
       opts = result_options
       if ((top_level_meta_include_record_count) ||
-          (paginator && paginator.class.requires_record_count) ||
+          (paginator && paginator.requires_record_count) ||
           (top_level_meta_include_page_count))
 
         opts[:record_count] = source_resource.class.count_related(
@@ -213,7 +213,7 @@ module JSONAPI
 
       opts[:pagination_params] = if paginator && JSONAPI.configuration.top_level_links_include_pagination
                                    page_options = {}
-                                   page_options[:record_count] = opts[:record_count] if paginator.class.requires_record_count
+                                   page_options[:record_count] = opts[:record_count] if paginator.requires_record_count
                                    paginator.links_page_params(page_options.merge(fetched_resources: resource_set))
                                  else
                                    {}


### PR DESCRIPTION
Will fallback to deprecated class method for custom paginators derived from JSONAPI::Paginator

This will allow for custom paginators to optionally run record count queries based on pagination parameters in the request. Some count queries are expensive and are not required for all client uses.

### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [x] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [x] Maintains compliance with JSON:API
- [x] Adequate test coverage exists to prevent regressions