### PR TITLE
fix: format model polymorphic type from resource object type

### DIFF
--- a/lib/jsonapi/acts_as_resource_controller.rb
+++ b/lib/jsonapi/acts_as_resource_controller.rb
@@ -164,7 +164,7 @@ module JSONAPI
     end
 
     def resource_klass_name
-      @resource_klass_name ||= "#{self.class.name.underscore.sub(/_controller$/, '').singularize}_resource".camelize
+      @resource_klass_name ||= "#{self.class.name.underscore.sub(/_controller$/, '').classify}Resource"
     end
 
     def verify_content_type_header

--- a/lib/jsonapi/link_builder.rb
+++ b/lib/jsonapi/link_builder.rb
@@ -92,7 +92,7 @@ module JSONAPI
 
       begin
         unless scopes.empty?
-          "#{ scopes.first.to_s.camelize }::Engine".safe_constantize
+          "#{ scopes.first.to_s.classify }::Engine".safe_constantize
         end
 
           # :nocov:

--- a/lib/jsonapi/relationship.rb
+++ b/lib/jsonapi/relationship.rb
@@ -155,7 +155,7 @@ module JSONAPI
 
       def initialize(name, options = {})
         super
-        @class_name = options.fetch(:class_name, name.to_s.camelize)
+        @class_name = options.fetch(:class_name, name.to_s.classify)
         @foreign_key ||= "#{name}_id".to_sym
         @foreign_key_on = options.fetch(:foreign_key_on, :self)
         # if parent_resource
@@ -231,7 +231,7 @@ module JSONAPI
 
       def initialize(name, options = {})
         super
-        @class_name = options.fetch(:class_name, name.to_s.camelize.singularize)
+        @class_name = options.fetch(:class_name, name.to_s.classify)
         @foreign_key ||= "#{name.to_s.singularize}_ids".to_sym
         @reflect = options.fetch(:reflect, true) == true
         # if parent_resource

--- a/lib/jsonapi/resource_common.rb
+++ b/lib/jsonapi/resource_common.rb
@@ -578,6 +578,10 @@ module JSONAPI
         end
       end
 
+      def polymorphic_type_for(model_name)
+        model_name&.to_s&.classify
+      end
+
       attr_accessor :_attributes,
                     :_relationships,
                     :_type,
@@ -1199,12 +1203,9 @@ module JSONAPI
 
       def define_foreign_key_setter(relationship)
         if relationship.polymorphic?
-          define_on_resource "format_model_polymorphic_type" do |resource_object_type|
-            resource_object_type&.to_s&.classify
-          end
           define_on_resource "#{relationship.foreign_key}=" do |v|
             _model.public_send("#{relationship.foreign_key}=", v[:id])
-            _model.public_send("#{relationship.polymorphic_type}=", format_model_polymorphic_type(v[:type]))
+            _model.public_send("#{relationship.polymorphic_type}=", self.class.polymorphic_type_for(v[:type]))
           end
         else
           define_on_resource "#{relationship.foreign_key}=" do |value|

--- a/lib/jsonapi/resource_common.rb
+++ b/lib/jsonapi/resource_common.rb
@@ -1199,9 +1199,12 @@ module JSONAPI
 
       def define_foreign_key_setter(relationship)
         if relationship.polymorphic?
+          define_on_resource "format_model_polymorphic_type" do |resource_object_type|
+            resource_object_type&.to_s&.classify
+          end
           define_on_resource "#{relationship.foreign_key}=" do |v|
             _model.public_send("#{relationship.foreign_key}=", v[:id])
-            _model.public_send("#{relationship.polymorphic_type}=", v[:type]&.to_s&.classify)
+            _model.public_send("#{relationship.polymorphic_type}=", format_model_polymorphic_type(v[:type]))
           end
         else
           define_on_resource "#{relationship.foreign_key}=" do |value|

--- a/lib/jsonapi/resource_common.rb
+++ b/lib/jsonapi/resource_common.rb
@@ -1200,16 +1200,12 @@ module JSONAPI
       def define_foreign_key_setter(relationship)
         if relationship.polymorphic?
           define_on_resource "#{relationship.foreign_key}=" do |v|
-            _model.assign_attributes(
-              relationship.foreign_key => v[:id],
-              relationship.polymorphic_type => v[:type]&.to_s&.classify
-            )
+            _model.public_send("#{relationship.foreign_key}=", v[:id])
+            _model.public_send("#{relationship.polymorphic_type}=", v[:type]&.to_s&.classify)
           end
         else
           define_on_resource "#{relationship.foreign_key}=" do |value|
-            _model.assign_attributes(
-              relationship.foreign_key => value
-            )
+            _model.public_send("#{relationship.foreign_key}=", value)
           end
         end
         relationship.foreign_key

--- a/lib/jsonapi/resource_common.rb
+++ b/lib/jsonapi/resource_common.rb
@@ -561,7 +561,7 @@ module JSONAPI
       end
 
       def _resource_name_from_type(type)
-        "#{type.to_s.underscore.singularize}_resource".camelize
+        "#{type.to_s.classify}Resource"
       end
 
       def resource_type_for(model)

--- a/lib/jsonapi/resource_common.rb
+++ b/lib/jsonapi/resource_common.rb
@@ -1200,12 +1200,16 @@ module JSONAPI
       def define_foreign_key_setter(relationship)
         if relationship.polymorphic?
           define_on_resource "#{relationship.foreign_key}=" do |v|
-            _model.method("#{relationship.foreign_key}=").call(v[:id])
-            _model.public_send("#{relationship.polymorphic_type}=", v[:type])
+            _model.assign_attributes(
+              relationship.foreign_key => v[:id],
+              relationship.polymorphic_type => v[:type]&.to_s&.classify
+            )
           end
         else
           define_on_resource "#{relationship.foreign_key}=" do |value|
-            _model.method("#{relationship.foreign_key}=").call(value)
+            _model.assign_attributes(
+              relationship.foreign_key => value
+            )
           end
         end
         relationship.foreign_key

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -275,6 +275,7 @@ ActiveRecord::Schema.define do
     t.string :drive_layout
     t.string :serial_number
     t.integer :person_id
+    t.references :imageable, polymorphic: true, index: true
     t.timestamps null: false
   end
 
@@ -734,6 +735,9 @@ end
 
 class Vehicle < ActiveRecord::Base
   belongs_to :person
+  belongs_to :imageable, polymorphic: true
+  # belongs_to :document, -> { where( pictures: { imageable_type: 'Document' } ) }, foreign_key: 'imageable_id'
+  # belongs_to :product, -> { where( pictures: { imageable_type: 'Product' } ) }, foreign_key: 'imageable_id'
 end
 
 class Car < Vehicle
@@ -743,13 +747,13 @@ class Boat < Vehicle
 end
 
 class Document < ActiveRecord::Base
-  has_many :pictures, as: :imageable
+  has_many :pictures, as: :imageable # polymorphic
   belongs_to :author, class_name: 'Person', foreign_key: 'author_id'
   has_one :file_properties, as: :fileable
 end
 
 class Product < ActiveRecord::Base
-  has_many :pictures, as: :imageable
+  has_many :pictures, as: :imageable # polymorphic
   belongs_to :designer, class_name: 'Person', foreign_key: 'designer_id'
   has_one :file_properties, as: :fileable
 end
@@ -1336,6 +1340,7 @@ class VehicleResource < JSONAPI::Resource
   immutable
 
   has_one :person
+  has_one :imageable, polymorphic: true
   attributes :make, :model, :serial_number
 end
 
@@ -1915,6 +1920,8 @@ module Api
     class SectionResource < SectionResource; end
     class TagResource < TagResource; end
     class CommentResource < CommentResource; end
+    class DocumentResource < DocumentResource; end
+    class ProductResource < ProductResource; end
     class VehicleResource < VehicleResource; end
     class CarResource < CarResource; end
     class BoatResource < BoatResource; end

--- a/test/integration/requests/request_test.rb
+++ b/test/integration/requests/request_test.rb
@@ -391,7 +391,7 @@ class RequestTest < ActionDispatch::IntegrationTest
 
     assert_jsonapi_response 201
 
-    body = JSON.parse(response.body)
+    body = response.parsed_body
     car = Vehicle.find(body.dig("data", "id"))
 
     assert_equal "Car", car.type


### PR DESCRIPTION
In our app which is currently on the latest 0.9 we have a test
failing on the 0-11-dev branch (which was also failing on 0-10)

which posts the JSON body

```json
{
  "data": {
    "type": "broker-memberships",
    "relationships": {
      "organization": {
        "data": {
          "type": "brokers",
          "id": "1"
        }
      },
      "user": {
        "data": {
          "type": "users",
          "id": "2"
        }
      }
    },
    "attributes": {
      "external-employee-id": "123"
    }
  },
}
```

to `v1/broker-memberships`

BrokerMembership is an STI ActiveRecord model
below Membership like below.

```ruby
class Membership < ApplicationRecord
  belongs_to :organization, optional: false, polymorphic: true
  belongs_to :user, optional: false
end
class BrokerMembership < Membership
  validates :organization_type, inclusion: {in: ["Broker"], message: "must be Broker"}
end
class User < ApplicationRecord
end
class Broker < ApplicationRecord
end
```

our BrokerMembership resource looks like

```ruby
module V1
  class MembershipResource < BaseResource

    has_one :organization,
      polymorphic: true,
      always_include_linkage_data: true,
      eager_load_on_include: false,
      create_implicit_polymorphic_type_relationships: false

    has_one :user,
      always_include_linkage_data: true
  end
end
```

In `_replace_fields` you can see the parsed `field_data` is

```ruby
{
  :attributes=>{
    :external_employee_id=>"123"
  },
  :to_one=>{
    :organization=>{:id=>1, :type=>:brokers},
    :user=>2
  },
  :to_many=>{
  }
}
```

And in the call to `_replace_polymorphic_to_one_link` (as defined in
JSONAPI::ResourceCommon)

```ruby
def _replace_polymorphic_to_one_link(relationship_type, key_value, key_type, _options)
  # relationship_type #=> "organization"
  relationship = self.class._relationship(relationship_type.to_sym)

  # self.organization_id = { type:  :brokers, id: 1 }
  send("#{relationship.foreign_key}=", {type: key_type, id: key_value})
  @save_needed = true

  :completed
end
```

calls the method defined by JSONAPI::ResourceCommon.define_on_resource like

```ruby
def define_foreign_key_setter(relationship)
  if relationship.polymorphic?
    define_on_resource "#{relationship.foreign_key}=" do |v|
      _model.method("#{relationship.foreign_key}=").call(v[:id])
      _model.public_send("#{relationship.polymorphic_type}=", v[:type])
    end
```

which practially speaking calls

```ruby
_model.organization_id = 1
_model.organization_type = :brokers
```

This latter behavior causes a failure since the 'organization_type' should be 'Broker' and not ':brokers'.

I'm not sure if this should be addressed in the definition of `define_on_resource` (by making it lookup the polymorphic type)
or in the `JSONAPI::Request(Parser).parse_to_one_relationship` (by removing the unformat and calling classify) or elsewhere.


### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [x] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [x] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [x] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [x] I've included an explanation of what the changes do and why I'd like you to include them.
- [x] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [x] Maintains compliance with JSON:API
- [x] Adequate test coverage exists to prevent regressions