### PR TITLE
Store the resource_klass and id in an array for efficiency

### DIFF
--- a/lib/jsonapi/resource_identity.rb
+++ b/lib/jsonapi/resource_identity.rb
@@ -13,11 +13,17 @@ module JSONAPI
   # rid = ResourceIdentity.new(PostResource, 12)
   #
   class ResourceIdentity
-    attr_reader :resource_klass, :id
-
+    # Store the identity parts as an array to avoid allocating a new array for the hash method to work on
     def initialize(resource_klass, id)
-      @resource_klass = resource_klass
-      @id = id
+      @identity_parts = [resource_klass, id]
+    end
+
+    def resource_klass
+      @identity_parts[0]
+    end
+
+    def id
+      @identity_parts[1]
     end
 
     def ==(other)
@@ -27,11 +33,11 @@ module JSONAPI
     end
 
     def eql?(other)
-      other.is_a?(ResourceIdentity) && other.resource_klass == @resource_klass && other.id == @id
+      hash == other.hash
     end
 
     def hash
-      [@resource_klass, @id].hash
+      @identity_parts.hash
     end
 
     def <=>(other_identity)


### PR DESCRIPTION
Removes the need to allocate a new array for every comparison.

Found a large number of allocations in the `hash` method when profiling the code. This removes about 35K allocations from a result set that contained about 3500 resources (1000 primary with 2500 includes). Not surprisingly that doesn't actually make a statistically significant performance issue for small requests like the one tested, but every little bit helps.

Also changes the `eql?` to use the `hash` method 

### All Submissions:

- [ ] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions