### PR TITLE
Warn on missing inverse relationships

### DIFF
--- a/lib/jsonapi/active_relation_retrieval_v09.rb
+++ b/lib/jsonapi/active_relation_retrieval_v09.rb
@@ -287,7 +287,9 @@ module JSONAPI
           if source_resource
             source_resource.add_related_identity(source_relationship.name, related_resource.identity)
             fragment.add_related_from(source_resource.identity)
-            fragment.add_related_identity(source_relationship.inverse_relationship, source_resource.identity)
+
+            inverse_relationship = source_relationship._inverse_relationship
+            fragment.add_related_identity(inverse_relationship.name, source_resource.identity) if inverse_relationship.present?
           end
         end
       end

--- a/lib/jsonapi/active_relation_retrieval_v10.rb
+++ b/lib/jsonapi/active_relation_retrieval_v10.rb
@@ -464,10 +464,8 @@ module JSONAPI
           end
 
           if connect_source_identity
-            related_relationship = resource_klass._relationship(relationship.inverse_relationship)
-            if related_relationship
-              fragments[rid].add_related_identity(related_relationship.name, source_rid)
-            end
+            inverse_relationship = relationship._inverse_relationship
+            fragments[rid].add_related_identity(inverse_relationship.name, source_rid) if inverse_relationship``.present?
           end
         end
 
@@ -598,10 +596,8 @@ module JSONAPI
             related_fragments[rid].add_related_from(source_rid)
 
             if connect_source_identity
-              related_relationship = related_klass._relationship(relationship.inverse_relationship)
-              if related_relationship
-                related_fragments[rid].add_related_identity(related_relationship.name, source_rid)
-              end
+              inverse_relationship = relationship._inverse_relationship
+              related_fragments[rid].add_related_identity(inverse_relationship.name, source_rid) if inverse_relationship.present?
             end
 
             relation_position = relation_positions[row[2].underscore.pluralize]

--- a/lib/jsonapi/configuration.rb
+++ b/lib/jsonapi/configuration.rb
@@ -14,6 +14,8 @@ module JSONAPI
                 :warn_on_missing_routes,
                 :warn_on_performance_issues,
                 :warn_on_eager_loading_disabled,
+                :warn_on_missing_relationships,
+                :raise_on_missing_relationships,
                 :default_allow_include_to_one,
                 :default_allow_include_to_many,
                 :allow_sort,
@@ -69,6 +71,11 @@ module JSONAPI
       self.warn_on_missing_routes = true
       self.warn_on_performance_issues = true
       self.warn_on_eager_loading_disabled = true
+      self.warn_on_missing_relationships = true
+      # If this is set to true an error will be raised if a resource is found to be missing a relationship
+      # If this is set to false a warning will be logged (see warn_on_missing_relationships) and related resouces for
+      # this relationship will not be included in the response.
+      self.raise_on_missing_relationships = false
 
       # :none, :offset, :paged, or a custom paginator name
       self.default_paginator = :none
@@ -329,6 +336,10 @@ module JSONAPI
     attr_writer :warn_on_performance_issues
 
     attr_writer :warn_on_eager_loading_disabled
+
+    attr_writer :warn_on_missing_relationships
+
+    attr_writer :raise_on_missing_relationships
 
     attr_writer :use_relationship_reflection
 

--- a/lib/jsonapi/link_builder.rb
+++ b/lib/jsonapi/link_builder.rb
@@ -34,7 +34,7 @@ module JSONAPI
         @primary_resources_url_cached ||= "#{ base_url }#{ engine_mount_point }#{ primary_resources_path }"
       else
         if JSONAPI.configuration.warn_on_missing_routes && !@primary_resource_klass._warned_missing_route
-          warn "primary_resources_url for #{@primary_resource_klass} could not be generated"
+          warn "primary_resources_url for #{@primary_resource_klass.name} could not be generated"
           @primary_resource_klass._warned_missing_route = true
         end
         nil
@@ -54,7 +54,7 @@ module JSONAPI
         url
       else
         if JSONAPI.configuration.warn_on_missing_routes && !relationship._warned_missing_route
-          warn "related_link for #{relationship} could not be generated"
+          warn "related_link for #{relationship.display_name} could not be generated"
           relationship._warned_missing_route = true
         end
         nil
@@ -66,7 +66,7 @@ module JSONAPI
         "#{ self_link(source) }/relationships/#{ route_for_relationship(relationship) }"
       else
         if JSONAPI.configuration.warn_on_missing_routes && !relationship._warned_missing_route
-          warn "self_link for #{relationship} could not be generated"
+          warn "self_link for #{relationship.display_name} could not be generated"
           relationship._warned_missing_route = true
         end
         nil
@@ -78,7 +78,7 @@ module JSONAPI
         resource_url(source)
       else
         if JSONAPI.configuration.warn_on_missing_routes && !source.class._warned_missing_route
-          warn "self_link for #{source.class} could not be generated"
+          warn "self_link for #{source.class.name} could not be generated"
           source.class._warned_missing_route = true
         end
         nil

--- a/lib/jsonapi/resource_identity.rb
+++ b/lib/jsonapi/resource_identity.rb
@@ -58,7 +58,7 @@ module JSONAPI
     # Creates a string representation of the identifier.
     def to_s
       # :nocov:
-      "#{resource_klass}:#{id}"
+      "#{resource_klass.name}:#{id}"
       # :nocov:
     end
   end

--- a/test/unit/serializer/link_builder_test.rb
+++ b/test/unit/serializer/link_builder_test.rb
@@ -248,7 +248,7 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
       link = builder.relationships_related_link(source, relationship)
       assert_nil link
     end
-    assert_equal(err, "related_link for Api::Secret::PostResource.author(BelongsToOne) could not be generated\n")
+    assert_equal("related_link for Api::Secret::PostResource.author(BelongsToOne) could not be generated\n", err)
 
     # should only warn once
     builder = JSONAPI::LinkBuilder.new(config)


### PR DESCRIPTION
Adds method to the Relationship class to get the inverse_relationship. This supports warning once when the inverse can't be found. This is controllable with a configuration setting and is true by default.

It also adds an option to raise an exception if the inverse can't be found. This is false by default. In this default case if the inverse relationship is missing related resources will not collected or counted.

### All Submissions:

- [ ] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions