### PR TITLE
Polymorphic types override per relationship

### DIFF
--- a/lib/jsonapi/active_relation_retrieval.rb
+++ b/lib/jsonapi/active_relation_retrieval.rb
@@ -262,7 +262,7 @@ module JSONAPI
       def find_related_fragments(source_fragment, relationship, options = {})
         if relationship.polymorphic? # && relationship.foreign_key_on == :self
           source_resource_klasses = if relationship.foreign_key_on == :self
-                                      relationship.class.polymorphic_types(relationship.name).collect do |polymorphic_type|
+                                      relationship.polymorphic_types.collect do |polymorphic_type|
                                         resource_klass_for(polymorphic_type)
                                       end
                                     else
@@ -284,7 +284,7 @@ module JSONAPI
       def find_included_fragments(source_fragments, relationship, options)
         if relationship.polymorphic? # && relationship.foreign_key_on == :self
           source_resource_klasses = if relationship.foreign_key_on == :self
-                                      relationship.class.polymorphic_types(relationship.name).collect do |polymorphic_type|
+                                      relationship.polymorphic_types.collect do |polymorphic_type|
                                         resource_klass_for(polymorphic_type)
                                       end
                                     else

--- a/lib/jsonapi/configuration.rb
+++ b/lib/jsonapi/configuration.rb
@@ -13,6 +13,7 @@ module JSONAPI
                 :warn_on_route_setup_issues,
                 :warn_on_missing_routes,
                 :warn_on_performance_issues,
+                :warn_on_eager_loading_disabled,
                 :default_allow_include_to_one,
                 :default_allow_include_to_many,
                 :allow_sort,
@@ -67,6 +68,7 @@ module JSONAPI
       self.warn_on_route_setup_issues = true
       self.warn_on_missing_routes = true
       self.warn_on_performance_issues = true
+      self.warn_on_eager_loading_disabled = true
 
       # :none, :offset, :paged, or a custom paginator name
       self.default_paginator = :none
@@ -325,6 +327,8 @@ module JSONAPI
     attr_writer :warn_on_missing_routes
 
     attr_writer :warn_on_performance_issues
+
+    attr_writer :warn_on_eager_loading_disabled
 
     attr_writer :use_relationship_reflection
 

--- a/lib/jsonapi/resources/railtie.rb
+++ b/lib/jsonapi/resources/railtie.rb
@@ -19,8 +19,12 @@ module JSONAPI
           }
       end
 
-      initializer "jsonapi_resources.initialize", after: :initialize do
-        JSONAPI::Utils::PolymorphicTypesLookup.polymorphic_types_lookup_clear!
+      config.before_initialize do
+        if !Rails.application.config.eager_load && ::JSONAPI::configuration.warn_on_eager_loading_disabled
+          warn 'WARNING: jsonapi-resources may not load polymorphic types when Rails `eager_load` is disabled. ' \
+                 'Polymorphic types may be set per relationship . This warning may be disable in the configuration ' \
+                 'by setting `warn_on_eager_loading_disabled` to false.'
+        end
       end
     end
   end


### PR DESCRIPTION
Allow relationship to set the polymorphic types

Warn when eager loading is disabled, which results in not being able to detect the types.


### All Submissions:

- [ ] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions