### PR TITLE
fix: more reliable check of module is included

### DIFF
--- a/lib/tasks/check_upgrade.rake
+++ b/lib/tasks/check_upgrade.rake
@@ -9,7 +9,7 @@ namespace :jsonapi do
     task :check_upgrade => :environment do
       Rails.application.eager_load!
 
-      resource_klasses = ObjectSpace.each_object(Class).select { |klass| klass.include?(JSONAPI::ResourceCommon)}
+      resource_klasses = ObjectSpace.each_object(Class).select { |klass| klass.included_modules.include?(JSONAPI::ResourceCommon)}
 
       puts "Checking #{resource_klasses.count} resources"
 


### PR DESCRIPTION
target is https://github.com/cerebris/jsonapi-resources/pull/1411

handle gems like GraphQL which override `include?`

```
rake aborted!
ArgumentError: wrong number of arguments (given 1, expected 3)
gems/graphql-2.0.13/lib/graphql/schema/directive.rb:58:in `include?'
```


### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [x] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions