### PR TITLE
Rails 7.0 deprecates content_type  in favor of media_type

### DIFF
--- a/lib/jsonapi/acts_as_resource_controller.rb
+++ b/lib/jsonapi/acts_as_resource_controller.rb
@@ -140,8 +140,8 @@ module JSONAPI
     end
 
     def verify_content_type_header
-      unless request.content_type == JSONAPI::MEDIA_TYPE
-        fail JSONAPI::Exceptions::UnsupportedMediaTypeError.new(request.content_type)
+      unless request.media_type == JSONAPI::MEDIA_TYPE
+        fail JSONAPI::Exceptions::UnsupportedMediaTypeError.new(request.media_type)
       end
       true
     rescue => e

--- a/test/helpers/functional_helpers.rb
+++ b/test/helpers/functional_helpers.rb
@@ -32,8 +32,8 @@ module Helpers
     #       end
     #   end
     #
-    #   if @response.content_type
-    #     ct = @response.content_type
+    #   if @response.media_type
+    #     ct = @response.media_type
     #   elsif methods.include?('assert_response_response')
     #     ct = assert_response_response
     #   else

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -471,7 +471,7 @@ class ActionDispatch::IntegrationTest
   fixtures :all
 
   def assert_jsonapi_response(expected_status, msg = nil)
-    media_type = Rails::VERSION::MAJOR >= 6 ? response.media_type : response.media_type
+    media_type = response.media_type
     assert_equal JSONAPI::MEDIA_TYPE, media_type
     if status != expected_status && status >= 400
       pp json_response rescue nil

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -471,7 +471,7 @@ class ActionDispatch::IntegrationTest
   fixtures :all
 
   def assert_jsonapi_response(expected_status, msg = nil)
-    media_type = Rails::VERSION::MAJOR >= 6 ? response.media_type : response.content_type
+    media_type = Rails::VERSION::MAJOR >= 6 ? response.media_type : response.media_type
     assert_equal JSONAPI::MEDIA_TYPE, media_type
     if status != expected_status && status >= 400
       pp json_response rescue nil


### PR DESCRIPTION
Affects [0.10](https://github.com/cerebris/jsonapi-resources/pull/1390) and 0.9

Rails 7.0 deprecates content_type in favor of media_type

### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### Bug fixes and Changes to Core Features:

- [x] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions