### PR TITLE
Fix incorrect translation key for parameter_not_allowed.detail

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,8 @@ version = ENV['RAILS_VERSION'] || 'default'
 
 platforms :ruby do
   gem 'pg'
+  gem 'concurrent-ruby', '1.3.4'
+  gem 'pry'
 
   if version.start_with?('4.2', '5.0')
     gem 'sqlite3', '~> 1.3.13'

--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,6 @@ version = ENV['RAILS_VERSION'] || 'default'
 
 platforms :ruby do
   gem 'pg'
-  gem 'concurrent-ruby', '1.3.4'
-  gem 'pry'
 
   if version.start_with?('4.2', '5.0')
     gem 'sqlite3', '~> 1.3.13'

--- a/lib/jsonapi/exceptions.rb
+++ b/lib/jsonapi/exceptions.rb
@@ -402,7 +402,7 @@ module JSONAPI
                             status: :bad_request,
                             title: I18n.translate('jsonapi-resources.exceptions.parameter_not_allowed.title',
                                                   default: 'Param not allowed'),
-                            detail: I18n.translate('jsonapi-resources.exceptions.parameters_not_allowed.detail',
+                            detail: I18n.translate('jsonapi-resources.exceptions.parameter_not_allowed.detail',
                                                    default: "#{param} is not allowed.", param: param))]
       end
     end

--- a/test/unit/exceptions/translation_test.rb
+++ b/test/unit/exceptions/translation_test.rb
@@ -1,0 +1,34 @@
+require File.expand_path('../../../test_helper', __FILE__)
+
+class TranslationTest < ActiveSupport::TestCase
+  setup do
+    @original_locale = I18n.locale
+  end
+
+  teardown do
+    I18n.locale = @original_locale
+  end
+
+  test "parameter_not_allowed translation is loaded correctly in another language" do
+    I18n.with_locale(:pt) do
+      I18n.backend.store_translations(:pt, {
+        "jsonapi-resources": {
+          exceptions: {
+            parameter_not_allowed: {
+              title: "Parâmetro não permitido",
+              detail: "%{param} não permitido."
+            }
+          }
+        }
+      })
+
+      param = "sort"
+      exception = JSONAPI::Exceptions::ParameterNotAllowed.new(param).errors[0]
+      expected_title = I18n.t("jsonapi-resources.exceptions.parameter_not_allowed.title")
+      expected_detail = I18n.t("jsonapi-resources.exceptions.parameter_not_allowed.detail", param: param)
+
+      assert_equal expected_title, exception.title
+      assert_equal expected_detail, exception.detail
+    end
+  end
+end


### PR DESCRIPTION
Closes https://github.com/cerebris/jsonapi-resources/issues/1468.

### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.  
- [x] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.  
- [x] My submission passes all tests. (I ran the full test suite locally to avoid unnecessary failures.)  
- [x] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.  
- [x] I've added/updated tests for this change.  

### Bug fixes and Changes to Core Features:

- [x] I've included an explanation of what the changes do and why I'd like you to include them.  
- [x] I've provided test(s) that fail without the change.  

### Test Plan:  

The issue occurs because the translation key being used in the code is incorrect.  
The code currently looks for `parameters_not_allowed.detail` (plural), but the correct key in the translation files is `parameter_not_allowed.detail` (singular).  

- Added a test to verify that the correct key (`parameter_not_allowed.detail`) is used.  
- Without the fix, the test fails because the translation isn't found, falling back to the default English message.  
- With the fix, the test correctly retrieves the translation.  

### Reviewer Checklist:  

- [ ] Maintains compliance with JSON:API  
- [ ] Adequate test coverage exists to prevent regressions 