### PR TITLE
resource identity comparable

### DIFF
--- a/jsonapi-resources.gemspec
+++ b/jsonapi-resources.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'database_cleaner'
   spec.add_development_dependency 'hashie'
   spec.add_development_dependency 'sorted_set'
+  spec.add_development_dependency 'memory_profiler'
   spec.add_dependency 'activerecord', '>= 5.1'
   spec.add_dependency 'railties', '>= 5.1'
   spec.add_dependency 'concurrent-ruby'

--- a/lib/jsonapi/resource_identity.rb
+++ b/lib/jsonapi/resource_identity.rb
@@ -13,6 +13,8 @@ module JSONAPI
   # rid = ResourceIdentity.new(PostResource, 12)
   #
   class ResourceIdentity
+    include Comparable
+
     # Store the identity parts as an array to avoid allocating a new array for the hash method to work on
     def initialize(resource_klass, id)
       @identity_parts = [resource_klass, id]
@@ -41,7 +43,16 @@ module JSONAPI
     end
 
     def <=>(other_identity)
-      self.id <=> other_identity.id
+      return nil unless other_identity.is_a?(ResourceIdentity)
+
+      case self.resource_klass.name <=> other_identity.resource_klass.name
+      when -1
+        -1
+      when 1
+        1
+      else
+        self.id <=> other_identity.id
+      end
     end
 
     # Creates a string representation of the identifier.

--- a/test/unit/resource/resource_identity_test.rb
+++ b/test/unit/resource/resource_identity_test.rb
@@ -1,0 +1,58 @@
+require File.expand_path('../../../test_helper', __FILE__)
+require 'memory_profiler'
+
+class ResourceIdentity < ActiveSupport::TestCase
+
+  def test_can_generate_a_consistent_hash_for_comparison
+    rid = JSONAPI::ResourceIdentity.new(PostResource, 12)
+    assert_equal(rid.hash, [PostResource, 12].hash)
+  end
+
+  def test_equality
+    rid = JSONAPI::ResourceIdentity.new(PostResource, 12)
+    rid2 = JSONAPI::ResourceIdentity.new(PostResource, 12)
+    assert_equal(rid, rid2) # uses == internally
+    assert rid.eql?(rid2)
+  end
+
+  def test_inequality
+    rid = JSONAPI::ResourceIdentity.new(PostResource, 12)
+    rid2 = JSONAPI::ResourceIdentity.new(PostResource, 13)
+    refute_equal(rid, rid2)
+  end
+
+  def test_sorting_by_resource_class_name
+    rid = JSONAPI::ResourceIdentity.new(CommentResource, 13)
+    rid2 = JSONAPI::ResourceIdentity.new(PostResource, 13)
+    rid3 = JSONAPI::ResourceIdentity.new(SectionResource, 13)
+    assert_equal([rid2, rid3, rid].sort, [rid, rid2, rid3])
+  end
+
+  def test_sorting_by_id_secondarily
+    rid = JSONAPI::ResourceIdentity.new(PostResource, 12)
+    rid2 = JSONAPI::ResourceIdentity.new(PostResource, 13)
+    rid3 = JSONAPI::ResourceIdentity.new(PostResource, 14)
+
+    assert_equal([rid2, rid3, rid].sort, [rid, rid2, rid3])
+  end
+
+  def test_to_s
+    rid = JSONAPI::ResourceIdentity.new(PostResource, 12)
+    assert_equal(rid.to_s, 'PostResource:12')
+  end
+
+  def test_comparisons_return_nil_for_non_resource_identity
+    rid = JSONAPI::ResourceIdentity.new(PostResource, 13)
+    rid2 = "PostResource:13"
+    assert_nil(rid <=> rid2)
+  end
+
+  def test_comparisons_allocate_no_new_memory
+    rid = JSONAPI::ResourceIdentity.new(PostResource, 13)
+    rid2 = JSONAPI::ResourceIdentity.new(PostResource, 13)
+    allocation_report = MemoryProfiler.report do
+      rid == rid2
+    end
+    assert_equal 0, allocation_report.total_allocated
+  end
+end


### PR DESCRIPTION
Fixes #1429 

add tests for ResourceIdentity, including that comparison does not allocate memory


### All Submissions:

- [ ] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions