### PR TITLE
Change method used to retrieve rack status

### DIFF
--- a/lib/jsonapi/error.rb
+++ b/lib/jsonapi/error.rb
@@ -17,7 +17,7 @@ module JSONAPI
       @source         = options[:source]
       @links          = options[:links]
 
-      @status         = Rack::Utils::SYMBOL_TO_STATUS_CODE[options[:status]].to_s
+      @status         = Rack::Utils.status_code(options[:status]).to_s
       @meta           = options[:meta]
     end
 
@@ -48,7 +48,7 @@ module JSONAPI
 
       if error_object_overrides[:status]
         # :nocov:
-        @status         = Rack::Utils::SYMBOL_TO_STATUS_CODE[error_object_overrides[:status]].to_s
+        @status         = Rack::Utils.status_code(error_object_overrides[:status]).to_s
         # :nocov:
       end
       @meta           = error_object_overrides[:meta] || @meta


### PR DESCRIPTION
This is a very small change to the way jsonapi-resources fetches the status code from the symbol. Currently, it makes use of `Rack::Utils::SYMBOL_TO_STATUS_CODE`, however this has started to break on new versions of Rack.

A [change introduced to Rack](https://github.com/rack/rack/pull/2137) deprecates the status `:unprocessable_entity` in favour of `:unprocessable_content`. By using the `Rack::Utils::SYMBOL_TO_STATUS_CODE` hash directly, no status is found due to the internal changes, which results in `jsonapi-resources` returning a `0` status when there are validation errors.

This is the first step to fixing the issue and is fully backwards compatible. In the future however, the status `:unprocessable_entity` should stopped being used entirely, however this will require checks to see which version of Rack is being used. I haven't tackled this here as I wasn't sure how best you wanted to handle this but I'd be happy to take a look at it in the future.

This fixes the issue #1456

### All Submissions:

- [x ] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [x] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [x] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [x] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [x] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [x] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions