### PR TITLE
Fix show_related_resources and top_level_meta_include_page_count

### DIFF
--- a/lib/jsonapi/processor.rb
+++ b/lib/jsonapi/processor.rb
@@ -204,7 +204,7 @@ module JSONAPI
           options)
       end
 
-      if (JSONAPI.configuration.top_level_meta_include_page_count && opts[:record_count])
+      if (paginator && JSONAPI.configuration.top_level_meta_include_page_count && opts[:record_count])
         opts[:page_count] = paginator.calculate_page_count(opts[:record_count])
       end
 

--- a/test/integration/requests/request_test.rb
+++ b/test/integration/requests/request_test.rb
@@ -813,6 +813,17 @@ class RequestTest < ActionDispatch::IntegrationTest
     JSONAPI.configuration.top_level_meta_include_record_count = false
   end
 
+  def test_pagination_none_related_resources_and_top_level_meta_include_page_count
+    Api::V2::BookResource.paginator :offset
+    Api::V2::BookCommentResource.paginator :none
+    JSONAPI.configuration.top_level_meta_include_page_count = true
+    assert_cacheable_jsonapi_get '/api/v2/books/1/book_comments'
+    assert json_response['data']
+    assert_nil json_response.dig('meta', 'record_count')
+  ensure
+    JSONAPI.configuration.top_level_meta_include_page_count = false
+  end
+
   def test_filter_related_resources_relationship_filter
     Api::V2::BookCommentResource.paginator :offset
     JSONAPI.configuration.top_level_meta_include_record_count = true


### PR DESCRIPTION
problem:

When the paginator is :none and top_level_meta_include_page_count is true
The show_related_resources was crashing as the paginator is nil

solution:

Just fixing the immediate problem but the code still leaves page_count
as nil in the meta

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions