### PR TITLE
feat: teach JR in tests to parse the response

### DIFF
--- a/lib/jsonapi/resources/railtie.rb
+++ b/lib/jsonapi/resources/railtie.rb
@@ -6,6 +6,19 @@ module JSONAPI
       rake_tasks do
         load 'tasks/check_upgrade.rake'
       end
+
+
+      initializer "jsonapi_resources.testing", after: :initialize do
+        next unless Rails.env.test?
+        # Make response.parsed_body work
+        ActionDispatch::IntegrationTest.register_encoder :api_json,
+          param_encoder: ->(params) {
+            params
+          },
+          response_parser: ->(body) {
+            JSONAPI::MimeTypes.parser.call(body)
+          }
+      end
     end
   end
 end

--- a/test/helpers/functional_helpers.rb
+++ b/test/helpers/functional_helpers.rb
@@ -53,7 +53,7 @@ module Helpers
     # end
     #
     def json_response
-      JSON.parse(@response.body)
+      @response.parsed_body
     end
   end
 end

--- a/test/integration/requests/request_test.rb
+++ b/test/integration/requests/request_test.rb
@@ -73,13 +73,13 @@ class RequestTest < ActionDispatch::IntegrationTest
       'Accept' => JSONAPI::MEDIA_TYPE
     }
     assert_jsonapi_response 201
-    json_body = JSON.parse(response.body)
+    json_body = response.parsed_body
     session_id = json_body["data"]["id"]
 
     # Get what we just created
     get "/sessions/#{session_id}?include=responses"
     assert_jsonapi_response 200
-    json_body = JSON.parse(response.body)
+    json_body = response.parsed_body
 
     assert(json_body.is_a?(Object));
     assert(json_body["included"].is_a?(Array));
@@ -87,7 +87,7 @@ class RequestTest < ActionDispatch::IntegrationTest
 
     get "/sessions/#{session_id}?include=responses,responses.paragraph"
     assert_jsonapi_response 200
-    json_body = JSON.parse(response.body)
+    json_body = response.parsed_body
 
     assert_equal("single_textbox", json_body["included"][0]["attributes"]["response_type"]["single_textbox"]);
 

--- a/test/integration/requests/request_test.rb
+++ b/test/integration/requests/request_test.rb
@@ -348,7 +348,7 @@ class RequestTest < ActionDispatch::IntegrationTest
 
     assert_jsonapi_response 201
 
-    body = JSON.parse(response.body)
+    body = response.parsed_body
     person = Person.find(body.dig("data", "id"))
 
     assert_equal "Reo", person.name
@@ -649,7 +649,7 @@ class RequestTest < ActionDispatch::IntegrationTest
 
     assert_jsonapi_response 200
 
-    body = JSON.parse(response.body)
+    body = response.parsed_body
     person = Person.find(body.dig("data", "id"))
 
     assert_equal "Reo", person.name


### PR DESCRIPTION
Gems like rspec-openapi rely on response.parsed_body
to work. It also simplifies JR tests a bit, so that's nice, too.


### All Submissions:

- [ ] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions