### PR TITLE
Co-erce non-present values like false to string

### DIFF
--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -895,6 +895,13 @@ module JSONAPI
 
       def verify_filter(filter, raw, context = nil)
         filter_values = []
+        if raw == true
+          raw = "true"
+        elsif raw == false
+          raw = "false"
+        else
+          nil # no-op
+        end
         if raw.present?
           begin
             filter_values += raw.is_a?(String) ? CSV.parse_line(raw) : [raw]

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -321,6 +321,18 @@ class ResourceTest < ActiveSupport::TestCase
     assert(!FelineResource.updatable_fields.include?(:id))
   end
 
+  def test_verify_filter
+    resource_klass = PersonResource
+    context = nil
+    filter = :name
+    assert_equal([filter, ["true"]], resource_klass.verify_filter(filter, true, context))
+    assert_equal([filter, ["false"]], resource_klass.verify_filter(filter, false, context))
+    assert_equal([filter, ["true"]], resource_klass.verify_filter(filter, "true", context))
+    assert_equal([filter, ["false"]], resource_klass.verify_filter(filter, "false", context))
+    assert_equal([filter, []], resource_klass.verify_filter(filter, nil, context))
+    assert_equal([filter, []], resource_klass.verify_filter(filter, "", context))
+  end
+
   def test_filter_on_to_many_relationship_id
     posts = PostResource.find(:comments => 3)
     assert_equal([2], posts.map(&:id))


### PR DESCRIPTION
We have a resource which calls another resource, and specifically calls 'verify_filters'. We discovered that in 0.9 and 0.10 `verify_filter` calls `raw.present?` which is false when raw is `false`.  This change makes the processing of the true and false consistent.

### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [x] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [x] I've added/updated tests for this change.

### Bug fixes and Changes to Core Features:

- [x] I've included an explanation of what the changes do and why I'd like you to include them.
- [x] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions