### PR TITLE
feat!: Drop support for Rails 5, 5.1, 5.2

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -35,8 +35,6 @@ jobs:
           - 7.0.4
           - 6.1.7
           - 6.0.6
-          - 5.2.8.1
-          - 5.1.7
         database_url:
           - postgresql://postgres:password@localhost:5432/test
           - sqlite3:test_db
@@ -45,24 +43,13 @@ jobs:
             rails: 6.0.6
           - ruby: 3.2
             rails: 5.2.8.1
-          - ruby: 3.2
-            rails: 5.1.7
           - ruby: 3.1
             rails: 6.0.6
-          - ruby: 3.1
-            rails: 5.2.8.1
-          - ruby: 3.1
-            rails: 5.1.7
           - ruby: '3.0'
             rails: 6.0.6
-          - ruby: '3.0'
-            rails: 5.2.8.1
-          - ruby: '3.0'
-            rails: 5.1.7
           - ruby: 2.6
             rails: 7.0.4
-          - database_url: postgresql://postgres:password@localhost:5432/test
-            rails: 5.1.7
+
     env:
       RAILS_VERSION: ${{ matrix.rails }}
       DATABASE_URL: ${{ matrix.database_url }}

--- a/Gemfile
+++ b/Gemfile
@@ -11,11 +11,7 @@ version = ENV['RAILS_VERSION'] || 'default'
 platforms :ruby do
   gem 'pg'
 
-  if version.start_with?('4.2', '5.0')
-    gem 'sqlite3', '~> 1.3.13'
-  else
-    gem 'sqlite3', '~> 1.4'
-  end
+  gem 'sqlite3', '~> 1.4'
 end
 
 case version

--- a/jsonapi-resources.gemspec
+++ b/jsonapi-resources.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'concurrent-ruby-ext'
   spec.add_development_dependency 'database_cleaner'
-  spec.add_dependency 'activerecord', '>= 5.1'
+  spec.add_dependency 'activerecord', '>= 6.0'
   spec.add_dependency 'railties', '>= 5.1'
   spec.add_dependency 'concurrent-ruby'
 end

--- a/lib/jsonapi-resources.rb
+++ b/lib/jsonapi-resources.rb
@@ -9,11 +9,7 @@ require 'jsonapi/resource'
 require 'jsonapi/cached_response_fragment'
 require 'jsonapi/response_document'
 require 'jsonapi/acts_as_resource_controller'
-if Rails::VERSION::MAJOR >= 6
-  ActiveSupport.on_load(:action_controller_base) do
-    require 'jsonapi/resource_controller'
-  end
-else
+ActiveSupport.on_load(:action_controller_base) do
   require 'jsonapi/resource_controller'
 end
 require 'jsonapi/resource_controller_metal'

--- a/lib/jsonapi/active_relation/adapters/join_left_active_record_adapter.rb
+++ b/lib/jsonapi/active_relation/adapters/join_left_active_record_adapter.rb
@@ -2,8 +2,8 @@ module JSONAPI
   module ActiveRelation
     module Adapters
       module JoinLeftActiveRecordAdapter
-        # DEPRECATED - simply use `left_joins``
         def joins_left(*columns)
+          ActiveSupport::Deprecation.warn "Prefer `left_joins`, JSONAPI::ActiveRelation::Adapters::JoinLeftActiveRecordAdapter will be removed in a future release"
           left_joins(columns)
         end
 

--- a/lib/jsonapi/active_relation/adapters/join_left_active_record_adapter.rb
+++ b/lib/jsonapi/active_relation/adapters/join_left_active_record_adapter.rb
@@ -2,18 +2,10 @@ module JSONAPI
   module ActiveRelation
     module Adapters
       module JoinLeftActiveRecordAdapter
-        # Extends left_joins functionality to rails 4, and uses the same logic for rails 5.0.x and 5.1.x
-        # The default left_joins logic of rails 5.2.x is used. This results in and extra join in some cases. For
-        # example Post.joins(:comments).joins_left(comments: :author) will join the comments table twice,
-        # once inner and once left in 5.2, but only as inner in earlier versions.
+        # DEPRECATED - simply use `left_joins``
         def joins_left(*columns)
-          if Rails::VERSION::MAJOR >= 6 || (Rails::VERSION::MAJOR >= 5 && ActiveRecord::VERSION::MINOR >= 2)
-            left_joins(columns)
-          else
-            join_dependency = ActiveRecord::Associations::JoinDependency.new(self, columns, [])
-            joins(join_dependency)
-          end
-         end
+          left_joins(columns)
+        end
 
         alias_method :join_left, :joins_left
       end

--- a/lib/jsonapi/active_relation_resource.rb
+++ b/lib/jsonapi/active_relation_resource.rb
@@ -329,7 +329,7 @@ module JSONAPI
           when :inner
             records = records.joins(resource_type.to_s.singularize.to_sym)
           when :left
-            records = records.joins_left(resource_type.to_s.singularize.to_sym)
+            records = records.left_joins(resource_type.to_s.singularize.to_sym)
           end
         else
           relation_name = relationship.relation_name(options)
@@ -337,7 +337,7 @@ module JSONAPI
           when :inner
             records = records.joins(relation_name)
           when :left
-            records = records.joins_left(relation_name)
+            records = records.left_joins(relation_name)
           end
         end
         records

--- a/lib/jsonapi/active_relation_resource.rb
+++ b/lib/jsonapi/active_relation_resource.rb
@@ -772,11 +772,7 @@ module JSONAPI
 
       # Assumes ActiveRecord's counting. Override if you need a different counting method
       def count_records(records)
-        if (Rails::VERSION::MAJOR == 5 && ActiveRecord::VERSION::MINOR >= 1) || Rails::VERSION::MAJOR >= 6
-          records.count(:all)
-        else
-          records.count
-        end
+        records.count(:all)
       end
 
       def filter_records(records, filters, options)

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -2319,7 +2319,7 @@ module Api
           when :inner
             records = records.joins(relationship.relation_name(options))
           when :left
-            records = records.joins_left(relationship.relation_name(options))
+            records = records.left_joins(relationship.relation_name(options))
         end
         records.where(comments: {approved: true})
       }
@@ -2369,7 +2369,7 @@ module Api
         when :inner
           records = records.joins(relationship.relation_name(options))
         when :left
-          records = records.joins_left(relationship.relation_name(options))
+          records = records.left_joins(relationship.relation_name(options))
         end
         records.where(comments: {approved: true})
       }

--- a/test/unit/active_relation_resource_finder/join_manager_test.rb
+++ b/test/unit/active_relation_resource_finder/join_manager_test.rb
@@ -6,11 +6,7 @@ class JoinTreeTest < ActiveSupport::TestCase
   def db_true
     case ActiveRecord::Base.connection.adapter_name
       when 'SQLite'
-        if Rails::VERSION::MAJOR >= 6 || (Rails::VERSION::MAJOR >= 5 && ActiveRecord::VERSION::MINOR >= 2)
-          "1"
-        else
-          "'t'"
-        end
+        "1"
       when 'PostgreSQL'
         'TRUE'
     end


### PR DESCRIPTION
https://endoflife.date/rails
<img width="962" height="886" alt="image" src="https://github.com/user-attachments/assets/3236a2c3-dfb5-4e23-a904-cf32c6cd3cb6" />

While Rails 5 experienced significant usage, versions less than 6 went EOL some years ago. This reduces the maintenance surface; while still keeping a fairly wide window

Related:

- #1490 


### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [x] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions