### PR TITLE
fix: Reliably quote columns/tables

### DIFF
--- a/lib/jsonapi/active_relation_resource.rb
+++ b/lib/jsonapi/active_relation_resource.rb
@@ -860,6 +860,7 @@ module JSONAPI
       end
 
       def quote_column_name(column_name)
+        return column_name if column_name == "*"
         if _model_class.try(:connection)
           _model_class.connection.quote_column_name(column_name)
         else
@@ -868,7 +869,6 @@ module JSONAPI
       end
 
       def quote(field)
-        raise "zomg, we are using the fallback for #{field}"
         %{"#{field.to_s}"}
       end
 

--- a/lib/jsonapi/active_relation_resource.rb
+++ b/lib/jsonapi/active_relation_resource.rb
@@ -804,14 +804,14 @@ module JSONAPI
         if table.blank? || field.to_s.include?('.')
           # :nocov:
           if quoted
-            quote(field)
+            quote(field) # split on '.'?
           else
             field.to_s
           end
           # :nocov:
         else
           if quoted
-            "#{quote(table)}.#{quote(field)}"
+            "#{quote_table_name(table)}.#{quote_column_name(field)}"
           else
             # :nocov:
             "#{table.to_s}.#{field.to_s}"
@@ -828,7 +828,7 @@ module JSONAPI
         if table.blank? || field.to_s.include?('.')
           # :nocov:
           if quoted
-            quote(field)
+            quote_column_name(field)
           else
             field.to_s
           end
@@ -836,12 +836,20 @@ module JSONAPI
         else
           if quoted
             # :nocov:
-            quote("#{table.to_s}_#{field.to_s}")
+            quote_column_name("#{table.to_s}_#{field.to_s}")
             # :nocov:
           else
             "#{table.to_s}_#{field.to_s}"
           end
         end
+      end
+
+      def quote_table_name(table_name)
+        quote(table_name)
+      end
+
+      def quote_column_name(column_name)
+        quote(column_name)
       end
 
       def quote(field)

--- a/lib/jsonapi/active_relation_resource.rb
+++ b/lib/jsonapi/active_relation_resource.rb
@@ -852,7 +852,7 @@ module JSONAPI
       end
 
       def quote_table_name(table_name)
-        if _model_class.try(:connection)
+        if _model_class&.connection
           _model_class.connection.quote_table_name(table_name)
         else
           quote(table_name)
@@ -861,13 +861,14 @@ module JSONAPI
 
       def quote_column_name(column_name)
         return column_name if column_name == "*"
-        if _model_class.try(:connection)
+        if _model_class&.connection
           _model_class.connection.quote_column_name(column_name)
         else
           quote(column_name)
         end
       end
 
+      # fallback quote identifier when database adapter not available
       def quote(field)
         %{"#{field.to_s}"}
       end

--- a/lib/jsonapi/active_relation_resource.rb
+++ b/lib/jsonapi/active_relation_resource.rb
@@ -853,7 +853,7 @@ module JSONAPI
 
       def quote_table_name(table_name)
         if _model_class.try(:connection)
-          _model_class.connection.quote(table_name)
+          _model_class.connection.quote_table_name(table_name)
         else
           quote(table_name)
         end
@@ -861,14 +861,14 @@ module JSONAPI
 
       def quote_column_name(column_name)
         if _model_class.try(:connection)
-          _model_class.connection.quote(column_name)
+          _model_class.connection.quote_column_name(column_name)
         else
           quote(column_name)
         end
       end
 
       def quote(field)
-        "\"#{field.to_s}\""
+        %{"#{field.to_s}"}
       end
 
       def apply_filters(records, filters, options = {})

--- a/lib/jsonapi/active_relation_resource.rb
+++ b/lib/jsonapi/active_relation_resource.rb
@@ -852,11 +852,19 @@ module JSONAPI
       end
 
       def quote_table_name(table_name)
-        quote(table_name)
+        if _model_class.try(:connection)
+          _model_class.connection.quote(table_name)
+        else
+          quote(table_name)
+        end
       end
 
       def quote_column_name(column_name)
-        quote(column_name)
+        if _model_class.try(:connection)
+          _model_class.connection.quote(column_name)
+        else
+          quote(column_name)
+        end
       end
 
       def quote(field)

--- a/lib/jsonapi/active_relation_resource.rb
+++ b/lib/jsonapi/active_relation_resource.rb
@@ -868,6 +868,7 @@ module JSONAPI
       end
 
       def quote(field)
+        raise "zomg, we are using the fallback for #{field}"
         %{"#{field.to_s}"}
       end
 

--- a/lib/jsonapi/active_relation_resource.rb
+++ b/lib/jsonapi/active_relation_resource.rb
@@ -801,10 +801,17 @@ module JSONAPI
       end
 
       def concat_table_field(table, field, quoted = false)
-        if table.blank? || field.to_s.include?('.')
+        if table.blank?
+          split_table, split_field = field.to_s.split('.')
+          if split_table && split_field
+            table = split_table
+            field = split_field
+          end
+        end
+        if table.blank?
           # :nocov:
           if quoted
-            quote(field) # split on '.'?
+            quote_column_name(field)
           else
             field.to_s
           end

--- a/lib/jsonapi/active_relation_resource.rb
+++ b/lib/jsonapi/active_relation_resource.rb
@@ -800,6 +800,10 @@ module JSONAPI
         apply_sort(records, order_options, options)
       end
 
+      def sql_field_with_alias(table, field, quoted = true)
+        Arel.sql("#{concat_table_field(table, field, quoted)} AS #{alias_table_field(table, field, quoted)}")
+      end
+
       def concat_table_field(table, field, quoted = false)
         if table.blank?
           split_table, split_field = field.to_s.split('.')
@@ -825,10 +829,6 @@ module JSONAPI
             # :nocov:
           end
         end
-      end
-
-      def sql_field_with_alias(table, field, quoted = true)
-        Arel.sql("#{concat_table_field(table, field, quoted)} AS #{alias_table_field(table, field, quoted)}")
       end
 
       def alias_table_field(table, field, quoted = false)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -459,6 +459,29 @@ class Minitest::Test
 
   self.fixture_path = "#{Rails.root}/fixtures"
   fixtures :all
+
+  def adapter_name
+    ActiveRecord::Base.connection.adapter_name
+  end
+
+  def db_quote_identifier
+    case adapter_name
+    when 'SQLite', 'PostgreSQL'
+      %{"}
+    when 'MySQL'
+      %{`}
+    else
+      fail ArgumentError, "Unhandled adapter #{adapter_name} in #{__callee__}"
+    end
+  end
+
+  def db_true
+    ActiveRecord::Base.connection.quote(true)
+  end
+
+  def sql_for_compare(sql)
+    sql.tr(db_quote_identifier, %{"})
+  end
 end
 
 class ActiveSupport::TestCase
@@ -501,8 +524,8 @@ class ActionDispatch::IntegrationTest
     end
 
     assert_equal(
-      non_caching_response.pretty_inspect.tr("`", %{"}),
-      json_response.pretty_inspect.tr("`", %{"}),
+      sql_for_compare(non_caching_response.pretty_inspect),
+      sql_for_compare(json_response.pretty_inspect),
       "Cache warmup response must match normal response"
     )
 
@@ -511,8 +534,8 @@ class ActionDispatch::IntegrationTest
     end
 
     assert_equal(
-      non_caching_response.pretty_inspect.tr("`", %{"}),
-      json_response.pretty_inspect.tr("`", %{"}),
+      sql_for_compare(non_caching_response.pretty_inspect),
+      sql_for_compare(json_response.pretty_inspect),
       "Cached response must match normal response"
     )
     assert_equal 0, cached[:total][:misses], "Cached response must not cause any cache misses"
@@ -580,8 +603,8 @@ class ActionController::TestCase
           "Cache (mode: #{mode}) #{phase} response status must match normal response"
         )
         assert_equal(
-          non_caching_response.pretty_inspect.tr("`", %{"}),
-          json_response_sans_all_backtraces.pretty_inspect.tr("`", %{"}),
+          sql_for_compare(non_caching_response.pretty_inspect),
+          sql_for_compare(json_response_sans_all_backtraces.pretty_inspect),
           "Cache (mode: #{mode}) #{phase} response body must match normal response"
         )
         assert_operator(

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -501,8 +501,8 @@ class ActionDispatch::IntegrationTest
     end
 
     assert_equal(
-      non_caching_response.pretty_inspect,
-      json_response.pretty_inspect,
+      non_caching_response.pretty_inspect.tr("`", %{"}),
+      json_response.pretty_inspect.tr("`", %{"}),
       "Cache warmup response must match normal response"
     )
 
@@ -511,8 +511,8 @@ class ActionDispatch::IntegrationTest
     end
 
     assert_equal(
-      non_caching_response.pretty_inspect,
-      json_response.pretty_inspect,
+      non_caching_response.pretty_inspect.tr("`", %{"}),
+      json_response.pretty_inspect.tr("`", %{"}),
       "Cached response must match normal response"
     )
     assert_equal 0, cached[:total][:misses], "Cached response must not cause any cache misses"
@@ -580,8 +580,8 @@ class ActionController::TestCase
           "Cache (mode: #{mode}) #{phase} response status must match normal response"
         )
         assert_equal(
-          non_caching_response.pretty_inspect,
-          json_response_sans_all_backtraces.pretty_inspect,
+          non_caching_response.pretty_inspect.tr("`", %{"}),
+          json_response_sans_all_backtraces.pretty_inspect.tr("`", %{"}),
           "Cache (mode: #{mode}) #{phase} response body must match normal response"
         )
         assert_operator(

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -468,7 +468,7 @@ class Minitest::Test
     case adapter_name
     when 'SQLite', 'PostgreSQL'
       %{"}
-    when 'MySQL'
+    when 'Mysql2'
       %{`}
     else
       fail ArgumentError, "Unhandled adapter #{adapter_name} in #{__callee__}"

--- a/test/unit/active_relation_resource_finder/join_manager_test.rb
+++ b/test/unit/active_relation_resource_finder/join_manager_test.rb
@@ -3,32 +3,12 @@ require 'jsonapi-resources'
 
 class JoinTreeTest < ActiveSupport::TestCase
 
-  def adapter_name
-    ActiveRecord::Base.connection.adapter_name
-  end
-
-  def db_quote_identifier
-    case adapter_name
-      when 'SQLite', 'PostgreSQL'
-        %{"}
-      when 'MySQL'
-        %{`}
-      else
-        fail ArgumentError, "Unhandled adapter #{adapter_name} in #{__callee__}"
-      end
-    end
-  end
-
-  def db_true
-    ActiveRecord::Base.connection.quote(true)
-  end
-
   def test_no_added_joins
     join_manager = JSONAPI::ActiveRelation::JoinManager.new(resource_klass: PostResource)
 
     records = PostResource.records({})
     records = join_manager.join(records, {})
-    assert_equal 'SELECT "posts".* FROM "posts"', records.to_sql.tr(db_quote_identifier, %{"})
+    assert_equal 'SELECT "posts".* FROM "posts"', sql_for_compare(records.to_sql)
 
     assert_hash_equals({alias: 'posts', join_type: :root}, join_manager.source_join_details)
   end
@@ -38,7 +18,7 @@ class JoinTreeTest < ActiveSupport::TestCase
     join_manager = JSONAPI::ActiveRelation::JoinManager.new(resource_klass: PostResource, filters: filters)
     records = PostResource.records({})
     records = join_manager.join(records, {})
-    assert_equal 'SELECT "posts".* FROM "posts" LEFT OUTER JOIN "posts_tags" ON "posts_tags"."post_id" = "posts"."id" LEFT OUTER JOIN "tags" ON "tags"."id" = "posts_tags"."tag_id"', records.to_sql
+    assert_equal 'SELECT "posts".* FROM "posts" LEFT OUTER JOIN "posts_tags" ON "posts_tags"."post_id" = "posts"."id" LEFT OUTER JOIN "tags" ON "tags"."id" = "posts_tags"."tag_id"', sql_for_compare(records.to_sql)
     assert_hash_equals({alias: 'posts', join_type: :root}, join_manager.source_join_details)
     assert_hash_equals({alias: 'tags', join_type: :left}, join_manager.join_details_by_relationship(PostResource._relationship(:tags)))
   end
@@ -49,7 +29,7 @@ class JoinTreeTest < ActiveSupport::TestCase
     records = PostResource.records({})
     records = join_manager.join(records, {})
 
-    assert_equal 'SELECT "posts".* FROM "posts" LEFT OUTER JOIN "posts_tags" ON "posts_tags"."post_id" = "posts"."id" LEFT OUTER JOIN "tags" ON "tags"."id" = "posts_tags"."tag_id"', records.to_sql.tr(db_quote_identifier, %{"})
+    assert_equal 'SELECT "posts".* FROM "posts" LEFT OUTER JOIN "posts_tags" ON "posts_tags"."post_id" = "posts"."id" LEFT OUTER JOIN "tags" ON "tags"."id" = "posts_tags"."tag_id"', sql_for_compare(records.to_sql)
     assert_hash_equals({alias: 'posts', join_type: :root}, join_manager.source_join_details)
     assert_hash_equals({alias: 'tags', join_type: :left}, join_manager.join_details_by_relationship(PostResource._relationship(:tags)))
   end
@@ -60,7 +40,7 @@ class JoinTreeTest < ActiveSupport::TestCase
     join_manager = JSONAPI::ActiveRelation::JoinManager.new(resource_klass: PostResource, sort_criteria: sort_criteria, filters: filters)
     records = PostResource.records({})
     records = join_manager.join(records, {})
-    assert_equal 'SELECT "posts".* FROM "posts" LEFT OUTER JOIN "posts_tags" ON "posts_tags"."post_id" = "posts"."id" LEFT OUTER JOIN "tags" ON "tags"."id" = "posts_tags"."tag_id"', records.to_sql.tr(db_quote_identifier, %{"})
+    assert_equal 'SELECT "posts".* FROM "posts" LEFT OUTER JOIN "posts_tags" ON "posts_tags"."post_id" = "posts"."id" LEFT OUTER JOIN "tags" ON "tags"."id" = "posts_tags"."tag_id"', sql_for_compare(records.to_sql)
     assert_hash_equals({alias: 'posts', join_type: :root}, join_manager.source_join_details)
     assert_hash_equals({alias: 'tags', join_type: :left}, join_manager.join_details_by_relationship(PostResource._relationship(:tags)))
   end
@@ -75,7 +55,7 @@ class JoinTreeTest < ActiveSupport::TestCase
     records = PostResource.records({})
     records = join_manager.join(records, {})
 
-    assert_equal 'SELECT "posts".* FROM "posts" LEFT OUTER JOIN "posts_tags" ON "posts_tags"."post_id" = "posts"."id" LEFT OUTER JOIN "tags" ON "tags"."id" = "posts_tags"."tag_id" LEFT OUTER JOIN "people" ON "people"."id" = "posts"."author_id"', records.to_sql.tr(db_quote_identifier, %{"})
+    assert_equal 'SELECT "posts".* FROM "posts" LEFT OUTER JOIN "posts_tags" ON "posts_tags"."post_id" = "posts"."id" LEFT OUTER JOIN "tags" ON "tags"."id" = "posts_tags"."tag_id" LEFT OUTER JOIN "people" ON "people"."id" = "posts"."author_id"', sql_for_compare(records.to_sql)
     assert_hash_equals({alias: 'posts', join_type: :root}, join_manager.source_join_details)
     assert_hash_equals({alias: 'tags', join_type: :left}, join_manager.join_details_by_relationship(PostResource._relationship(:tags)))
     assert_hash_equals({alias: 'people', join_type: :left}, join_manager.join_details_by_relationship(PostResource._relationship(:author)))
@@ -88,7 +68,7 @@ class JoinTreeTest < ActiveSupport::TestCase
     records = PostResource.records({})
     records = join_manager.join(records, {})
 
-    assert_equal 'SELECT "posts".* FROM "posts" INNER JOIN "comments" ON "comments"."post_id" = "posts"."id"', records.to_sql.tr(db_quote_identifier, %{"})
+    assert_equal 'SELECT "posts".* FROM "posts" INNER JOIN "comments" ON "comments"."post_id" = "posts"."id"', sql_for_compare(records.to_sql)
     assert_hash_equals({alias: 'comments', join_type: :inner}, join_manager.source_join_details)
   end
 
@@ -101,7 +81,7 @@ class JoinTreeTest < ActiveSupport::TestCase
 
     sql = 'SELECT "posts".* FROM "posts" INNER JOIN "comments" ON "comments"."post_id" = "posts"."id" WHERE "comments"."approved" = ' + db_true
 
-    assert_equal sql, records.to_sql.tr(db_quote_identifier, %{"})
+    assert_equal sql, sql_for_compare(records.to_sql)
 
     assert_hash_equals({alias: 'comments', join_type: :inner}, join_manager.source_join_details)
   end
@@ -202,7 +182,7 @@ class JoinTreeTest < ActiveSupport::TestCase
     records = PictureResource.records({})
     records = join_manager.join(records, {})
 
-    # assert_equal 'SELECT "pictures".* FROM "pictures" LEFT OUTER JOIN "products" ON "products"."id" = "pictures"."imageable_id" AND "pictures"."imageable_type" = \'Product\' LEFT OUTER JOIN "documents" ON "documents"."id" = "pictures"."imageable_id" AND "pictures"."imageable_type" = \'Document\'', records.to_sql.tr(db_quote_identifier, %{"})
+    # assert_equal 'SELECT "pictures".* FROM "pictures" LEFT OUTER JOIN "products" ON "products"."id" = "pictures"."imageable_id" AND "pictures"."imageable_type" = \'Product\' LEFT OUTER JOIN "documents" ON "documents"."id" = "pictures"."imageable_id" AND "pictures"."imageable_type" = \'Document\'', sql_for_compare(records.to_sql)
     assert_hash_equals({alias: 'products', join_type: :left}, join_manager.source_join_details('products'))
     assert_hash_equals({alias: 'documents', join_type: :left}, join_manager.source_join_details('documents'))
     assert_hash_equals({alias: 'products', join_type: :left}, join_manager.join_details_by_polymorphic_relationship(PictureResource._relationship(:imageable), 'products'))
@@ -216,7 +196,7 @@ class JoinTreeTest < ActiveSupport::TestCase
     records = PictureResource.records({})
     records = join_manager.join(records, {})
 
-    # assert_equal 'SELECT "pictures".* FROM "pictures" LEFT OUTER JOIN "products" ON "products"."id" = "pictures"."imageable_id" AND "pictures"."imageable_type" = \'Product\' LEFT OUTER JOIN "documents" ON "documents"."id" = "pictures"."imageable_id" AND "pictures"."imageable_type" = \'Document\'', records.to_sql.tr(db_quote_identifier, %{"})
+    # assert_equal 'SELECT "pictures".* FROM "pictures" LEFT OUTER JOIN "products" ON "products"."id" = "pictures"."imageable_id" AND "pictures"."imageable_type" = \'Product\' LEFT OUTER JOIN "documents" ON "documents"."id" = "pictures"."imageable_id" AND "pictures"."imageable_type" = \'Document\'', sql_for_compare(records.to_sql)
     assert_hash_equals({alias: 'pictures', join_type: :root}, join_manager.source_join_details)
     assert_hash_equals({alias: 'products', join_type: :left}, join_manager.join_details_by_polymorphic_relationship(PictureResource._relationship(:imageable), 'products'))
     assert_hash_equals({alias: 'documents', join_type: :left}, join_manager.join_details_by_polymorphic_relationship(PictureResource._relationship(:imageable), 'documents'))


### PR DESCRIPTION
see https://github.com/rails/rails/blob/7-0-stable/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb#L8-L146

Addresses https://github.com/cerebris/jsonapi-resources/issues/1369