### PR TITLE
Add frozen_string_literal magic comment

### DIFF
--- a/lib/jsonapi-resources.rb
+++ b/lib/jsonapi-resources.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'jsonapi/resources/railtie'
 require 'jsonapi/naive_cache'
 require 'jsonapi/compiled_json'

--- a/lib/jsonapi/active_relation_resource.rb
+++ b/lib/jsonapi/active_relation_resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JSONAPI
   class ActiveRelationResource < BasicResource
     root_resource

--- a/lib/jsonapi/acts_as_resource_controller.rb
+++ b/lib/jsonapi/acts_as_resource_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'csv'
 
 module JSONAPI

--- a/lib/jsonapi/basic_resource.rb
+++ b/lib/jsonapi/basic_resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'jsonapi/callbacks'
 require 'jsonapi/configuration'
 

--- a/lib/jsonapi/cached_response_fragment.rb
+++ b/lib/jsonapi/cached_response_fragment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JSONAPI
   class CachedResponseFragment
 

--- a/lib/jsonapi/callbacks.rb
+++ b/lib/jsonapi/callbacks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'active_support/callbacks'
 
 module JSONAPI

--- a/lib/jsonapi/compiled_json.rb
+++ b/lib/jsonapi/compiled_json.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JSONAPI
   class CompiledJson
     def self.compile(h)

--- a/lib/jsonapi/configuration.rb
+++ b/lib/jsonapi/configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'jsonapi/formatter'
 require 'jsonapi/processor'
 require 'concurrent'

--- a/lib/jsonapi/error.rb
+++ b/lib/jsonapi/error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JSONAPI
   class Error
     attr_accessor :title, :detail, :id, :href, :code, :source, :links, :status, :meta

--- a/lib/jsonapi/error_codes.rb
+++ b/lib/jsonapi/error_codes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JSONAPI
   VALIDATION_ERROR = '100'
   INVALID_RESOURCE = '101'

--- a/lib/jsonapi/exceptions.rb
+++ b/lib/jsonapi/exceptions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JSONAPI
   module Exceptions
     class Error < RuntimeError

--- a/lib/jsonapi/formatter.rb
+++ b/lib/jsonapi/formatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JSONAPI
   class Formatter
     class << self

--- a/lib/jsonapi/include_directives.rb
+++ b/lib/jsonapi/include_directives.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JSONAPI
   class IncludeDirectives
     # Construct an IncludeDirectives Hash from an array of dot separated include strings.

--- a/lib/jsonapi/link_builder.rb
+++ b/lib/jsonapi/link_builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JSONAPI
   class LinkBuilder
     attr_reader :base_url,

--- a/lib/jsonapi/mime_types.rb
+++ b/lib/jsonapi/mime_types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json'
 
 module JSONAPI

--- a/lib/jsonapi/naive_cache.rb
+++ b/lib/jsonapi/naive_cache.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JSONAPI
 
   # Cache which memoizes the given block.

--- a/lib/jsonapi/operation.rb
+++ b/lib/jsonapi/operation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JSONAPI
   class Operation
     attr_reader :resource_klass, :operation_type, :options

--- a/lib/jsonapi/operation_result.rb
+++ b/lib/jsonapi/operation_result.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JSONAPI
   class OperationResult
     attr_accessor :code

--- a/lib/jsonapi/paginator.rb
+++ b/lib/jsonapi/paginator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JSONAPI
   class Paginator
     def initialize(_params)

--- a/lib/jsonapi/path.rb
+++ b/lib/jsonapi/path.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JSONAPI
   class Path
     attr_reader :segments, :resource_klass

--- a/lib/jsonapi/path_segment.rb
+++ b/lib/jsonapi/path_segment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JSONAPI
   class PathSegment
     def self.parse(source_resource_klass:, segment_string:, parse_fields: true)

--- a/lib/jsonapi/processor.rb
+++ b/lib/jsonapi/processor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JSONAPI
   class Processor
     include Callbacks

--- a/lib/jsonapi/relationship.rb
+++ b/lib/jsonapi/relationship.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JSONAPI
   class Relationship
     attr_reader :acts_as_set, :foreign_key, :options, :name,

--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JSONAPI
   class Request
     attr_accessor :fields, :include, :filters, :sort_criteria, :errors, :controller_module_path,

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JSONAPI
   class Resource < ActiveRelationResource
     root_resource

--- a/lib/jsonapi/resource_controller.rb
+++ b/lib/jsonapi/resource_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JSONAPI
   class ResourceController < ActionController::Base
     include JSONAPI::ActsAsResourceController

--- a/lib/jsonapi/resource_controller_metal.rb
+++ b/lib/jsonapi/resource_controller_metal.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JSONAPI
   class ResourceControllerMetal < ActionController::Metal
     MODULES = [

--- a/lib/jsonapi/resource_fragment.rb
+++ b/lib/jsonapi/resource_fragment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JSONAPI
 
   # A ResourceFragment holds a ResourceIdentity and associated partial resource data.

--- a/lib/jsonapi/resource_identity.rb
+++ b/lib/jsonapi/resource_identity.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JSONAPI
 
   # ResourceIdentity describes a unique identity of a resource in the system.

--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JSONAPI
   class ResourceSerializer
 

--- a/lib/jsonapi/resource_set.rb
+++ b/lib/jsonapi/resource_set.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JSONAPI
   # Contains a hash of resource types which contain a hash of resources, relationships and primary status keyed by
   # resource id.

--- a/lib/jsonapi/resource_tree.rb
+++ b/lib/jsonapi/resource_tree.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JSONAPI
 
   # A tree structure representing the resource structure of the requested resource(s). This is an intermediate structure

--- a/lib/jsonapi/response_document.rb
+++ b/lib/jsonapi/response_document.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JSONAPI
   class ResponseDocument
     attr_reader :serialized_results

--- a/lib/jsonapi/routing_ext.rb
+++ b/lib/jsonapi/routing_ext.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActionDispatch
   module Routing
     class Mapper


### PR DESCRIPTION
Adopting the almost ubiquitous `frozen_string_literal` magic comment to ensure efficient string storage. I observed that we don't mutate any of the string literals after we have declared them which implies that, in essence, they're already treated as frozen values. Invoking the magic comment is only a clue to the Ruby VM to optimize the strings.

Closes #1407.

### All Submissions:
- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [x] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [x] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [x] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.

### Test Plan:
All existing tests pass.

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions