### PR TITLE
fix: add railtie to clear caches when code reloads

### DIFF
--- a/lib/jsonapi/resources/railtie.rb
+++ b/lib/jsonapi/resources/railtie.rb
@@ -26,6 +26,10 @@ module JSONAPI
                  'by setting `warn_on_eager_loading_disabled` to false.'
         end
       end
+      config.to_prepare do
+        ::JSONAPI::Resource._clear_resource_type_to_klass_cache
+        ::JSONAPI::Resource._clear_model_to_resource_type_cache
+      end
     end
   end
 end


### PR DESCRIPTION
fixes #1439 

This adds a railtie hook to clean up the `JSONAPI::Resource` caches when code reloads so that we don't have stale references to classes lying around.
I'm not sure how to test this one in a test suite, but there's a reproduction script in #1439 that passes with this.

### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [x] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist. https://github.com/cerebris/jsonapi-resources/issues/1439
- [x] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [x] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### Bug fixes and Changes to Core Features:

- [x] I've included an explanation of what the changes do and why I'd like you to include them.
- [x] I've provided test(s) that fails without the change. (see script in #1439, happy to incorporate into CI if you have ideas on how to do that)

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions