### PR TITLE
Make SortedSet for identity arrays optional

### DIFF
--- a/jsonapi-resources.gemspec
+++ b/jsonapi-resources.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'concurrent-ruby-ext'
   spec.add_development_dependency 'database_cleaner'
   spec.add_development_dependency 'hashie'
+  spec.add_development_dependency 'sorted_set'
   spec.add_dependency 'activerecord', '>= 5.1'
   spec.add_dependency 'railties', '>= 5.1'
   spec.add_dependency 'concurrent-ruby'

--- a/jsonapi-resources.gemspec
+++ b/jsonapi-resources.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activerecord', '>= 5.1'
   spec.add_dependency 'railties', '>= 5.1'
   spec.add_dependency 'concurrent-ruby'
+  spec.add_dependency 'sorted_set'
 end

--- a/jsonapi-resources.gemspec
+++ b/jsonapi-resources.gemspec
@@ -32,5 +32,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activerecord', '>= 5.1'
   spec.add_dependency 'railties', '>= 5.1'
   spec.add_dependency 'concurrent-ruby'
-  spec.add_dependency 'sorted_set'
 end

--- a/lib/jsonapi/active_relation_retrieval.rb
+++ b/lib/jsonapi/active_relation_retrieval.rb
@@ -271,7 +271,7 @@ module JSONAPI
           source_resource_klasses.each do |resource_klass|
             inverse_direct_relationship = _relationship(resource_klass._type.to_s.singularize)
 
-            fragments.merge!(resource_klass.find_related_fragments_from_inverse([source_fragment], inverse_direct_relationship, options, true))
+            fragments.merge!(resource_klass.find_related_fragments_from_inverse([source_fragment], inverse_direct_relationship, options, false))
           end
           fragments
         else
@@ -317,9 +317,14 @@ module JSONAPI
         linkage_relationships = to_one_relationships_for_linkage(include_directives[:include_related])
 
         sort_criteria = []
-        options[:sort_criteria].try(:each) do |sort|
-          field = sort[:field].to_s == 'id' ? _primary_key : sort[:field]
-          sort_criteria << { field: field, direction: sort[:direction] }
+
+        # Do not sort the includes. Key off connect_source_identity to indicate wether this is a related resource
+        # primary step vs an include step
+        unless connect_source_identity
+          options[:sort_criteria].try(:each) do |sort|
+            field = sort[:field].to_s == 'id' ? _primary_key : sort[:field]
+            sort_criteria << { field: field, direction: sort[:direction] }
+          end
         end
 
         join_manager = ActiveRelation::JoinManager.new(resource_klass: self,

--- a/lib/jsonapi/active_relation_retrieval.rb
+++ b/lib/jsonapi/active_relation_retrieval.rb
@@ -318,9 +318,11 @@ module JSONAPI
 
         sort_criteria = []
 
-        # Do not sort the includes. Key off connect_source_identity to indicate wether this is a related resource
-        # primary step vs an include step
-        unless connect_source_identity
+        # Do not sort the related_fragments. This can be keyed off `connect_source_identity` to indicate whether this
+        # is a related resource primary step vs. an include step.
+        sort_related_fragments = !connect_source_identity
+
+        if sort_related_fragments
           options[:sort_criteria].try(:each) do |sort|
             field = sort[:field].to_s == 'id' ? _primary_key : sort[:field]
             sort_criteria << { field: field, direction: sort[:direction] }

--- a/lib/jsonapi/configuration.rb
+++ b/lib/jsonapi/configuration.rb
@@ -43,7 +43,8 @@ module JSONAPI
                 :resource_cache_usage_report_function,
                 :default_exclude_links,
                 :default_resource_retrieval_strategy,
-                :use_related_resource_records_for_joins
+                :use_related_resource_records_for_joins,
+                :sort_related_identities_by_primary_key
 
     def initialize
       #:underscored_key, :camelized_key, :dasherized_key, or custom
@@ -182,6 +183,10 @@ module JSONAPI
       # This setting allows included resources to account for permission scopes. It can be overridden explicitly per
       # relationship. Furthermore, specifying a `relation_name` on a relationship will cause this setting to be ignored.
       self.use_related_resource_records_for_joins = true
+
+      # Collect the include keys into a SortedSet. This carries a small performance cost in the rails app but produces
+      # consistent and more human navigable result sets.
+      self.sort_related_identities_by_primary_key = false
     end
 
     def cache_formatters=(bool)
@@ -327,6 +332,8 @@ module JSONAPI
     attr_writer :default_resource_retrieval_strategy
 
     attr_writer :use_related_resource_records_for_joins
+
+    attr_writer :sort_related_identities_by_primary_key
   end
 
   class << self

--- a/lib/jsonapi/configuration.rb
+++ b/lib/jsonapi/configuration.rb
@@ -186,8 +186,9 @@ module JSONAPI
 
       # Collect the include keys into a Set or a SortedSet. SortedSet carries a small performance cost in the rails app
       # but produces consistent and more human navigable result sets.
-      # Note: If using SortedSet be sure to add `sorted_set` to your Gemfile and require 'sorted_set'`
+      # To use SortedSet be sure to add `sorted_set` to your Gemfile and the following two lines to your JR initializer:
       # require 'sorted_set'
+      # config.related_identities_set = SortedSet
       self.related_identities_set = Set
     end
 

--- a/lib/jsonapi/configuration.rb
+++ b/lib/jsonapi/configuration.rb
@@ -44,7 +44,7 @@ module JSONAPI
                 :default_exclude_links,
                 :default_resource_retrieval_strategy,
                 :use_related_resource_records_for_joins,
-                :sort_related_identities_by_primary_key
+                :related_identities_set
 
     def initialize
       #:underscored_key, :camelized_key, :dasherized_key, or custom
@@ -184,9 +184,11 @@ module JSONAPI
       # relationship. Furthermore, specifying a `relation_name` on a relationship will cause this setting to be ignored.
       self.use_related_resource_records_for_joins = true
 
-      # Collect the include keys into a SortedSet. This carries a small performance cost in the rails app but produces
-      # consistent and more human navigable result sets.
-      self.sort_related_identities_by_primary_key = false
+      # Collect the include keys into a Set or a SortedSet. SortedSet carries a small performance cost in the rails app
+      # but produces consistent and more human navigable result sets.
+      # Note: If using SortedSet be sure to add `sorted_set` to your Gemfile and require 'sorted_set'`
+      # require 'sorted_set'
+      self.related_identities_set = Set
     end
 
     def cache_formatters=(bool)
@@ -333,7 +335,7 @@ module JSONAPI
 
     attr_writer :use_related_resource_records_for_joins
 
-    attr_writer :sort_related_identities_by_primary_key
+    attr_writer :related_identities_set
   end
 
   class << self

--- a/lib/jsonapi/resource_fragment.rb
+++ b/lib/jsonapi/resource_fragment.rb
@@ -25,7 +25,7 @@ module JSONAPI
       @primary = primary
 
       @related = {}
-      @related_from = Set.new
+      @related_from = JSONAPI.configuration.sort_related_identities_by_primary_key ? SortedSet.new : Set.new
     end
 
     def initialize_related(relationship_name)

--- a/lib/jsonapi/resource_fragment.rb
+++ b/lib/jsonapi/resource_fragment.rb
@@ -25,7 +25,7 @@ module JSONAPI
       @primary = primary
 
       @related = {}
-      @related_from = JSONAPI.configuration.sort_related_identities_by_primary_key ? SortedSet.new : Set.new
+      @related_from = JSONAPI.configuration.related_identities_set.new
     end
 
     def initialize_related(relationship_name)

--- a/lib/jsonapi/resource_set.rb
+++ b/lib/jsonapi/resource_set.rb
@@ -180,7 +180,7 @@ module JSONAPI
         flattened_tree[resource_klass][id][:resource] ||= fragment.resource if fragment.resource
 
         fragment.related.try(:each_pair) do |relationship_name, related_rids|
-          flattened_tree[resource_klass][id][:relationships][relationship_name] ||= JSONAPI.configuration.sort_related_identities_by_primary_key ? SortedSet.new : Set.new
+          flattened_tree[resource_klass][id][:relationships][relationship_name] ||= JSONAPI.configuration.related_identities_set.new
           flattened_tree[resource_klass][id][:relationships][relationship_name].merge(related_rids)
         end
       end

--- a/lib/jsonapi/resource_set.rb
+++ b/lib/jsonapi/resource_set.rb
@@ -180,7 +180,7 @@ module JSONAPI
         flattened_tree[resource_klass][id][:resource] ||= fragment.resource if fragment.resource
 
         fragment.related.try(:each_pair) do |relationship_name, related_rids|
-          flattened_tree[resource_klass][id][:relationships][relationship_name] ||= Set.new
+          flattened_tree[resource_klass][id][:relationships][relationship_name] ||= JSONAPI.configuration.sort_related_identities_by_primary_key ? SortedSet.new : Set.new
           flattened_tree[resource_klass][id][:relationships][relationship_name].merge(related_rids)
         end
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -66,6 +66,8 @@ class TestApp < ::Rails::Application
   end
 
   config.hosts << "www.example.com"
+
+  config.sort_related_identities_by_primary_key = true
 end
 
 require 'rails/test_help'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -39,6 +39,7 @@ I18n.enforce_available_locales = false
 
 JSONAPI.configure do |config|
   config.json_key_format = :camelized_key
+  config.sort_related_identities_by_primary_key = true
 end
 
 ActiveSupport::Deprecation.silenced = true

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -39,7 +39,9 @@ I18n.enforce_available_locales = false
 
 JSONAPI.configure do |config|
   config.json_key_format = :camelized_key
-  config.sort_related_identities_by_primary_key = true
+
+  require 'sorted_set'
+  config.related_identities_set = SortedSet
 end
 
 ActiveSupport::Deprecation.silenced = true
@@ -67,8 +69,6 @@ class TestApp < ::Rails::Application
   end
 
   config.hosts << "www.example.com"
-
-  config.sort_related_identities_by_primary_key = true
 end
 
 require 'rails/test_help'


### PR DESCRIPTION
Restores SortedSet as an option.

Removes default sorting for includes. Because of how included resources are collected the database sort doesn't actually produce properly sorted results, but does slow the queries.

Fixes `connect_source_identity` option when  calling `find_related_fragments_from_inverse` for polymorphic relationship routes


### All Submissions:

- [ ] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions