### PR TITLE
fix: validate type matches resource type for sparse fieldsets

### DIFF
--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -309,6 +309,7 @@ module JSONAPI
         if type_resource.nil?
           fail JSONAPI::Exceptions::InvalidResource.new(type, error_object_overrides)
         else
+          verify_type(type, type_resource)
           unless values.nil?
             valid_fields = type_resource.fields.collect { |key| format_key(key) }
             values.each do |field|

--- a/test/unit/jsonapi_request/jsonapi_request_test.rb
+++ b/test/unit/jsonapi_request/jsonapi_request_test.rb
@@ -171,6 +171,30 @@ class JSONAPIRequestTest < ActiveSupport::TestCase
     assert_equal 'iso_currency is not a valid includable relationship of expense-entries', request.errors[0].detail
   end
 
+  def test_parse_fields_singular
+    params = ActionController::Parameters.new(
+      {
+        controller: 'expense_entries',
+        action: 'index',
+        fields: {expense_entry: 'iso_currency'}
+      }
+    )
+
+    request = JSONAPI::Request.new(
+      params,
+      {
+        context: nil,
+        key_formatter: JSONAPI::Formatter.formatter_for(:underscored_key)
+      }
+    )
+
+    e = assert_raises JSONAPI::Exceptions::InvalidResource do
+      request.parse_fields(ExpenseEntryResource, params[:fields])
+    end
+    refute e.errors.empty?
+    assert_equal 'expense_entry is not a valid resource.', e.errors[0].detail
+  end
+
   def test_parse_fields_underscored
     params = ActionController::Parameters.new(
       {


### PR DESCRIPTION
Fixes #1460

Ensures that the type provided to sparse fieldsets matches the type of the resulting resource.

### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [x] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [x] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [x] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [x] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [x] I've included an explanation of what the changes do and why I'd like you to include them.
- [x] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions