### PR TITLE
docs: Update repo links in various places

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -8,7 +8,7 @@
 
 - [ ] I've searched for an existing issue.
 - [ ] I've asked my question on [Gitter](https://gitter.im/cerebris/jsonapi-resources) and have not received a satisfactory answer.
-- [ ] I've included a complete [bug report template](https://github.com/cerebris/jsonapi-resources/blob/master/lib/bug_report_templates/rails_5_master.rb). This step helps us and allows us to see the bug without trying to reproduce the problem from your description. It helps you because you will frequently detect if it's a problem specific to your project.
+- [ ] I've included a complete [bug report template](https://github.com/JSONAPI-Resources/jsonapi-resources/blob/master/lib/bug_report_templates/rails_5_master.rb). This step helps us and allows us to see the bug without trying to reproduce the problem from your description. It helps you because you will frequently detect if it's a problem specific to your project.
 - [ ] The feature I'm asking for is compliant with the [JSON:API](http://jsonapi.org/) spec.
 
 ## Description
@@ -17,7 +17,7 @@ Choose one section below and delete the other:
 
 ### Bug reports:
 
-Please review [Did you find a bug?](https://github.com/cerebris/jsonapi-resources/blob/master/README.md#did-you-find-a-bug) and replace this content with a brief summary of your issue. If you can't submit a [bug report template](https://github.com/cerebris/jsonapi-resources/blob/master/lib/bug_report_templates/rails_5_master.rb) please be as thorough as possible when describing your your description. It's helpful to indicate which version of ruby and the JR gem you are using.
+Please review [Did you find a bug?](https://github.com/JSONAPI-Resources/jsonapi-resources/blob/master/README.md#did-you-find-a-bug) and replace this content with a brief summary of your issue. If you can't submit a [bug report template](https://github.com/JSONAPI-Resources/jsonapi-resources/blob/master/lib/bug_report_templates/rails_5_master.rb) please be as thorough as possible when describing your your description. It's helpful to indicate which version of ruby and the JR gem you are using.
 
 ### Features:
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,8 +2,8 @@
 
 ### All Submissions:
 
-- [ ] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
-- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
+- [ ] I've checked to ensure there aren't other open [Pull Requests](https://github.com/JSONAPI-Resources/jsonapi-resources/pulls) for the same update/change.
+- [ ] I've submitted a [ticket](https://github.com/JSONAPI-Resources/jsonapi-resources/issues) for my issue if one did not already exist.
 - [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
 - [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
 - [ ] I've added/updated tests for this change.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# JSONAPI::Resources [![Gem Version](https://badge.fury.io/rb/jsonapi-resources.svg)](https://badge.fury.io/rb/jsonapi-resources) [![Build Status](https://secure.travis-ci.org/cerebris/jsonapi-resources.svg?branch=master)](http://travis-ci.org/cerebris/jsonapi-resources) [![Code Climate](https://codeclimate.com/github/cerebris/jsonapi-resources/badges/gpa.svg)](https://codeclimate.com/github/cerebris/jsonapi-resources)
+# JSONAPI::Resources [![Gem Version](https://badge.fury.io/rb/jsonapi-resources.svg)](https://badge.fury.io/rb/jsonapi-resources) [![Build Status](https://secure.travis-ci.org/cerebris/jsonapi-resources.svg?branch=master)](http://travis-ci.org/cerebris/jsonapi-resources)
 
 [![Join the chat at https://gitter.im/cerebris/jsonapi-resources](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/cerebris/jsonapi-resources?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
@@ -49,7 +49,7 @@ gem install jsonapi-resources
 ## Contributing
 
 1. Submit an issue describing any new features you wish it add or the bug you intend to fix
-1. Fork it ( http://github.com/cerebris/jsonapi-resources/fork )
+1. Fork it ( http://github.com/JSONAPI-Resources/jsonapi-resources/fork )
 1. Create your feature branch (`git checkout -b my-new-feature`)
 1. Run the full test suite (`rake test`)
 1. Fix any failing tests
@@ -59,16 +59,16 @@ gem install jsonapi-resources
 
 ## Did you find a bug?
 
-* **Ensure the bug was not already reported** by searching on GitHub under [Issues](https://github.com/cerebris/jsonapi-resources/issues).
+* **Ensure the bug was not already reported** by searching on GitHub under [Issues](https://github.com/JSONAPI-Resources/jsonapi-resources/issues).
 
-* If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/cerebris/jsonapi-resources/issues/new). 
+* If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/JSONAPI-Resources/jsonapi-resources/issues/new). 
 Be sure to include a **title and clear description**, as much relevant information as possible, 
 and a **code sample** or an **executable test case** demonstrating the expected behavior that is not occurring.
 
 * If possible, use the relevant bug report templates to create the issue. 
 Simply copy the content of the appropriate template into a .rb file, make the necessary changes to demonstrate the issue, 
 and **paste the content into the issue description or attach as a file**:
-  * [**Rails 5** issues](https://github.com/cerebris/jsonapi-resources/blob/master/lib/bug_report_templates/rails_5_master.rb)
+  * [**Rails 5** issues](https://github.com/JSONAPI-Resources/jsonapi-resources/blob/master/lib/bug_report_templates/rails_5_master.rb)
 
 
 ## License

--- a/jsonapi-resources.gemspec
+++ b/jsonapi-resources.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email         = ['dan@cerebris.com', 'larry@cerebris.com']
   spec.summary       = 'Easily support JSON API in Rails.'
   spec.description   = 'A resource-centric approach to implementing the controllers, routes, and serializers needed to support the JSON API spec.'
-  spec.homepage      = 'https://github.com/cerebris/jsonapi-resources'
+  spec.homepage      = 'https://github.com/JSONAPI-Resources/jsonapi-resources'
   spec.license       = 'MIT'
 
   spec.files         = Dir.glob("{bin,lib}/**/*") + %w(LICENSE.txt README.md)

--- a/lib/bug_report_templates/rails_5_master.rb
+++ b/lib/bug_report_templates/rails_5_master.rb
@@ -20,7 +20,7 @@ gemfile(true, ui: ENV['SILENT'] ? Bundler::UI::Silent.new : Bundler::UI::Shell.n
   if ENV['JSONAPI_RESOURCES_PATH']
     gem 'jsonapi-resources', path: ENV['JSONAPI_RESOURCES_PATH'], require: false
   else
-    gem 'jsonapi-resources', git: 'https://github.com/cerebris/jsonapi-resources', require: false
+    gem 'jsonapi-resources', git: 'https://github.com/JSONAPI-Resources/jsonapi-resources', require: false
   end
 
 end


### PR DESCRIPTION
Following the move from the old location, updates various links to this repo.
Removes code coverage link badge, which is stale.

### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions