### PR TITLE
Fix issue with relationship sorts due to missing join_manager

### DIFF
--- a/lib/jsonapi/active_relation_retrieval_v09.rb
+++ b/lib/jsonapi/active_relation_retrieval_v09.rb
@@ -107,7 +107,12 @@ module JSONAPI
                                                        filters: filters,
                                                        sort_criteria: sort_criteria)
 
-        options[:_relation_helper_options] = { join_manager: join_manager, sort_fields: [] }
+        options[:_relation_helper_options] = {
+          context: context,
+          join_manager: join_manager,
+          sort_fields: []
+        }
+
         include_directives = options[:include_directives]
 
         records = records(options)
@@ -116,7 +121,7 @@ module JSONAPI
 
         records = filter_records(records, filters, options)
 
-        records = sort_records(records, order_options, context)
+        records = sort_records(records, order_options, options)
 
         records = apply_pagination(records, options[:paginator], order_options)
 


### PR DESCRIPTION
Fix issue with relationship sorts due to missing join_manager.


### All Submissions:

- [ ] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions