### PR TITLE
fix: more flexible polymorphic types lookup

### DIFF
--- a/lib/jsonapi/resource_common.rb
+++ b/lib/jsonapi/resource_common.rb
@@ -1020,17 +1020,7 @@ module JSONAPI
       end
 
       def _polymorphic_types
-        @poly_hash ||= {}.tap do |hash|
-          ObjectSpace.each_object do |klass|
-            next unless Module === klass
-            if klass < ActiveRecord::Base
-              klass.reflect_on_all_associations(:has_many).select{|r| r.options[:as] }.each do |reflection|
-                (hash[reflection.options[:as]] ||= []) << klass.name.underscore
-              end
-            end
-          end
-        end
-        @poly_hash[_polymorphic_name.to_sym]
+        JSONAPI::Relationship.polymorphic_types(_polymorphic_name.to_sym)
       end
 
       def _polymorphic_resource_klasses

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -429,6 +429,18 @@ ActiveRecord::Schema.define do
     t.integer :version
     t.timestamps null: false
   end
+  create_table :contact_media do |t|
+    t.string :name
+    t.references :party, polymorphic: true, index: true
+  end
+
+  create_table :individuals do |t|
+    t.string :name
+  end
+
+  create_table :organizations do |t|
+    t.string :name
+  end
 end
 
 ### MODELS
@@ -622,6 +634,24 @@ class Fact < ActiveRecord::Base
 end
 
 class Like < ActiveRecord::Base
+end
+
+class TestApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+end
+
+class ContactMedium < TestApplicationRecord
+  belongs_to :party, polymorphic: true, inverse_of: :contact_media
+  belongs_to :individual, -> { where( contact_media: { party_type: 'Individual' } ).eager_load( :contact_media ) }, foreign_key: 'party_id'
+  belongs_to :organization, -> { where( contact_media: { party_type: 'Organization' } ).eager_load( :contact_media ) }, foreign_key: 'party_id'
+end
+
+class Individual < TestApplicationRecord
+  has_many :contact_media, as: :party
+end
+
+class Organization < TestApplicationRecord
+  has_many :contact_media, as: :party
 end
 
 class Breed
@@ -1225,6 +1255,18 @@ class IndicatorsController < JSONAPI::ResourceController
 end
 
 class RobotsController < JSONAPI::ResourceController
+end
+
+class IndividualsController < BaseController
+end
+
+class OrganizationsController < BaseController
+end
+
+class ContactMediaController < BaseController
+end
+
+class PartiesController < BaseController
 end
 
 ### RESOURCES
@@ -2683,6 +2725,24 @@ class RobotResource < ::JSONAPI::Resource
   sort :lower_name, apply: ->(records, direction, _context) do
     records.order("LOWER(robots.name) #{direction}")
   end
+end
+
+class ContactMediumResource < JSONAPI::Resource
+  attribute :name
+  has_one :party, polymorphic: true
+end
+
+class IndividualResource < JSONAPI::Resource
+  attribute :name
+  has_many :contact_media
+end
+
+class OrganizationResource < JSONAPI::Resource
+  attribute :name
+  has_many :contact_media
+end
+
+class PartyResource < JSONAPI::Resource
 end
 
 ### PORO Data - don't do this in a production app

--- a/test/integration/requests/polymorphic_test.rb
+++ b/test/integration/requests/polymorphic_test.rb
@@ -1,0 +1,83 @@
+require File.expand_path('../../../test_helper', __FILE__)
+
+# copied from https://github.com/cerebris/jsonapi-resources/blob/e60dc7dd2c7fdc85834163a7e706a10a8940a62b/test/integration/requests/polymorphic_test.rb
+# https://github.com/cerebris/jsonapi-resources/compare/bf4_fix_polymorphic_relations_lookup?expand=1
+class PolymorphicTest < ActionDispatch::IntegrationTest
+
+  def json_api_headers
+    {'Accept' => JSONAPI::MEDIA_TYPE, 'CONTENT_TYPE' => JSONAPI::MEDIA_TYPE}
+  end
+
+  def test_find_party_via_contact_medium
+    individual = Individual.create(name: 'test')
+    contact_medium = ContactMedium.create(party: individual, name: 'test contact medium')
+    fetched_party = contact_medium.party
+    assert_same individual, fetched_party, "Expect an individual to have been found via contact medium model's relationship 'party'"
+  end
+
+  def test_get_individual
+    individual = Individual.create(name: 'test')
+    ContactMedium.create(party: individual, name: 'test contact medium')
+    get "/individuals/#{individual.id}"
+    assert_jsonapi_response 200
+  end
+
+  def test_get_party_via_contact_medium
+    individual = Individual.create(name: 'test')
+    contact_medium = ContactMedium.create(party: individual, name: 'test contact medium')
+    get "/contact_media/#{contact_medium.id}/party"
+    assert_jsonapi_response 200, "Expect an individual to have been found via contact medium resource's relationship 'party'"
+  end
+end
+
+# copied from https://github.com/cerebris/jsonapi-resources/pull/1349/files
+# require File.expand_path('../test_helper', __FILE__)
+#
+# Replace this with the code necessary to make your test fail.
+# class BugTest < Minitest::Test
+#   include Rack::Test::Methods
+#
+#   def json_api_headers
+#     {'Accept' => JSONAPI::MEDIA_TYPE, 'CONTENT_TYPE' => JSONAPI::MEDIA_TYPE}
+#   end
+#
+#   def teardown
+#     Individual.delete_all
+#     ContactMedium.delete_all
+#   end
+#
+#   def test_find_party_via_contact_medium
+#     individual = Individual.create(name: 'test')
+#     contact_medium = ContactMedium.create(party: individual, name: 'test contact medium')
+#     fetched_party = contact_medium.party
+#     assert_same individual, fetched_party, "Expect an individual to have been found via contact medium model's relationship 'party'"
+#   end
+#
+#   def test_get_individual
+#     individual = Individual.create(name: 'test')
+#     ContactMedium.create(party: individual, name: 'test contact medium')
+#     get "/individuals/#{individual.id}"
+#     assert_last_response_status 200
+#   end
+#
+#   def test_get_party_via_contact_medium
+#     individual = Individual.create(name: 'test')
+#     contact_medium = ContactMedium.create(party: individual, name: 'test contact medium')
+#     get "/contact_media/#{contact_medium.id}/party"
+#     assert_last_response_status 200, "Expect an individual to have been found via contact medium resource's relationship 'party'"
+#   end
+#
+#   private
+#
+#   def assert_last_response_status(status, failure_reason=nil)
+#     if last_response.status != status
+#       json_response = JSON.parse(last_response.body) rescue last_response.body
+#       pp json_response
+#     end
+#     assert_equal status, last_response.status, failure_reason
+#   end
+#
+#   def app
+#     Rails.application
+#   end
+# end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -414,6 +414,9 @@ TestApp.routes.draw do
   jsonapi_resources :widgets, only: [:index]
   jsonapi_resources :indicators, only: [:index]
   jsonapi_resources :robots, only: [:index]
+  jsonapi_resources :contact_media
+  jsonapi_resources :individuals
+  jsonapi_resources :organizations
 
   mount MyEngine::Engine => "/boomshaka", as: :my_engine
   mount ApiV2Engine::Engine => "/api_v2", as: :api_v2_engine


### PR DESCRIPTION
Includes:
- fix: more flexible polymorphic types lookup
- refactor: lookup polymorphic types only once

### All Submissions:

- [ ] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions