### PR TITLE
chore: address deprecations

### DIFF
--- a/lib/jsonapi/acts_as_resource_controller.rb
+++ b/lib/jsonapi/acts_as_resource_controller.rb
@@ -63,7 +63,7 @@ module JSONAPI
 
     def get_related_resource
       # :nocov:
-    ActiveSupport::Deprecation.warn "In #{self.class.name} you exposed a `get_related_resource`"\
+      JSONAPI.configuration.deprecate "In #{self.class.name} you exposed a `get_related_resource`"\
                                       " action. Please use `show_related_resource` instead."
       show_related_resource
       # :nocov:
@@ -71,7 +71,7 @@ module JSONAPI
 
     def get_related_resources
       # :nocov:
-      ActiveSupport::Deprecation.warn "In #{self.class.name} you exposed a `get_related_resources`"\
+      JSONAPI.configuration.deprecate "In #{self.class.name} you exposed a `get_related_resources`"\
                                       " action. Please use `index_related_resources` instead."
       index_related_resources
       # :nocov:

--- a/lib/jsonapi/configuration.rb
+++ b/lib/jsonapi/configuration.rb
@@ -256,8 +256,16 @@ module JSONAPI
         @exception_class_allowlist.flatten.any? { |k| e.class.ancestors.map(&:to_s).include?(k.to_s) }
     end
 
+    def deprecate(msg)
+      if defined?(ActiveSupport.deprecator)
+        ActiveSupport.deprecator.warn(msg)
+      else
+        ActiveSupport::Deprecation.warn(msg)
+      end
+    end
+
     def default_processor_klass=(default_processor_klass)
-      ActiveSupport::Deprecation.warn('`default_processor_klass` has been replaced by `default_processor_klass_name`.')
+      deprecate('`default_processor_klass` has been replaced by `default_processor_klass_name`.')
       @default_processor_klass = default_processor_klass
     end
 
@@ -271,7 +279,7 @@ module JSONAPI
     end
 
     def allow_include=(allow_include)
-      ActiveSupport::Deprecation.warn('`allow_include` has been replaced by `default_allow_include_to_one` and `default_allow_include_to_many` options.')
+      deprecate('`allow_include` has been replaced by `default_allow_include_to_one` and `default_allow_include_to_many` options.')
       @default_allow_include_to_one = allow_include
       @default_allow_include_to_many = allow_include
     end

--- a/lib/jsonapi/relationship.rb
+++ b/lib/jsonapi/relationship.rb
@@ -21,7 +21,7 @@ module JSONAPI
       @polymorphic = options.fetch(:polymorphic, false) == true
       @polymorphic_types = options[:polymorphic_types]
       if options[:polymorphic_relations]
-        ActiveSupport::Deprecation.warn('Use polymorphic_types instead of polymorphic_relations')
+        JSONAPI.configuration.deprecate('Use polymorphic_types instead of polymorphic_relations')
         @polymorphic_types ||= options[:polymorphic_relations]
       end
 

--- a/lib/jsonapi/resource_common.rb
+++ b/lib/jsonapi/resource_common.rb
@@ -626,7 +626,7 @@ module JSONAPI
         check_reserved_attribute_name(attr)
 
         if (attr == :id) && (options[:format].nil?)
-          ActiveSupport::Deprecation.warn('Id without format is no longer supported. Please remove ids from attributes, or specify a format.')
+          JSONAPI.configuration.deprecate('Id without format is no longer supported. Please remove ids from attributes, or specify a format.')
         end
 
         check_duplicate_attribute_name(attr) if options[:format].nil?
@@ -688,7 +688,7 @@ module JSONAPI
       end
 
       def belongs_to(*attrs)
-        ActiveSupport::Deprecation.warn "In #{name} you exposed a `has_one` relationship "\
+        JSONAPI.configuration.deprecate "In #{name} you exposed a `has_one` relationship "\
                                       " using the `belongs_to` class method. We think `has_one`" \
                                       " is more appropriate. If you know what you're doing," \
                                       " and don't want to see this warning again, override the" \

--- a/test/integration/requests/request_test.rb
+++ b/test/integration/requests/request_test.rb
@@ -1371,7 +1371,7 @@ class RequestTest < ActionDispatch::IntegrationTest
   end
 
   def test_deprecated_include_message
-    ActiveSupport::Deprecation.silenced = false
+    silence_deprecations! false
     original_config = JSONAPI.configuration.dup
     _out, err = capture_io do
       eval <<-CODE
@@ -1381,7 +1381,7 @@ class RequestTest < ActionDispatch::IntegrationTest
     assert_match(/DEPRECATION WARNING: `allow_include` has been replaced by `default_allow_include_to_one` and `default_allow_include_to_many` options./, err)
   ensure
     JSONAPI.configuration = original_config
-    ActiveSupport::Deprecation.silenced = true
+    silence_deprecations! true
   end
 
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -44,8 +44,6 @@ JSONAPI.configure do |config|
   config.related_identities_set = SortedSet
 end
 
-ActiveSupport::Deprecation.silenced = true
-
 puts "Testing With RAILS VERSION #{Rails.version}"
 
 class TestApp < ::Rails::Application
@@ -69,6 +67,14 @@ class TestApp < ::Rails::Application
   end
 
   config.hosts << "www.example.com"
+end
+
+def silence_deprecations!(bool = true)
+  if Rails.application.respond_to?(:deprecators)
+    Rails.application.deprecators.silenced = bool
+  else
+    ActiveSupport::Deprecation.silenced = bool
+  end
 end
 
 require 'rails/test_help'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -70,7 +70,7 @@ class TestApp < ::Rails::Application
 end
 
 def silence_deprecations!(bool = true)
-  if Rails.application.respond_to?(:deprecators)
+  if defined?(Rails.application) && Rails.application.respond_to?(:deprecators)
     Rails.application.deprecators.silenced = bool
   else
     ActiveSupport::Deprecation.silenced = bool

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -463,7 +463,11 @@ class Minitest::Test
     true
   end
 
-  self.fixture_path = "#{Rails.root}/fixtures"
+  if respond_to?(:fixture_paths=)
+    self.fixture_paths |= ["#{Rails.root}/fixtures"]
+  else
+    self.fixture_path = "#{Rails.root}/fixtures"
+  end
   fixtures :all
 
   def adapter_name
@@ -515,7 +519,11 @@ class Minitest::Test
 end
 
 class ActiveSupport::TestCase
-  self.fixture_path = "#{Rails.root}/fixtures"
+  if respond_to?(:fixture_paths=)
+    self.fixture_paths |= ["#{Rails.root}/fixtures"]
+  else
+    self.fixture_path = "#{Rails.root}/fixtures"
+  end
   fixtures :all
   setup do
     @routes = TestApp.routes
@@ -523,7 +531,11 @@ class ActiveSupport::TestCase
 end
 
 class ActionDispatch::IntegrationTest
-  self.fixture_path = "#{Rails.root}/fixtures"
+  if respond_to?(:fixture_paths=)
+    self.fixture_paths |= ["#{Rails.root}/fixtures"]
+  else
+    self.fixture_path = "#{Rails.root}/fixtures"
+  end
   fixtures :all
 
   def assert_jsonapi_response(expected_status, msg = nil)

--- a/test/unit/resource/resource_test.rb
+++ b/test/unit/resource/resource_test.rb
@@ -399,8 +399,7 @@ class ResourceTest < ActiveSupport::TestCase
   end
 
   def test_id_attr_deprecation
-
-    ActiveSupport::Deprecation.silenced = false
+    silence_deprecations! false
     _out, err = capture_io do
       eval <<-CODE
         class ProblemResource < JSONAPI::Resource
@@ -410,7 +409,7 @@ class ResourceTest < ActiveSupport::TestCase
     end
     assert_match /DEPRECATION WARNING: Id without format is no longer supported. Please remove ids from attributes, or specify a format./, err
   ensure
-    ActiveSupport::Deprecation.silenced = true
+    silence_deprecations! true
   end
 
   def test_id_attr_with_format


### PR DESCRIPTION
### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [x] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [x] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions