### PR TITLE
fix: allow multiple resource relation retrieval methods

### DIFF
--- a/lib/jsonapi-resources.rb
+++ b/lib/jsonapi-resources.rb
@@ -3,6 +3,7 @@
 require 'jsonapi/resources/railtie'
 require 'jsonapi/naive_cache'
 require 'jsonapi/compiled_json'
+require 'jsonapi/relation_retrieval'
 require 'jsonapi/active_relation_retrieval'
 require 'jsonapi/active_relation_retrieval_v09'
 require 'jsonapi/active_relation_retrieval_v10'

--- a/lib/jsonapi/active_relation_retrieval.rb
+++ b/lib/jsonapi/active_relation_retrieval.rb
@@ -2,6 +2,8 @@
 
 module JSONAPI
   module ActiveRelationRetrieval
+    include ::JSONAPI::RelationRetrieval
+
     def find_related_ids(relationship, options = {})
       self.class.find_related_fragments(self, relationship, options).keys.collect { |rid| rid.id }
     end

--- a/lib/jsonapi/active_relation_retrieval_v09.rb
+++ b/lib/jsonapi/active_relation_retrieval_v09.rb
@@ -2,6 +2,8 @@
 
 module JSONAPI
   module ActiveRelationRetrievalV09
+    include ::JSONAPI::RelationRetrieval
+
     def find_related_ids(relationship, options = {})
       self.class.find_related_fragments(self.fragment, relationship, options).keys.collect { |rid| rid.id }
     end

--- a/lib/jsonapi/active_relation_retrieval_v10.rb
+++ b/lib/jsonapi/active_relation_retrieval_v10.rb
@@ -2,6 +2,8 @@
 
 module JSONAPI
   module ActiveRelationRetrievalV10
+    include ::JSONAPI::RelationRetrieval
+
     def find_related_ids(relationship, options = {})
       self.class.find_related_fragments(self, relationship, options).keys.collect { |rid| rid.id }
     end

--- a/lib/jsonapi/relation_retrieval.rb
+++ b/lib/jsonapi/relation_retrieval.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module JSONAPI
+  module RelationRetrieval
+  end
+end
+

--- a/lib/jsonapi/resource_common.rb
+++ b/lib/jsonapi/resource_common.rb
@@ -440,8 +440,12 @@ module JSONAPI
         raise "Unable to find resource_retrieval_strategy #{module_name}" unless resource_retrieval_module
 
         if included_modules.include?(::JSONAPI::RelationRetrieval)
-          warn "Resource retrieval strategy #{module_name} already loaded for #{self.name}"
-          return
+          if _resource_retrieval_strategy_loaded.nil? || module_name == _resource_retrieval_strategy_loaded
+            warn "Resource retrieval strategy #{module_name} already loaded for #{self.name}"
+            return
+          else
+            fail ArgumentError.new("Resource retrieval strategy #{_resource_retrieval_strategy_loaded} already loaded for #{self.name}. Cannot load #{module_name}")
+          end
         end
 
         class_eval do

--- a/lib/jsonapi/resource_common.rb
+++ b/lib/jsonapi/resource_common.rb
@@ -431,19 +431,20 @@ module JSONAPI
 
     module ClassMethods
       def resource_retrieval_strategy(module_name = JSONAPI.configuration.default_resource_retrieval_strategy)
-        if @_resource_retrieval_strategy_loaded
-          warn "Resource retrieval strategy #{@_resource_retrieval_strategy_loaded} already loaded for #{self.name}"
-          return
-        end
-
         module_name = module_name.to_s
 
         return if module_name.blank? || module_name == 'self' || module_name == 'none'
 
-        class_eval do
-          resource_retrieval_module = module_name.safe_constantize
-          raise "Unable to find resource_retrieval_strategy #{module_name}" unless resource_retrieval_module
+        resource_retrieval_module = module_name.safe_constantize
 
+        raise "Unable to find resource_retrieval_strategy #{module_name}" unless resource_retrieval_module
+
+        if included_modules.include?(::JSONAPI::RelationRetrieval)
+          warn "Resource retrieval strategy #{module_name} already loaded for #{self.name}"
+          return
+        end
+
+        class_eval do
           include resource_retrieval_module
           extend "#{module_name}::ClassMethods".safe_constantize
           @_resource_retrieval_strategy_loaded = module_name

--- a/test/unit/resource/multilple_active_relation_resource_retrieval_test.rb
+++ b/test/unit/resource/multilple_active_relation_resource_retrieval_test.rb
@@ -1,0 +1,78 @@
+require File.expand_path('../../../test_helper', __FILE__)
+
+module VX
+end
+
+class MultipleActiveRelationResourceTest < ActiveSupport::TestCase
+  def setup
+  end
+
+  def teardown
+    teardown_test_constant(::VX, :BaseResource)
+    teardown_test_constant(::VX, :DuplicateSubBaseResource)
+    teardown_test_constant(::VX, :InvalidSubBaseResource)
+    teardown_test_constant(::VX, :ValidCustomBaseResource)
+  end
+
+  def teardown_test_constant(namespace, constant_name)
+    return unless namespace.const_defined?(constant_name)
+    namespace.send(:remove_const, constant_name)
+  rescue NameError
+  end
+
+  def test_correct_resource_retrieval_strategy
+    expected = 'JSONAPI::ActiveRelationRetrieval'
+    default = JSONAPI.configuration.default_resource_retrieval_strategy
+    assert_equal expected, default
+    assert_nil JSONAPI::Resource._resource_retrieval_strategy_loaded
+
+    expected = 'JSONAPI::ActiveRelationRetrieval'
+    assert_silent do
+      ::VX.module_eval <<~MODULE
+        class BaseResource < JSONAPI::Resource
+          abstract
+        end
+      MODULE
+    end
+    assert_equal expected, VX::BaseResource._resource_retrieval_strategy_loaded
+
+    strategy = 'JSONAPI::ActiveRelationRetrieval'
+    expected = 'JSONAPI::ActiveRelationRetrieval'
+    assert_output nil, "Resource retrieval strategy #{expected} already loaded for VX::DuplicateSubBaseResource\n" do
+      ::VX.module_eval <<~MODULE
+        class DuplicateSubBaseResource < JSONAPI::Resource
+          resource_retrieval_strategy '#{strategy}'
+          abstract
+        end
+      MODULE
+    end
+    assert_equal expected, VX::DuplicateSubBaseResource._resource_retrieval_strategy_loaded
+
+    strategy = 'JSONAPI::ActiveRelationRetrievalV10'
+    expected = "Resource retrieval strategy #{default} already loaded for VX::InvalidSubBaseResource. Cannot load #{strategy}"
+    ex = assert_raises ArgumentError do
+      ::VX.module_eval <<~MODULE
+        class InvalidSubBaseResource < JSONAPI::Resource
+          resource_retrieval_strategy '#{strategy}'
+          abstract
+        end
+      MODULE
+    end
+    assert_equal expected, ex.message
+
+    strategy = 'JSONAPI::ActiveRelationRetrievalV10'
+    expected = 'JSONAPI::ActiveRelationRetrievalV10'
+    assert_silent do
+      ::VX.module_eval <<~MODULE
+        class ValidCustomBaseResource
+          include JSONAPI::ResourceCommon
+          root_resource
+          abstract
+          immutable
+          resource_retrieval_strategy '#{strategy}'
+        end
+      MODULE
+    end
+    assert_equal expected, VX::ValidCustomBaseResource._resource_retrieval_strategy_loaded
+  end
+end


### PR DESCRIPTION
This PR  was named from my experience that it wasn't letting me have a JSONAPI::Resource with the default retrieval method and also create another resource using the mixin with a different retrieval method.

While working on it, I realized it was possible to apply multiple different retrieval methods. If it's the same, it warns you, which I think is fine, but the new thing is that if it's different, it raises, since I can't imagine anything good could come from intentionally saying 'using v10' but it's already 'v09' and not knowing that 'v09' wasn't included

I saw some slightly different behavior in the JSONAPI::Resource vs. all manual includes so I'll try that in our app and see if it works by 100% avoiding JSONAPI::Resource


------------


- [ ] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions