### PR TITLE
Add option to specify custom method for has_many relationships creation 

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -62,7 +62,9 @@ class TestApp < Rails::Application
   config.active_support.halt_callback_chains_on_return_false = false
   config.active_record.time_zone_aware_types = [:time, :datetime]
   config.active_record.belongs_to_required_by_default = false
-  unless Rails::VERSION::MAJOR == 5 && Rails::VERSION::MINOR < 2 || Rails::VERSION::MAJOR == 6 && Rails::VERSION::MINOR >= 1
+  unless Rails::VERSION::MAJOR == 5 && Rails::VERSION::MINOR < 2 ||
+           Rails::VERSION::MAJOR == 6 && Rails::VERSION::MINOR >= 1 ||
+           Rails::VERSION::MAJOR > 6
     config.active_record.sqlite3.represent_boolean_as_integer = true
   end
 end
@@ -221,6 +223,7 @@ TestApp.routes.draw do
   jsonapi_resources :posts do
     jsonapi_relationships
     jsonapi_links :special_tags
+    jsonapi_links :super_tags, only: [:create]
   end
   jsonapi_resources :sections
   jsonapi_resources :iso_currencies


### PR DESCRIPTION
Currently has_many relations are added to a parent record via `ActiveRecord`'s `collection<<` method. And there is no way to change that.

- `collection<<` doesn't always work for complex associations (especially for using `through` option)
- `collection<<` doesn't provide full control and confidence
- `collection<<` silently ignores invalid records
- customizing `collection<<` on model level (which is now the only workaround) for API purposes is not a good way

So, there should be a way to specify (and implement on API level) a custom method that appends has_many relationships.

Example
```
# post_resource.rb

has_many :tags, create_method: :add_tag

def add_tag(tag)
  @model.post_tags.create!(tag: tag) if @model.acceptable_tag?(tag)
end
``` 