### PR TITLE
Fix / Use `table_name` instead of relation name

### DIFF
--- a/lib/jsonapi/active_relation/join_manager.rb
+++ b/lib/jsonapi/active_relation/join_manager.rb
@@ -94,7 +94,7 @@ module JSONAPI
           table_name = relationship.resource_klass._table_name
 
           last_join = join_sources.find { |j|
-            valid_join_types.any? { |t| j.is_a?(t) } && j.left.name == table_name
+            valid_join_types.any? { |t| j.is_a?(t) } && j.left.table_name == table_name
           }
         end
 


### PR DESCRIPTION
This PR fix a bug. We have discuss it in https://github.com/cerebris/jsonapi-resources/pull/1450 PR.

# Context

I have a `user` and `patient_enrolled_journal_event` resources

In `user` resource, I have this relation: 
```ruby
has_one :patient_enrolled_journal_event
```

In `patient_enrolled_journal_event` resource, I have this relation:
```ruby
has_one :patient_enrolled_journal_event,
              exclude_links: :default,
              foreign_key_on: :related,
              relation_name: :patient_enrolled_journal_event
```

In `PatientEnrolledJournalEvent` model, I have this scope: 
```ruby
scope :active, lambda {
    where(archived_at: nil).left_outer_joins(:user).where.not(
      user: {
        id: nil
      }
    )
  }
```

And in `PatientEnrolledJournalEventResource`, I rewrite `records` method to apply this scope like this:
```ruby
def self.records(options = {})
    super.active
  end
```

And when I get `http://localhost:3001/api/v1/users?include=patient-enrolled-journal-event` I have this SQL error :
```
SQLite3::SQLException: ambiguous column name: id:\nSELECT patient_enrolled_journal_events.*, \"id\" AS jr_source_id FROM \"patient_enrolled_journal_events\" INNER JOIN \"users\" \"user\" ON \"user\".\"id\" = \"patient_enrolled_journal_events\".\"user_id\" WHERE \"patient_enrolled_journal_events\".\"archived_at\" IS NULL AND \"user\".\"id\" IS NOT NULL AND \"patient_enrolled_journal_events\".\"id\" = ? ORDER BY patient_enrolled_journal_events.id asc\n^",
```

I have investigated, my breakpoint is in `get_join_arel_node` method:
```
last_join = join_sources.find { |j|
            valid_join_types.any? { |t| j.is_a?(t) } && j.left.name == table_name
          }
```
`j.left.name` = user
`table_name` = users
So, the condition is false :(

# Problem
In the condition, we compare a relation name with table name and when the relation name is singular so isn't match with `table_name`.

# Solution
The `join_sources[0].left` is a `Arel::Nodes::TableAlias` class so we have a `table_name` getter. It's better to compare the both table_name.

# Checklists

### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [x] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions