### PR TITLE
feat!: Remove Ruby 2.6 and 2.7 as EOL

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -26,8 +26,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - 2.6
-          - 2.7
           - '3.0'
           - 3.1
           - 3.2
@@ -59,8 +57,6 @@ jobs:
             rails: 5.2.8.1
           - ruby: '3.0'
             rails: 5.1.7
-          - ruby: 2.6
-            rails: 7.0.4
           - database_url: postgresql://postgres:password@localhost:5432/test
             rails: 5.1.7
     env:

--- a/jsonapi-resources.gemspec
+++ b/jsonapi-resources.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.3'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_development_dependency 'bundler', '>= 1.17'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
https://endoflife.date/ruby - EOL for over 3 years.
This reduces maintenance surface slightly, and drops a lot of combinations from CI.

<img width="957" height="712" alt="image" src="https://github.com/user-attachments/assets/1ceaf2c5-93f5-4623-a0f0-15a22630cd9d" />


Will probably do 3.x releases as well as a followup, plus rails versions at some point.




### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions