### PR TITLE
Fix include_optional_linkage_data with joins

### DIFF
--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -1059,6 +1059,8 @@ module Api
   module V3
     class PostsController < JSONAPI::ResourceController
     end
+    class MoonsController < JSONAPI::ResourceController
+    end
   end
 
   module V4
@@ -2042,6 +2044,15 @@ module Api
   module V3
     class PostResource < PostResource; end
     class PreferencesResource < PreferencesResource; end
+    class PlanetResource < JSONAPI::Resource
+    end
+    class MoonResource < JSONAPI::Resource
+      has_one :planet, always_include_optional_linkage_data: true
+
+      def self.records(options = {})
+        Moon.joins(:planet).merge(Planet.where(name: 'Satern')) # sic
+      end
+    end
   end
 end
 

--- a/test/integration/requests/request_test.rb
+++ b/test/integration/requests/request_test.rb
@@ -1855,4 +1855,10 @@ class RequestTest < ActionDispatch::IntegrationTest
     JSONAPI.configuration = original_config
     $test_user = $original_test_user
   end
+
+  def test_include_optional_linkage_data_with_join
+    get "/api/v3/moons", headers: { 'Accept' => JSONAPI::MEDIA_TYPE }
+    assert_jsonapi_response 200
+    refute_nil json_response['data'][0]['relationships']['planet']
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -312,6 +312,9 @@ TestApp.routes.draw do
         jsonapi_link :author, except: [:destroy]
         jsonapi_links :tags, only: [:show, :create]
       end
+
+      jsonapi_resources :planets
+      jsonapi_resources :moons
     end
 
     JSONAPI.configuration.route_format = :camelized_route


### PR DESCRIPTION
When the user adds a join in `records`, it confuses `get_join_arel_node` because it finds the same number of joins before & after adding a join for `include_optional_linkage_data` (or equivalently for `always_include_*_linkage_data`).

This commit falls back to searching the existing arel nodes for a compatible join and uses that if found.

Fixes cerebris/jsonapi-resources#1449

### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [x] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [x] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [x] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [x] I've added/updated tests for this change.

### Bug fixes and Changes to Core Features:

- [x] I've included an explanation of what the changes do and why I'd like you to include them.
- [x] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions