### PR TITLE
Fix quoting issue on generate sql statements

### DIFF
--- a/lib/jsonapi/active_relation_resource.rb
+++ b/lib/jsonapi/active_relation_resource.rb
@@ -845,7 +845,7 @@ module JSONAPI
       end
 
       def quote(field)
-        "\"#{field.to_s}\""
+        ActiveRecord::Base.connection.quote_table_name(field)
       end
 
       def apply_filters(records, filters, options = {})


### PR DESCRIPTION
Using the previous method to generate the quote string could lead to incorrect sql statement where double quotes were used for select statements in MySql.

By using the `quote_table_name` function from Rails, the correct quoting mechnism will be automatically used for the specific database.

Fixes #1369



### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [x] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [x] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [x] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions