### PR TITLE
fix: qualify Rails as ::Rails to avoid namespace clashes with other gems

### DIFF
--- a/lib/jsonapi-resources.rb
+++ b/lib/jsonapi-resources.rb
@@ -9,7 +9,7 @@ require 'jsonapi/resource'
 require 'jsonapi/cached_response_fragment'
 require 'jsonapi/response_document'
 require 'jsonapi/acts_as_resource_controller'
-if Rails::VERSION::MAJOR >= 6
+if ::Rails::VERSION::MAJOR >= 6
   ActiveSupport.on_load(:action_controller_base) do
     require 'jsonapi/resource_controller'
   end

--- a/lib/jsonapi/active_relation/adapters/join_left_active_record_adapter.rb
+++ b/lib/jsonapi/active_relation/adapters/join_left_active_record_adapter.rb
@@ -7,7 +7,7 @@ module JSONAPI
         # example Post.joins(:comments).joins_left(comments: :author) will join the comments table twice,
         # once inner and once left in 5.2, but only as inner in earlier versions.
         def joins_left(*columns)
-          if Rails::VERSION::MAJOR >= 6 || (Rails::VERSION::MAJOR >= 5 && ActiveRecord::VERSION::MINOR >= 2)
+          if ::Rails::VERSION::MAJOR >= 6 || (::Rails::VERSION::MAJOR >= 5 && ActiveRecord::VERSION::MINOR >= 2)
             left_joins(columns)
           else
             join_dependency = ActiveRecord::Associations::JoinDependency.new(self, columns, [])

--- a/lib/jsonapi/active_relation_resource.rb
+++ b/lib/jsonapi/active_relation_resource.rb
@@ -772,7 +772,7 @@ module JSONAPI
 
       # Assumes ActiveRecord's counting. Override if you need a different counting method
       def count_records(records)
-        if (Rails::VERSION::MAJOR == 5 && ActiveRecord::VERSION::MINOR >= 1) || Rails::VERSION::MAJOR >= 6
+        if (::Rails::VERSION::MAJOR == 5 && ActiveRecord::VERSION::MINOR >= 1) || ::Rails::VERSION::MAJOR >= 6
           records.count(:all)
         else
           records.count

--- a/lib/jsonapi/acts_as_resource_controller.rb
+++ b/lib/jsonapi/acts_as_resource_controller.rb
@@ -160,7 +160,7 @@ module JSONAPI
     end
 
     def base_url
-      @base_url ||= "#{request.protocol}#{request.host_with_port}#{Rails.application.config.relative_url_root}"
+      @base_url ||= "#{request.protocol}#{request.host_with_port}#{::Rails.application.config.relative_url_root}"
     end
 
     def resource_klass_name
@@ -286,7 +286,7 @@ module JSONAPI
             request.env['action_dispatch.exception'] ||= e
 
             internal_server_error = JSONAPI::Exceptions::InternalServerError.new(e)
-            Rails.logger.error { "Internal Server Error: #{e.message} #{e.backtrace.join("\n")}" }
+            ::Rails.logger.error { "Internal Server Error: #{e.message} #{e.backtrace.join("\n")}" }
             errors = internal_server_error.errors
           end
       end
@@ -298,7 +298,7 @@ module JSONAPI
       begin
         callback.call(error)
       rescue => e
-        Rails.logger.error { "Error in error handling callback: #{e.message} #{e.backtrace.join("\n")}" }
+        ::Rails.logger.error { "Error in error handling callback: #{e.message} #{e.backtrace.join("\n")}" }
         internal_server_error = JSONAPI::Exceptions::InternalServerError.new(e)
         return JSONAPI::ErrorsOperationResult.new(internal_server_error.errors[0].code, internal_server_error.errors)
       end
@@ -324,7 +324,7 @@ module JSONAPI
             if self.respond_to? method
               send(method, error)
             else
-              Rails.logger.warn("#{method} not defined on #{self}, skipping error callback")
+              ::Rails.logger.warn("#{method} not defined on #{self}, skipping error callback")
             end
           end
         end.compact

--- a/lib/jsonapi/configuration.rb
+++ b/lib/jsonapi/configuration.rb
@@ -86,11 +86,11 @@ module JSONAPI
 
       # Whether or not to include exception backtraces in JSONAPI error
       # responses.  Defaults to `false` in anything other than development or test.
-      self.include_backtraces_in_errors = (Rails.env.development? || Rails.env.test?)
+      self.include_backtraces_in_errors = (::Rails.env.development? || ::Rails.env.test?)
 
       # Whether or not to include exception application backtraces in JSONAPI error
       # responses.  Defaults to `false` in anything other than development or test.
-      self.include_application_backtraces_in_errors = (Rails.env.development? || Rails.env.test?)
+      self.include_application_backtraces_in_errors = (::Rails.env.development? || ::Rails.env.test?)
 
       # List of classes that should not be rescued by the operations processor.
       # For example, if you use Pundit for authorization, you might

--- a/lib/jsonapi/exceptions.rb
+++ b/lib/jsonapi/exceptions.rb
@@ -54,7 +54,7 @@ module JSONAPI
         if JSONAPI.configuration.include_application_backtraces_in_errors
           meta ||= Hash.new
           meta[:exception] ||= exception.message
-          meta[:application_backtrace] = exception.backtrace.select{|line| line =~ /#{Rails.root}/}
+          meta[:application_backtrace] = exception.backtrace.select{|line| line =~ /#{::Rails.root}/}
         end
 
         [create_error_object(code: JSONAPI::INTERNAL_SERVER_ERROR,

--- a/lib/jsonapi/resources/railtie.rb
+++ b/lib/jsonapi/resources/railtie.rb
@@ -1,6 +1,6 @@
 module JSONAPI
   module Resources
-    class Railtie < Rails::Railtie
+    class Railtie < ::Rails::Railtie
       rake_tasks do
         load 'tasks/check_upgrade.rake'
       end

--- a/lib/tasks/check_upgrade.rake
+++ b/lib/tasks/check_upgrade.rake
@@ -5,7 +5,7 @@ namespace :jsonapi do
   namespace :resources do
     desc 'Checks application for orphaned overrides'
     task :check_upgrade => :environment do
-      Rails.application.eager_load!
+      ::Rails.application.eager_load!
 
       resource_klasses = ObjectSpace.each_object(Class).select { |klass| klass < JSONAPI::Resource}
 


### PR DESCRIPTION

### All Submissions:

- [ ] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [x] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [x] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [x] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [x] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [x] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:
I was unable to get the bug template to run and could not find instructions on how to do so.

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions