### PR TITLE
V0 11 dev performance

### DIFF
--- a/lib/jsonapi/link_builder.rb
+++ b/lib/jsonapi/link_builder.rb
@@ -49,8 +49,8 @@ module JSONAPI
 
     def relationships_related_link(source, relationship, query_params = {})
       if relationship._routed
-        url = "#{ self_link(source) }/#{ route_for_relationship(relationship) }"
-        url = "#{ url }?#{ query_params.to_query }" if query_params.present?
+        url = +"#{ self_link(source) }/#{ route_for_relationship(relationship) }"
+        url << "?#{ query_params.to_query }" if query_params.present?
         url
       else
         if JSONAPI.configuration.warn_on_missing_routes && !relationship._warned_missing_route
@@ -129,16 +129,12 @@ module JSONAPI
       @_resources_path[source_klass] ||= formatted_module_path_from_class(source_klass) + format_route(source_klass._type.to_s)
     end
 
-    def resource_path(source)
-      if source.class.singleton?
-        resources_path(source.class)
-      else
-        "#{resources_path(source.class)}/#{source.id}"
-      end
-    end
-
     def resource_url(source)
-      "#{ base_url }#{ engine_mount_point }#{ resource_path(source) }"
+      if source.class.singleton?
+        "#{ base_url }#{ engine_mount_point }#{ resources_path(source.class) }"
+      else
+        "#{ base_url }#{ engine_mount_point }#{resources_path(source.class)}/#{source.id}"
+      end
     end
 
     def route_for_relationship(relationship)

--- a/lib/jsonapi/resource_common.rb
+++ b/lib/jsonapi/resource_common.rb
@@ -39,7 +39,7 @@ module JSONAPI
     end
 
     def id
-      _model.public_send(self.class._primary_key)
+      @id ||= _model.public_send(self.class._primary_key)
     end
 
     def identity

--- a/lib/jsonapi/resource_common.rb
+++ b/lib/jsonapi/resource_common.rb
@@ -1181,18 +1181,6 @@ module JSONAPI
         end
       end
 
-      def _setup_relationship(klass, *attrs)
-        _clear_fields_cache
-
-        options = attrs.extract_options!
-        options[:parent_resource] = self
-
-        relationship_name = attrs[0].to_sym
-        check_duplicate_relationship_name(relationship_name)
-
-        define_relationship_methods(relationship_name.to_sym, klass, options)
-      end
-
       # ResourceBuilder methods
       def define_relationship_methods(relationship_name, relationship_klass, options)
         relationship = register_relationship(

--- a/lib/jsonapi/resource_common.rb
+++ b/lib/jsonapi/resource_common.rb
@@ -1132,11 +1132,11 @@ module JSONAPI
       end
 
       def module_path
-        if name == 'JSONAPI::Resource'
-          ''
-        else
-          name =~ /::[^:]+\Z/ ? ($`.freeze.gsub('::', '/') + '/').underscore : ''
-        end
+        @module_path ||= if name == 'JSONAPI::Resource'
+                           ''
+                         else
+                           name =~ /::[^:]+\Z/ ? ($`.freeze.gsub('::', '/') + '/').underscore : ''
+                         end
       end
 
       def default_sort

--- a/lib/jsonapi/resource_common.rb
+++ b/lib/jsonapi/resource_common.rb
@@ -927,11 +927,11 @@ module JSONAPI
       end
 
       def _updatable_attributes
-        _attributes.map { |key, options| key unless options[:readonly] }.compact
+        _attributes.map { |key, options| key unless options[:readonly] }.delete_if {|v| v.nil? }
       end
 
       def _updatable_relationships
-        @_relationships.map { |key, relationship| key unless relationship.readonly? }.compact
+        @_relationships.map { |key, relationship| key unless relationship.readonly? }.delete_if {|v| v.nil? }
       end
 
       def _relationship(type)

--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -262,7 +262,7 @@ module JSONAPI
       if !links.key?('self') && !source.class.exclude_link?(:self)
         links['self'] = link_builder.self_link(source)
       end
-      links.compact
+      links.delete_if {|k,v| v.nil? }
     end
 
     def custom_links_hash(source)
@@ -340,7 +340,7 @@ module JSONAPI
       links = {}
       links['self'] = self_link(source, relationship) unless relationship.exclude_link?(:self)
       links['related'] = related_link(source, relationship) unless relationship.exclude_link?(:related)
-      links.compact
+      links.delete_if {|k,v| v.nil? }
     end
 
     def to_many_linkage(rids)

--- a/lib/jsonapi/resource_tree.rb
+++ b/lib/jsonapi/resource_tree.rb
@@ -68,13 +68,13 @@ module JSONAPI
     private
 
     def init_included_relationships(fragment, include_related)
-      include_related && include_related.each_key do |relationship_name|
+      include_related&.each_key do |relationship_name|
         fragment.initialize_related(relationship_name)
       end
     end
 
     def load_included(resource_klass, source_resource_tree, include_related, options)
-       include_related.try(:each_key) do |key|
+       include_related&.each_key do |key|
         relationship = resource_klass._relationship(key)
         relationship_name = relationship.name.to_sym
 

--- a/lib/jsonapi/resource_tree.rb
+++ b/lib/jsonapi/resource_tree.rb
@@ -159,7 +159,6 @@ module JSONAPI
       @related_resource_trees ||= {}
 
       @parent_relationship = parent_relationship
-      @parent_relationship_name = parent_relationship.name.to_sym
       @source_resource_tree = source_resource_tree
     end
 

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -4028,8 +4028,8 @@ end
 
 class Api::V7::ClientsControllerTest < ActionController::TestCase
   def test_get_namespaced_model_not_matching_resource_using_model_hint
-    Api::V7::ClientResource._clear_cached_resource_types_for_model
-    Api::V7::ClientResource._clear_cached_resource_klasses_for_type
+    Api::V7::ClientResource._clear_model_to_resource_type_cache
+    Api::V7::ClientResource._clear_resource_type_to_klass_cache
     assert_cacheable_get :index
     assert_response :success
     assert_equal 'clients', json_response['data'][0]['type']
@@ -4039,8 +4039,8 @@ class Api::V7::ClientsControllerTest < ActionController::TestCase
 
   def test_get_namespaced_model_not_matching_resource_not_using_model_hint
     Api::V7::ClientResource._model_hints.delete('api/v7/customer')
-    Api::V7::ClientResource._clear_cached_resource_types_for_model
-    Api::V7::ClientResource._clear_cached_resource_klasses_for_type
+    Api::V7::ClientResource._clear_model_to_resource_type_cache
+    Api::V7::ClientResource._clear_resource_type_to_klass_cache
     assert_cacheable_get :index
     assert_response :success
     assert_equal 'customers', json_response['data'][0]['type']

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -4028,6 +4028,8 @@ end
 
 class Api::V7::ClientsControllerTest < ActionController::TestCase
   def test_get_namespaced_model_not_matching_resource_using_model_hint
+    Api::V7::ClientResource._clear_cached_resource_types_for_model
+    Api::V7::ClientResource._clear_cached_resource_klasses_for_type
     assert_cacheable_get :index
     assert_response :success
     assert_equal 'clients', json_response['data'][0]['type']
@@ -4037,6 +4039,8 @@ class Api::V7::ClientsControllerTest < ActionController::TestCase
 
   def test_get_namespaced_model_not_matching_resource_not_using_model_hint
     Api::V7::ClientResource._model_hints.delete('api/v7/customer')
+    Api::V7::ClientResource._clear_cached_resource_types_for_model
+    Api::V7::ClientResource._clear_cached_resource_klasses_for_type
     assert_cacheable_get :index
     assert_response :success
     assert_equal 'customers', json_response['data'][0]['type']


### PR DESCRIPTION
Implements some caching of frequently computed values. Significantly reduces allocations and run times for larger requests.



### All Submissions:

- [ ] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions