### PR TITLE
restricting default railties version to be < 7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ when 'master'
   gem 'railties', { git: 'https://github.com/rails/rails.git' }
   gem 'arel', { git: 'https://github.com/rails/arel.git' }
 when 'default'
-  gem 'railties', '>= 6.0'
+  gem 'railties', '>= 6.0', '< 7'
 else
   gem 'railties', "~> #{version}"
 end


### PR DESCRIPTION
Resolves https://github.com/cerebris/jsonapi-resources/issues/1415

### All Submissions:

- [X ] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ X] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ X] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ X] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [X ] I've added/updated tests for this change.

### Bug fixes and Changes to Core Features:

- [X ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ X] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions