### PR TITLE
Fix Ruby 2.6+ Logger compatibility issue

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,4 @@
+require 'logger'
 require 'simplecov'
 require 'database_cleaner'
 


### PR DESCRIPTION
## Summary

Fixes CI failures with Ruby 2.6 and Rails 6.0/6.1 by adding explicit `require 'logger'`.

## Problem

Tests are failing on Ruby 2.6 with the following error:

```
uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger (NameError)
```

This affects multiple CI jobs:
- Ruby 2.6 Rails 6.0.6 (both SQLite and PostgreSQL)
- Ruby 2.6 Rails 6.1.7 (both SQLite and PostgreSQL)

## Root Cause

Ruby 3.1+ moved `Logger` to a separate gem (`logger`), requiring explicit loading. While this primarily affects Ruby 3.1+, the issue also manifests with Ruby 2.6 and certain Rails versions where ActiveSupport tries to use `Logger::Severity` before the Logger class is loaded.

## Solution

Add `require 'logger'` at the top of `test/test_helper.rb` to ensure Logger is loaded before ActiveSupport attempts to use it.

## Testing

This fix should resolve the failing CI jobs while maintaining compatibility with all Ruby/Rails combinations in the test matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)